### PR TITLE
Incremental work towards working coofiles

### DIFF
--- a/mkninja.sh
+++ b/mkninja.sh
@@ -672,8 +672,9 @@ cowgol_thumb2_linux examples/empty.cow examples/empty.thumb2
 cowgol_thumb2_linux examples/file.cow examples/file.thumb2
 cowgol_thumb2_linux examples/malloc.cow examples/malloc.thumb2 
 
-cowgol_80386_linux src/cowlink/main.cow bin/cowlink
-cowgol_cpm src/cowlink/main.cow bin/cowlink.com
-cowgol_thumb2_linux src/cowlink/main.cow bin/cowlink.thumb2
+cowlink_coh=$(echo src/cowlink/*.coh)
+cowgol_80386_linux src/cowlink/main.cow bin/cowlink "$cowlink_coh"
+cowgol_cpm src/cowlink/main.cow bin/cowlink.com "$cowlink_coh"
+cowgol_thumb2_linux src/cowlink/main.cow bin/cowlink.thumb2 "$cowlink_coh"
 
 # vim: sw=4 ts=4 et

--- a/mkninja.sh
+++ b/mkninja.sh
@@ -277,7 +277,15 @@ ld80() {
 		"LD80 $bin"
 }
 
-cowgol_cpm_asm() {
+uncoo() {
+    rule \
+        "lua scripts/uncoo.lua $1 $2" \
+        "$1 scripts/uncoo.lua" \
+        "$2" \
+        "UNCOO $1"
+}
+
+cowgol_cpm_coo() {
 	local in
 	local out
 	local log
@@ -297,7 +305,8 @@ cowgol_cpm_asm() {
 cowgol_cpm() {
 	local base
 	base="$OBJDIR/$(dirname $1)/cpm/${1%.cow}"
-	cowgol_cpm_asm $1 $base.asm $base.log "$3"
+	cowgol_cpm_coo $1 $base.coo $base.log "$3"
+    uncoo $base.coo $base.asm
 	zmac8 $base.asm $base.rel
 	ld80 $base.bin \
 		$OBJDIR/rt/cpm/cowgol.rel \
@@ -314,7 +323,7 @@ test_cpm() {
 	rule "diff -u tests/$1.good $base.bad && touch $base.stamp" "tests/$1.good $base.bad" "$base.stamp" "DIFF $1"
 }
 
-cowgol_thumb2_s() {
+cowgol_thumb2_coo() {
 	local in
 	local out
 	local log
@@ -334,7 +343,8 @@ cowgol_thumb2_s() {
 cowgol_thumb2_linux() {
 	local base
 	base="$OBJDIR/$(dirname $1)/thumb2-linux/${1%.cow}"
-	cowgol_thumb2_s $1 $base.s $base.log "$3"
+	cowgol_thumb2_coo $1 $base.coo $base.log "$3"
+    uncoo $base.coo $base.s
     as_thumb2_linux $base.s $base.o
     rule \
         "arm-linux-gnueabihf-ld $OBJDIR/rt/thumb2-linux/cowgol.o $base.o -o $2" \
@@ -351,7 +361,7 @@ test_thumb2_linux() {
 	rule "diff -u tests/$1.good $base.bad && touch $base.stamp" "tests/$1.good $base.bad" "$base.stamp" "DIFF $1"
 }
 
-cowgol_80386_s() {
+cowgol_80386_coo() {
 	local in
 	local out
 	local log
@@ -371,7 +381,8 @@ cowgol_80386_s() {
 cowgol_80386_linux() {
 	local base
 	base="$OBJDIR/$(dirname $1)/80386-linux/${1%.cow}"
-	cowgol_80386_s $1 $base.s $base.log "$3"
+	cowgol_80386_coo $1 $base.coo $base.log "$3"
+    uncoo $base.coo $base.s
     as_80386_linux $base.s $base.o
     rule \
         "i686-linux-gnu-ld $OBJDIR/rt/80386-linux/cowgol.o $base.o -o $2" \

--- a/rt/80386-linux/cowgol.coh
+++ b/rt/80386-linux/cowgol.coh
@@ -9,6 +9,8 @@ var HIMEM: [uint8];
 @asm ".extern _himem";
 @asm "movl $_himem, ", HIMEM;
 
+extern sub Exit() := "_exit";
+
 sub print_char(c: uint8)
     @asm "movl $4, %eax";
     @asm "movl $1, %ebx";

--- a/rt/80386-linux/cowgol.coh
+++ b/rt/80386-linux/cowgol.coh
@@ -11,6 +11,10 @@ var HIMEM: [uint8];
 
 extern sub Exit() := "_exit";
 
+sub AlignUp(in: intptr): (out: intptr)
+	out := in;
+end sub;
+
 sub print_char(c: uint8)
     @asm "movl $4, %eax";
     @asm "movl $1, %ebx";

--- a/rt/80386-linux/cowgol.s
+++ b/rt/80386-linux/cowgol.s
@@ -4,6 +4,7 @@
 .arch i386
 .code32
 .global _start
+.global _exit
 _start:
 	/* On entry, the stack looks like this:
 	 *
@@ -17,6 +18,7 @@ _start:
     lea 4(%esp), %eax
     mov %eax, (_argv)
     call cmain
+_exit:
     mov $1, %eax
     int $0x80
 

--- a/rt/80386-linux/file.coh
+++ b/rt/80386-linux/file.coh
@@ -89,10 +89,15 @@ sub FCBClose(fcb: [FCB]): (errno: uint8)
 end sub;
 
 sub FCBSeek(fcb: [FCB], pos: uint32)
+	pos := pos - 1; # seek to *previous* character
 	var newblock := pos >> 9;
 	var newptr := (pos as uint16) & (FCB_BUFFER-1);
 	fcb_i_changeblock(fcb, newblock);
 	fcb.bufferptr := newptr;
+end sub;
+
+sub FCBPos(fcb: [FCB]): (pos: uint32)
+	pos := ((fcb.block << 9) + (fcb.bufferptr as uint32)) + 1;
 end sub;
 
 sub FCBExt(fcb: [FCB]): (len: uint32)

--- a/rt/common.coh
+++ b/rt/common.coh
@@ -72,3 +72,8 @@ sub print_hex_i32(value: uint32)
     print_hex_i8((value >> 8) as uint8);
     print_hex_i8(value as uint8);
 end sub;
+
+sub ExitWithError()
+	Exit();
+end sub;
+

--- a/rt/cpm/cowgol.asm
+++ b/rt/cpm/cowgol.asm
@@ -793,13 +793,13 @@ lsr2:
     cseg
 asl4:
     pop h
-    shld lsr4_ret
+    shld asl4_ret
 
     pop h ; HL = low
     pop d ; DE = high
 asl4_loop:
     dec b
-    jm lsr4_exit
+    jm asl4_exit
 
     dad h
     jnc asl4_skip
@@ -830,18 +830,18 @@ lsr4_loop:
     dec b
     jm lsr4_exit
     ora a
-    mov a, h
-    rar
-    mov h, a
-    mov a, l
-    rar
-    mov l, a
     mov a, d
     rar
     mov d, a
     mov a, e
     rar
     mov e, a
+    mov a, h
+    rar
+    mov h, a
+    mov a, l
+    rar
+    mov l, a
     jmp lsr4_loop
 lsr4_exit:
     push d
@@ -862,20 +862,20 @@ asr4:
 asr4_loop:
     dec b
     jm asr4_exit
-    mov a, h
+    mov a, d
     rla
-    mov a, h
-    rar
-    mov h, a
-    mov a, l
-    rar
-    mov l, a
     mov a, d
     rar
     mov d, a
     mov a, e
     rar
     mov e, a
+    mov a, h
+    rar
+    mov h, a
+    mov a, l
+    rar
+    mov l, a
     jmp asr4_loop
 asr4_exit:
     push d

--- a/rt/cpm/cowgol.asm
+++ b/rt/cpm/cowgol.asm
@@ -1,9 +1,11 @@
     extrn cmain
+    public _exit
 
     ; CP/M entry point at 0x100.
 
     lxi sp, stackend
     call cmain
+_exit:
     rst 0
     dseg
 stack:

--- a/rt/cpm/cowgol.coh
+++ b/rt/cpm/cowgol.coh
@@ -9,6 +9,10 @@ var HIMEM: [uint8];
 
 extern sub Exit() := "_exit";
 
+sub AlignUp(in: intptr): (out: intptr)
+	out := in;
+end sub;
+
 sub print_char(c: uint8)
 	@asm "lda ", c;
 	@asm "mov e, a";

--- a/rt/cpm/cowgol.coh
+++ b/rt/cpm/cowgol.coh
@@ -7,6 +7,8 @@ var HIMEM: [uint8];
 @asm "lhld 6";
 @asm "shld ", HIMEM;
 
+extern sub Exit() := "_exit";
+
 sub print_char(c: uint8)
 	@asm "lda ", c;
 	@asm "mov e, a";

--- a/rt/cpm/file.coh
+++ b/rt/cpm/file.coh
@@ -1,3 +1,5 @@
+# vim: ts=4 sw=4 et
+
 record CpmFCB
 	dr: uint8;
 	f: uint8[11];
@@ -153,10 +155,15 @@ sub FCBClose(fcb: [FCB]): (errno: uint8)
 end sub;
 
 sub FCBSeek(fcb: [FCB], pos: uint32)
+	pos := pos - 1; # seek to *previous* character
 	var newblock := (pos >> 7) as uint16;
 	var newptr := (pos as uint8) & 127;
 	fcb_i_changeblock(fcb, newblock);
 	fcb.bufferptr := newptr;
+end sub;
+
+sub FCBPos(fcb: [FCB]): (pos: uint32)
+	pos := (((fcb.cpm.r as uint32) << 7) | (fcb.bufferptr as uint32)) + 1;
 end sub;
 
 sub FCBExt(fcb: [FCB]): (len: uint32)

--- a/rt/malloc.coh
+++ b/rt/malloc.coh
@@ -27,6 +27,8 @@ sub DumpBlocks()
 end sub;
 
 sub Alloc(length: intptr): (block: [uint8])
+	length := AlignUp(length);
+
 	var prev := freeList;
 	var p := prev.next;
 	loop
@@ -54,9 +56,12 @@ sub Alloc(length: intptr): (block: [uint8])
 	end loop;
 
 	block := p as [uint8];
+	MemSet(block, 0, length);
 end sub;
 
 sub Free(start: [uint8], length: intptr)
+	length := AlignUp(length);
+
 	var h := start as [FreeBlock];
 	h.size := length;
 

--- a/rt/thumb2-linux/cowgol.coh
+++ b/rt/thumb2-linux/cowgol.coh
@@ -11,6 +11,8 @@ var HIMEM: [uint8];
 @asm "ldr r0, =_himem";
 @asm "str r0, ", HIMEM;
 
+extern sub Exit() := "_exit";
+
 sub print_char(c: uint8)
 	var pc := &c;
 	@asm "mov r0, #1"; # file descriptor

--- a/rt/thumb2-linux/cowgol.coh
+++ b/rt/thumb2-linux/cowgol.coh
@@ -13,6 +13,10 @@ var HIMEM: [uint8];
 
 extern sub Exit() := "_exit";
 
+sub AlignUp(in: intptr): (out: intptr)
+	out := (in + 3) & ~3;
+end sub;
+
 sub print_char(c: uint8)
 	var pc := &c;
 	@asm "mov r0, #1"; # file descriptor

--- a/rt/thumb2-linux/cowgol.s
+++ b/rt/thumb2-linux/cowgol.s
@@ -14,6 +14,7 @@ _start:
 	ldr r0, =_thumb_start
 	bx r0
 
+.global _exit
 .thumb_func
 _thumb_start:
 	add r1, sp, #4
@@ -21,6 +22,7 @@ _thumb_start:
 	str r1, [r0]
 
 	bl cmain
+_exit:
 	mov r0, #0
 	mov r7, #1 /* __exit() */
 	svc #0

--- a/rt/thumb2-linux/file.coh
+++ b/rt/thumb2-linux/file.coh
@@ -89,10 +89,15 @@ sub FCBClose(fcb: [FCB]): (errno: uint8)
 end sub;
 
 sub FCBSeek(fcb: [FCB], pos: uint32)
+	pos := pos - 1; # seek to *previous* character
 	var newblock := pos >> 9;
 	var newptr := (pos as uint16) & (FCB_BUFFER-1);
 	fcb_i_changeblock(fcb, newblock);
 	fcb.bufferptr := newptr;
+end sub;
+
+sub FCBPos(fcb: [FCB]): (pos: uint32)
+	pos := ((fcb.block << 9) | (fcb.bufferptr as uint32)) + 1;
 end sub;
 
 sub FCBExt(fcb: [FCB]): (len: uint32)

--- a/scripts/uncoo.lua
+++ b/scripts/uncoo.lua
@@ -7,21 +7,21 @@ local outfile = io.open(outfilename, "wb")
 
 while true do
 	local kind = infile:read(1)
+	local len = tonumber("0x"..infile:read(4))
+	local here = infile:seek()
 	if kind == 'E' then
 		break
 	elseif kind == 'S' then
-		local len = tonumber("0x"..infile:read(4))
 		local subid = tonumber("0x"..infile:read(4))
 		local data = infile:read(len - 4)
 		outfile:write(data)
 	elseif kind == 'R' then
-		local len = tonumber("0x"..infile:read(4))
 		local userid = tonumber("0x"..infile:read(4))
 		local usedid = tonumber("0x"..infile:read(4))
-		infile:read(len - 8)
 	else
 		error("unknown record")
 	end
+	infile:seek("set", here + len)
 end
 
 infile:close()

--- a/scripts/uncoo.lua
+++ b/scripts/uncoo.lua
@@ -11,7 +11,8 @@ while true do
 		break
 	elseif kind == 'S' then
 		local len = tonumber("0x"..infile:read(4))
-		local data = infile:read(len)
+		local subid = tonumber("0x"..infile:read(4))
+		local data = infile:read(len - 4)
 		outfile:write(data)
 	else
 		error("unknown record")

--- a/scripts/uncoo.lua
+++ b/scripts/uncoo.lua
@@ -18,6 +18,8 @@ while true do
 	elseif kind == 'R' then
 		local userid = tonumber("0x"..infile:read(4))
 		local usedid = tonumber("0x"..infile:read(4))
+	elseif kind == 'N' then
+		-- ignore
 	else
 		error("unknown record")
 	end

--- a/scripts/uncoo.lua
+++ b/scripts/uncoo.lua
@@ -14,6 +14,11 @@ while true do
 		local subid = tonumber("0x"..infile:read(4))
 		local data = infile:read(len - 4)
 		outfile:write(data)
+	elseif kind == 'R' then
+		local len = tonumber("0x"..infile:read(4))
+		local userid = tonumber("0x"..infile:read(4))
+		local usedid = tonumber("0x"..infile:read(4))
+		infile:read(len - 8)
 	else
 		error("unknown record")
 	end

--- a/scripts/uncoo.lua
+++ b/scripts/uncoo.lua
@@ -1,0 +1,23 @@
+local args = {...}
+local infilename = args[1]
+local outfilename = args[2]
+
+local infile = io.open(infilename, "rb")
+local outfile = io.open(outfilename, "wb")
+
+while true do
+	local kind = infile:read(1)
+	if kind == 'E' then
+		break
+	elseif kind == 'S' then
+		local len = tonumber("0x"..infile:read(4))
+		local data = infile:read(len)
+		outfile:write(data)
+	else
+		error("unknown record")
+	end
+end
+
+infile:close()
+outfile:close()
+

--- a/src/arch80386.ng
+++ b/src/arch80386.ng
@@ -13,11 +13,6 @@
 	#define E emitter_printf
 	static char asmbuffer[80];
 
-	struct subarch
-	{
-		int id;
-	};
-
 	static int id = 1;
 	static Symbol* uint32_type;
 	static Symbol* int32_type;
@@ -53,11 +48,7 @@
 		return int32_type;
 	}
 
-	void arch_init_subroutine(struct subroutine* sub)
-	{
-		sub->arch = calloc(1, sizeof(struct subarch));
-		sub->arch->id = id++;
-	}
+	void arch_init_subroutine(struct subroutine* sub) {}
 
 	void arch_init_variable(struct symbol* var)
 	{
@@ -158,7 +149,7 @@
 			return sub->externname;
 		
 		static char buffer[32];
-		snprintf(buffer, sizeof(buffer), "f%d", sub->arch->id);
+		snprintf(buffer, sizeof(buffer), "f%d", sub->id);
 		return buffer;
 	}
 
@@ -166,7 +157,7 @@
 	{
 		static char buffer[32];
 		snprintf(buffer, sizeof(buffer), "(w%d+%d)",
-			sym->u.var.sub->arch->id,
+			sym->u.var.sub->id,
 			sym->u.var.offset + off);
 		return buffer;
 	}
@@ -305,7 +296,7 @@ gen ENDSUB():s
 		E("\tret\n");
 
     E("\t.bss\n");
-	E("w%d:\n", $s.sub->arch->id);
+	E("w%d:\n", $s.sub->id);
 	if ($s.sub->workspace[0] != 0)
 		E("\t.space %d\n", $s.sub->workspace[0]);
     emitter_close_chunk(current_sub);

--- a/src/arch80386.ng
+++ b/src/arch80386.ng
@@ -234,7 +234,7 @@ gen STARTFILE()
 {
     emitter_open_chunk();
 	E("\t.code32\n");
-    emitter_close_chunk();
+    emitter_close_chunk(NULL);
 }
 
 gen ENDFILE();
@@ -308,7 +308,7 @@ gen ENDSUB():s
 	E("w%d:\n", $s.sub->arch->id);
 	if ($s.sub->workspace[0] != 0)
 		E("\t.space %d\n", $s.sub->workspace[0]);
-    emitter_close_chunk();
+    emitter_close_chunk(current_sub);
 }
 
 // --- Control flow ------------------------------------------------------
@@ -360,7 +360,7 @@ gen param := PUSHPARAM4(param, CONSTANT():c)
 		{
 			emitter_open_chunk();
 			E("\t.extern %s\n", sub->externname);
-			emitter_close_chunk();
+			emitter_close_chunk(current_sub);
 		}
 
 		arch_emit_comment("subroutine with %d input parameters", sub->inputparameters);
@@ -824,7 +824,7 @@ gen r32 := STRING():s
     if (!start)
         E(", ");
     E("0\n");
-    emitter_close_chunk();
+    emitter_close_chunk(current_sub);
 
 	E("\tlea s%d, %s\n", sid, regref($$));
 }

--- a/src/arch80386.ng
+++ b/src/arch80386.ng
@@ -489,6 +489,9 @@ gen r8 := CAST41(r32:val)
 gen r16 := CAST42(r32:val)
 	{ E("\tmovw %s, %s\n", wordregref($val), regref($$)); }
 
+gen r16 := CAST12(r8:val)
+	{ E("\tmovzx %s, %s\n", regref($val), longregref($$)); }
+
 gen r32 := CAST14(r8:val)
 	{ E("\tmovzx %s, %s\n", regref($val), longregref($$)); }
 

--- a/src/arch80386.ng
+++ b/src/arch80386.ng
@@ -209,6 +209,7 @@ regclass r8 := al|bl|cl|dl;
 regclass r16 := ax|bx|cx|dx|si|di;
 regclass r32 := eax|ebx|ecx|edx|esi|edi;
 regclass ri := ebx|esi|edi;
+regclass allregs := r8|r16|r32|ri;
 
 regdata eax compatible r32    uses eax|ax|al;
 regdata ebx compatible r32|ri uses ebx|bx|bl;
@@ -375,16 +376,16 @@ gen param := PUSHPARAM4(param, CONSTANT():c)
 
 gen CALLS(param);
 
-gen param := CALL0(param):c
+gen param := CALL0(param):c uses allregs
 	{ call($c.sub); }
 
-gen r8 := CALL1(param):c
+gen al := CALL1(param):c uses ebx|ecx|edx|esi|edi
 	{ calln($c.sub, $$); }
 
-gen r16 := CALL2(param):c
+gen ax := CALL2(param):c uses ebx|ecx|edx|esi|edi
 	{ calln($c.sub, $$); }
 
-gen r32 := CALL4(param):c
+gen eax := CALL4(param):c uses ebx|ecx|edx|esi|edi
 	{ calln($c.sub, $$); }
 
 %{

--- a/src/arch8080.ng
+++ b/src/arch8080.ng
@@ -13,11 +13,6 @@
 	#define E emitter_printf
 	static char asmbuffer[80];
 
-	struct subarch
-	{
-		int id;
-	};
-
 	static int id = 1;
 	static Symbol* uint32_type;
 	static Symbol* int32_type;
@@ -53,11 +48,7 @@
 		return int32_type;
 	}
 
-	void arch_init_subroutine(struct subroutine* sub)
-	{
-		sub->arch = calloc(1, sizeof(struct subarch));
-		sub->arch->id = id++;
-	}
+	void arch_init_subroutine(struct subroutine* sub) {}
 
 	void arch_init_variable(struct symbol* var)
 	{
@@ -111,7 +102,7 @@
 			return sub->externname;
 		
 		static char buffer[32];
-		snprintf(buffer, sizeof(buffer), "f%d", sub->arch->id);
+		snprintf(buffer, sizeof(buffer), "f%d", sub->id);
 		return buffer;
 	}
 
@@ -119,7 +110,7 @@
 	{
 		static char buffer[32];
 		snprintf(buffer, sizeof(buffer), "w%d%+d",
-			sym->u.var.sub->arch->id,
+			sym->u.var.sub->id,
 			sym->u.var.offset + off);
 		return buffer;
 	}
@@ -334,7 +325,7 @@ gen ENDSUB():s
 	}
 
     E("\tdseg\n");
-	E("w%d: ds %d\n", $s.sub->arch->id, $s.sub->workspace[0]);
+	E("w%d: ds %d\n", $s.sub->id, $s.sub->workspace[0]);
     emitter_close_chunk(current_sub);
 }
 

--- a/src/arch8080.ng
+++ b/src/arch8080.ng
@@ -389,19 +389,19 @@ gen CALLS(param);
 
 // Single return values go in registers.
 
-gen CALLS(POPPARAM1(CALL0(param):c, ADDRESS():a))
+gen CALLS(POPPARAM1(CALL0(param):c, ADDRESS():a)) uses bc|de|hl
 {
 	call($c.sub);
 	E("\tsta %s\n", symref($a.sym, $a.off));
 }
 
-gen CALLS(POPPARAM2(CALL0(param):c, ADDRESS():a))
+gen CALLS(POPPARAM2(CALL0(param):c, ADDRESS():a)) uses bc|de
 {
 	call($c.sub);
 	E("\tshld %s\n", symref($a.sym, $a.off));
 }
 
-gen CALLS(POPPARAM4(CALL0(param):c, ADDRESS():a))
+gen CALLS(POPPARAM4(CALL0(param):c, ADDRESS():a)) uses bc|de
 {
 	call($c.sub);
 	E("\tshld %s\n", symref($a.sym, $a.off+0));
@@ -409,20 +409,20 @@ gen CALLS(POPPARAM4(CALL0(param):c, ADDRESS():a))
 	E("\tshld %s\n", symref($a.sym, $a.off+2));
 }
 
-gen a := CALL1(param):c
+gen a := CALL1(param):c uses bc|de|hl
 	{ call($c.sub); }
 
-gen hl := CALL2(param):c
+gen hl := CALL2(param):c uses a|bc|de
 	{ call($c.sub); }
 
-gen stk4 := CALL4(param):c
+gen stk4 := CALL4(param):c uses a|bc
 {
 	call($c.sub);
 	E("\tpush d\n");
 	E("\tpush h\n");
 }
 
-gen param := CALL0(param):c
+gen param := CALL0(param):c uses a|bc|de|hl
 	{ call($c.sub); }
 
 gen param := POPPARAM1(param, ADDRESS():a) uses a

--- a/src/arch8080.ng
+++ b/src/arch8080.ng
@@ -212,7 +212,7 @@ gen STARTFILE()
 	E("\textrn cmpu4\n");
 	E("\textrn load4\n");
 	E("\textrn store4\n");
-    emitter_close_chunk();
+    emitter_close_chunk(NULL);
 }
 
 gen ENDFILE();
@@ -335,7 +335,7 @@ gen ENDSUB():s
 
     E("\tdseg\n");
 	E("w%d: ds %d\n", $s.sub->arch->id, $s.sub->workspace[0]);
-    emitter_close_chunk();
+    emitter_close_chunk(current_sub);
 }
 
 // --- Control flow ------------------------------------------------------
@@ -377,7 +377,7 @@ gen param := PUSHPARAM4(param, stk4);
 		{
 			emitter_open_chunk();
 			E("\textrn %s\n", sub->externname);
-			emitter_close_chunk();
+			emitter_close_chunk(current_sub);
 		}
 
 		arch_emit_comment("subroutine with %d input parameters", sub->inputparameters);
@@ -650,7 +650,7 @@ gen a := EOR1(a, b|d|h:rhs)
 	{ E("\txra %s\n", regref($rhs)); }
 
 gen a := NOT1(a)
-	{ E("\txri -1"); }
+	{ E("\txri -1\n"); }
 
 gen a := AND1(a, CONSTANT():c)
 	{ E("\tani %d\n", $c.value & 0xff); }
@@ -1074,7 +1074,7 @@ gen bc|de|hl := STRING():s
     if (!start)
         E(", ");
     E("0\n");
-    emitter_close_chunk();
+    emitter_close_chunk(current_sub);
 
     E("\tlxi %s, s%d\n", regref($$), sid);
 }

--- a/src/arch8080.ng
+++ b/src/arch8080.ng
@@ -990,8 +990,8 @@ gen a|d := CAST41(stk4) uses hl|bc
 	
 gen hl|de := CAST42(stk4) uses bc
 {
-	E("\tpop b\n");
 	E("\tpop %s\n", regref($$));
+	E("\tpop b\n");
 }
 	
 // --- Inline assembly ------------------------------------------------------

--- a/src/archthumb2.ng
+++ b/src/archthumb2.ng
@@ -13,11 +13,6 @@
 	#define E emitter_printf
 	static char asmbuffer[80];
 
-	struct subarch
-	{
-		int id;
-	};
-
 	static int id = 1;
 	static Symbol* int8_type;
 	static Symbol* int16_type;
@@ -58,11 +53,7 @@
 		return int32_type;
 	}
 
-	void arch_init_subroutine(struct subroutine* sub)
-	{
-		sub->arch = calloc(1, sizeof(struct subarch));
-		sub->arch->id = id++;
-	}
+	void arch_init_subroutine(struct subroutine* sub) {}
 
 	void arch_init_variable(struct symbol* var)
 	{
@@ -112,7 +103,7 @@
 			return sub->externname;
 		
 		static char buffer[32];
-		snprintf(buffer, sizeof(buffer), "f%d", sub->arch->id);
+		snprintf(buffer, sizeof(buffer), "f%d", sub->id);
 		return buffer;
 	}
 
@@ -120,7 +111,7 @@
 	{
 		static char buffer[32];
 		snprintf(buffer, sizeof(buffer), "w%d%+d",
-			sym->u.var.sub->arch->id,
+			sym->u.var.sub->id,
 			sym->u.var.offset + off);
 		return buffer;
 	}
@@ -197,7 +188,7 @@ gen STARTSUB():s
 	E(".thumb_func\n");
     E("%s:\n", subref($s.sub));
 
-	E("\tldr r1, =w%d\n", $s.sub->arch->id);
+	E("\tldr r1, =w%d\n", $s.sub->id);
     if ($s.sub->inputparameters != 0)
     {
         for (int i=$s.sub->inputparameters-1; i>=0; i--)
@@ -269,7 +260,7 @@ gen ENDSUB():s
 		E("\tpop {r8, pc}\n");
 
 	E(".bss\n");
-	E("w%d:\n", $s.sub->arch->id);
+	E("w%d:\n", $s.sub->id);
 	if ($s.sub->workspace[0])
 	{
 		E("\t.align 4\n");

--- a/src/archthumb2.ng
+++ b/src/archthumb2.ng
@@ -139,9 +139,9 @@
 			return;
 
 		if (!src)
-			E("\tpop %s\n", regref(dest));
+			E("\tpop {%s}\n", regref(dest));
 		else if (!dest)
-			E("\tpush %s\n", regref(src));
+			E("\tpush {%s}\n", regref(src));
 		else
 			E("\tmov %s, %s\n", regref(dest), regref(src));
 	}
@@ -334,16 +334,16 @@ gen param := PUSHPARAM4(param, reg:val)
 
 gen CALLS(param);
 
-gen param := CALL0(param):c
+gen param := CALL0(param):c uses reg
 	{ call($c.sub); }
 
-gen reg := CALL1(param):c
+gen r0 := CALL1(param):c uses r1|r2|r3|r4|r5|r6|r7
 	{ calln($c.sub, $$); }
 
-gen reg := CALL2(param):c
+gen r0 := CALL2(param):c uses r1|r2|r3|r4|r5|r6|r7
 	{ calln($c.sub, $$); }
 
-gen reg := CALL4(param):c
+gen r0 := CALL4(param):c uses r1|r2|r3|r4|r5|r6|r7
 	{ calln($c.sub, $$); }
 
 %{

--- a/src/archthumb2.ng
+++ b/src/archthumb2.ng
@@ -181,7 +181,7 @@ gen STARTFILE()
     emitter_open_chunk();
 	E(".syntax unified\n");
 	E(".code 16\n");
-    emitter_close_chunk();
+    emitter_close_chunk(NULL);
 }
 
 gen ENDFILE();
@@ -275,7 +275,7 @@ gen ENDSUB():s
 		E("\t.align 4\n");
 		E("\t.space %d\n", $s.sub->workspace[0]);
 	}
-    emitter_close_chunk();
+    emitter_close_chunk(current_sub);
 }
 
 // --- Control flow ------------------------------------------------------
@@ -318,7 +318,7 @@ gen param := PUSHPARAM4(param, reg:val)
 		{
 			emitter_open_chunk();
 			E("\t.extern %s\n", sub->externname);
-			emitter_close_chunk();
+			emitter_close_chunk(current_sub);
 		}
 
 		arch_emit_comment("subroutine with %d input parameters", sub->inputparameters);
@@ -753,7 +753,7 @@ gen reg := STRING():s
     if (!start)
         E(", ");
     E("0\n");
-    emitter_close_chunk();
+    emitter_close_chunk(current_sub);
 
     E("\tldr %s, =s%d\n", regref($$), sid);
 }

--- a/src/archthumb2.ng
+++ b/src/archthumb2.ng
@@ -259,11 +259,12 @@ gen ENDSUB():s
 	else
 		E("\tpop {r8, pc}\n");
 
+	E(".pool\n");
 	E(".bss\n");
+	E("\t.align 4\n");
 	E("w%d:\n", $s.sub->id);
 	if ($s.sub->workspace[0])
 	{
-		E("\t.align 4\n");
 		E("\t.space %d\n", $s.sub->workspace[0]);
 	}
     emitter_close_chunk(current_sub);
@@ -284,6 +285,7 @@ gen LABEL():b
 gen JUMP():j
 {
 	E("\tb %s\n", labelref($j.label));
+	E(".pool\n");
 }
 
 // --- Subroutines -------------------------------------------------------
@@ -388,11 +390,16 @@ gen reg := LOAD1(ADDRESS(sym is current_sub):a)
 gen reg := LOAD1(reg:lhs)
 	{ E("\tldrb %s, [%s]\n", regref($$), regref($lhs)); }
 
+rewrite CAST12(LOAD1(a)) := LOAD1(a);
+rewrite CAST14(LOAD1(a)) := LOAD1(a);
+
 gen reg := LOAD2(ADDRESS(sym is current_sub):a)
 	{ E("\tldrh %s, [r8, #%d]\n", regref($$), $a.sym->u.var.offset + $a.off); }
 
 gen reg := LOAD2(reg:lhs)
 	{ E("\tldrh %s, [%s]\n", regref($$), regref($lhs)); }
+
+rewrite CAST24(LOAD1(a)) := LOAD2(a);
 
 gen reg := LOAD4(ADDRESS(sym is current_sub):a)
 	{ E("\tldr %s, [r8, #%d]\n", regref($$), $a.sym->u.var.offset + $a.off); }
@@ -676,6 +683,9 @@ gen reg := CAST24(reg:rhs)
 	{ E("\tuxth %s, %s\n", regref($$), regref($rhs)); }
 
 gen reg := CAST14(reg:rhs)
+	{ E("\tuxtb %s, %s\n", regref($$), regref($rhs)); }
+
+gen reg := CAST12(reg:rhs)
 	{ E("\tuxtb %s, %s\n", regref($$), regref($rhs)); }
 
 // --- Inline assembly ------------------------------------------------------

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -132,7 +132,9 @@ static void shuffle_registers(Regmove* moves)
 	Regmove* m = moves;
 	while (m)
 	{
+		#if 0
 		arch_emit_comment("spill/reload 0x%x -> 0x%x", m->src, m->dest);
+		#endif
 		dests |= m->dest;
 		srcs |= m->src;
 		m = m->next;
@@ -455,6 +457,7 @@ void generate(Node* node)
 	while (instructioncount != 0)
 	{
 		Instruction* insn = &instructions[--instructioncount];
+		#if 0
 		arch_emit_comment("insn %d rule %p produces 0x%x inputs 0x%x outputs 0x%x",
 			insn - instructions,
 			insn->rule,
@@ -468,6 +471,7 @@ void generate(Node* node)
 				arch_emit_comment("consumes 0x%x from insn %d",
 					n->produced_reg, n->producer - instructions);
 		}
+		#endif
 		
 		/* Emit reloads. */
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -174,6 +174,9 @@ struct midnode* expr_shift(struct midnode* lhs, struct midnode* rhs,
 	if (rhs->type != uint8_type)
 		fatal("uint8 required on RHS of shift");
 
+	if (!lhs->type && rhs->type)
+		fatal("untyped constants not allowed on LHS of shift unless RHS is also an untype constant");
+
 	struct midnode* r = (is_snum(lhs->type) ? emitters : emitteru)
 		(lhs->type ? lhs->type->u.type.width : 0, lhs, rhs);
 	r->type = lhs->type;
@@ -190,7 +193,7 @@ void cond_simple(int truelabel, int falselabel, struct midnode* lhs, struct midn
 
 	generate(
 		(is_snum(lhs->type) ? emitters : emitteru)
-			(lhs->type->u.type.width, lhs, rhs, truelabel, falselabel));
+			(lhs->type ? lhs->type->u.type.width : 0, lhs, rhs, truelabel, falselabel));
 }
 
 struct symbol* dealias(struct symbol* sym)

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -32,6 +32,8 @@ extern void init_member(struct symbol* sym, struct symbol* type);
 extern struct symbol* make_pointer_type(struct symbol* type);
 extern struct symbol* make_array_type(struct symbol* type, int32_t size);
 
+extern void check_non_partial_type(Symbol* sym);
+extern void symbol_redeclaration(Symbol* sym);
 extern void check_expression_type(struct symbol** node, struct symbol* type);
 extern void unescape(char* string);
 

--- a/src/cowlink/cooread.coh
+++ b/src/cowlink/cooread.coh
@@ -1,0 +1,14 @@
+record Coo
+	fcb: FCB;
+end record;
+
+sub OpenCoo(filename: [uint8]): (coo: [Coo])
+	coo := Alloc(@bytesof Coo) as [Coo];
+	if FCBOpenIn(&coo.fcb, filename) != 0 then
+		print("error: unable to open '");
+		print(filename);
+		print("'\n");
+		ExitWithError();
+	end if;
+end sub;
+

--- a/src/cowlink/cooread.coh
+++ b/src/cowlink/cooread.coh
@@ -1,11 +1,20 @@
-record Coo
-	fcb: FCB;
+record Subroutine
+	next: [Subroutine];
+	id: uint16;
+	offset: uint32;
+	refs: [Reference];
+	name: [uint8];
+	used: uint8;
 end record;
 
-record Subroutine
-	id: uint16;
-	next: [Subroutine];
-	offset: uint32;
+record Reference
+	next: [Reference];
+	target: [Subroutine];
+end record;
+
+record Coo
+	fcb: FCB;
+	subroutines: [Subroutine];
 end record;
 
 sub read_hex4(fcb: [FCB]): (val: uint16)
@@ -33,7 +42,56 @@ sub read_hex4(fcb: [FCB]): (val: uint16)
 	end loop;
 end sub;
 
-sub OpenCoo(filename: [uint8]): (coo: [Coo])
+sub read_string(fcb: [FCB], len: uint8): (ptr: [uint8])
+	ptr := Alloc((len+1) as intptr) as [uint8];
+	var p := ptr;
+	loop
+		if len == 0 then
+			break;
+		end if;
+		[p] := FCBGetChar(fcb);
+		p := p + 1;
+		len := len - 1;
+	end loop;
+end sub;
+
+sub AddRef(user: [Subroutine], used: [Subroutine])
+	var ref := user.refs;
+	loop
+		if ref == (0 as [Reference]) then
+			break;
+		end if;
+		if ref.target == used then
+			return;
+		end if;
+		ref := ref.next;
+	end loop;
+
+	ref := Alloc(@bytesof Reference) as [Reference];
+	ref.target := used;
+	ref.next := user.refs;
+	user.refs := ref;
+end sub;
+
+sub FindSub(coo: [Coo], id: uint16): (subroutine: [Subroutine])
+	subroutine := coo.subroutines;
+	loop
+		if subroutine == (0 as [Subroutine]) then
+			break;
+		end if;
+		if subroutine.id == id then
+			return;
+		end if;
+		subroutine := subroutine.next;
+	end loop;
+
+	subroutine := Alloc(@bytesof Subroutine) as [Subroutine];
+	subroutine.id := id;
+	subroutine.next := coo.subroutines;
+	coo.subroutines := subroutine;
+end sub;
+
+sub OpenAndLoadCoo(filename: [uint8]): (coo: [Coo])
 	coo := Alloc(@bytesof Coo) as [Coo];
 	if FCBOpenIn(&coo.fcb, filename) != 0 then
 		print("error: unable to open '");
@@ -42,19 +100,24 @@ sub OpenCoo(filename: [uint8]): (coo: [Coo])
 		ExitWithError();
 	end if;
 
+	var id: uint16;
 	loop
 		var c := FCBGetChar(&coo.fcb);
 		var len := read_hex4(&coo.fcb);
 		var here := FCBPos(&coo.fcb);
 		if c == 'E' then
 			break;
+		elseif c == 'S' then
+			id := read_hex4(&coo.fcb);
+			#var subroutine := FindSub(coo, id);
 		elseif c == 'R' then
 			var userid := read_hex4(&coo.fcb);
 			var usedid := read_hex4(&coo.fcb);
-			print_hex_i16(userid);
-			print_char(' ');
-			print_hex_i16(usedid);
-			print_nl();
+			AddRef(FindSub(coo, userid), FindSub(coo, usedid));
+		elseif c == 'N' then
+			id := read_hex4(&coo.fcb);
+			var subroutine := FindSub(coo, id);
+			subroutine.name := read_string(&coo.fcb, (len as uint8) - 5);
 		end if;
 		FCBSeek(&coo.fcb, here + (len as uint32));
 	end loop;

--- a/src/cowlink/cooread.coh
+++ b/src/cowlink/cooread.coh
@@ -2,6 +2,37 @@ record Coo
 	fcb: FCB;
 end record;
 
+record Subroutine
+	id: uint16;
+	next: [Subroutine];
+	offset: uint32;
+end record;
+
+sub read_hex4(fcb: [FCB]): (val: uint16)
+	var i: uint8 := 4;
+	val := 0;
+	loop
+		var c := FCBGetChar(fcb);
+		if (c >= '0') and (c <= '9') then
+			c := c - '0';
+		else
+			c := c & ~0x20;
+			if (c >= 'A') and (c <= 'F') then
+				c := c - ('A' - 10);
+			else
+				print("error: invalid hex number in coofile\n");
+				ExitWithError();
+			end if;
+		end if;
+		val := (val << 4) + (c as uint16);
+
+		i := i - 1;
+		if i == 0 then
+			break;
+		end if;
+	end loop;
+end sub;
+
 sub OpenCoo(filename: [uint8]): (coo: [Coo])
 	coo := Alloc(@bytesof Coo) as [Coo];
 	if FCBOpenIn(&coo.fcb, filename) != 0 then
@@ -10,5 +41,22 @@ sub OpenCoo(filename: [uint8]): (coo: [Coo])
 		print("'\n");
 		ExitWithError();
 	end if;
+
+	loop
+		var c := FCBGetChar(&coo.fcb);
+		var len := read_hex4(&coo.fcb);
+		var here := FCBPos(&coo.fcb);
+		if c == 'E' then
+			break;
+		elseif c == 'R' then
+			var userid := read_hex4(&coo.fcb);
+			var usedid := read_hex4(&coo.fcb);
+			print_hex_i16(userid);
+			print_char(' ');
+			print_hex_i16(usedid);
+			print_nl();
+		end if;
+		FCBSeek(&coo.fcb, here + (len as uint32));
+	end loop;
 end sub;
 

--- a/src/cowlink/graph.coh
+++ b/src/cowlink/graph.coh
@@ -1,0 +1,48 @@
+const STACK_SIZE := 32;
+var stack: [Subroutine][STACK_SIZE];
+var sp: uint8 := 0;
+
+sub CalculateDependencyGraph(coo: [Coo])
+	sp := 1;
+	stack[0] := FindSub(coo, 0);
+
+	loop
+		if sp == 0 then
+			break;
+		end if;
+
+		sp := sp - 1;
+		var subroutine := stack[sp];
+		if subroutine.used == 0 then
+			subroutine.used := 1;
+
+			var ref := subroutine.refs;
+			loop
+				if ref == (0 as [Reference]) then
+					break;
+				end if;
+
+				if ref.target.used == 0 then
+					stack[sp] := ref.target;
+					sp := sp + 1;
+				end if;
+				ref := ref.next;
+			end loop;
+		end if;
+	end loop;
+
+	subroutine := coo.subroutines;
+	loop
+		if subroutine == (0 as [Subroutine]) then
+			break;
+		end if;
+		print_hex_i16(subroutine.id);
+		print_char(' ');
+		print_hex_i8(subroutine.used);
+		print_char(' ');
+		print(subroutine.name);
+		print_nl();
+		subroutine := subroutine.next;
+	end loop;
+end sub;
+

--- a/src/cowlink/main.cow
+++ b/src/cowlink/main.cow
@@ -2,7 +2,9 @@ include "cowgol.coh";
 include "argv.coh";
 include "malloc.coh";
 include "strings.coh";
-#include "file.coh";
+include "file.coh";
+
+include "src/cowlink/cooread.coh";
 
 print("COWLINK: ");
 print_i16((GetFreeMemory() >> 10) as uint16);
@@ -18,6 +20,8 @@ sub AddInputFile(filename: [uint8])
 	print("Adding input file: ");
 	print(filename);
 	print_nl();
+
+	var coo := OpenCoo(filename);
 end sub;
 
 ArgvInit();

--- a/src/cowlink/main.cow
+++ b/src/cowlink/main.cow
@@ -5,6 +5,7 @@ include "strings.coh";
 include "file.coh";
 
 include "src/cowlink/cooread.coh";
+include "src/cowlink/graph.coh";
 
 print("COWLINK: ");
 print_i16((GetFreeMemory() >> 10) as uint16);
@@ -21,7 +22,8 @@ sub AddInputFile(filename: [uint8])
 	print(filename);
 	print_nl();
 
-	var coo := OpenCoo(filename);
+	var coo := OpenAndLoadCoo(filename);
+	CalculateDependencyGraph(coo);
 end sub;
 
 ArgvInit();
@@ -43,4 +45,8 @@ end loop;
 if outputFilename == 0 as [uint8] then
 	print("No output filename specified\n");
 end if;
+
+print("done: ");
+print_i16((GetFreeMemory() >> 10) as uint16);
+print("kB free\n");
 

--- a/src/emitter.c
+++ b/src/emitter.c
@@ -23,7 +23,7 @@ void emitter_close(void)
 {
     if (current)
         fatal("output chunks still open");
-	fprintf(outfile, "E");
+	fprintf(outfile, "E0000");
 }
 
 static void write_record_header(char kind, uint16_t len)
@@ -33,7 +33,7 @@ static void write_record_header(char kind, uint16_t len)
 
 void emitter_reference_subroutine(Subroutine* user, Subroutine* used)
 {
-	write_record_header('R', 9);
+	write_record_header('R', 9); /* includes newline */
 	fprintf(outfile, "%04X%04X\n", user->id, used->id);
 }
 

--- a/src/emitter.c
+++ b/src/emitter.c
@@ -37,6 +37,12 @@ void emitter_reference_subroutine(Subroutine* user, Subroutine* used)
 	fprintf(outfile, "%04X%04X\n", user->id, used->id);
 }
 
+void emitter_declare_subroutine(Subroutine* sub)
+{
+	write_record_header('N', 4 + 1 + strlen(sub->name));
+	fprintf(outfile, "%04X%s\n", sub->id, sub->name);
+}
+
 void emitter_open_chunk(void)
 {
     struct chunk* newchunk = calloc(1, sizeof(struct chunk));

--- a/src/emitter.c
+++ b/src/emitter.c
@@ -31,6 +31,12 @@ static void write_record_header(char kind, uint16_t len)
 	fprintf(outfile, "%c%04X", kind, len);
 }
 
+void emitter_reference_subroutine(Subroutine* user, Subroutine* used)
+{
+	write_record_header('R', 9);
+	fprintf(outfile, "%04X%04X\n", user->id, used->id);
+}
+
 void emitter_open_chunk(void)
 {
     struct chunk* newchunk = calloc(1, sizeof(struct chunk));
@@ -41,7 +47,7 @@ void emitter_open_chunk(void)
     current = newchunk;
 }
 
-void emitter_close_chunk(struct subroutine* sub)
+void emitter_close_chunk(Subroutine* sub)
 {
     if (!current)
         fatal("no output chunk open");

--- a/src/emitter.c
+++ b/src/emitter.c
@@ -49,7 +49,8 @@ void emitter_close_chunk(struct subroutine* sub)
 	if (current->fill > 0xffff)
 		fatal("chunk too big");
 
-	write_record_header('S', current->fill);
+	write_record_header('S', current->fill + 4);
+	fprintf(outfile, "%04X", sub ? sub->id : 0);
     fwrite(current->data, 1, current->fill, outfile);
 
     struct chunk* oldchunk = current;

--- a/src/emitter.h
+++ b/src/emitter.h
@@ -5,7 +5,7 @@ void emitter_open(const char* filename);
 void emitter_open_chunk(void);
 void emitter_printf(const char* fmt, ...);
 void emitter_vprintf(const char* fmt, va_list ap);
-void emitter_close_chunk(void);
+void emitter_close_chunk(struct subroutine* sub);
 void emitter_close(void);
 
 #endif

--- a/src/emitter.h
+++ b/src/emitter.h
@@ -7,6 +7,7 @@ void emitter_printf(const char* fmt, ...);
 void emitter_vprintf(const char* fmt, va_list ap);
 void emitter_close_chunk(Subroutine* sub);
 void emitter_reference_subroutine(Subroutine* user, Subroutine* used);
+void emitter_declare_subroutine(Subroutine* sub);
 void emitter_close(void);
 
 #endif

--- a/src/emitter.h
+++ b/src/emitter.h
@@ -5,7 +5,8 @@ void emitter_open(const char* filename);
 void emitter_open_chunk(void);
 void emitter_printf(const char* fmt, ...);
 void emitter_vprintf(const char* fmt, va_list ap);
-void emitter_close_chunk(struct subroutine* sub);
+void emitter_close_chunk(Subroutine* sub);
+void emitter_reference_subroutine(Subroutine* user, Subroutine* used);
 void emitter_close(void);
 
 #endif

--- a/src/globals.h
+++ b/src/globals.h
@@ -105,6 +105,7 @@ struct subroutine
 	int inputparameters;
 	int outputparameters;
 	int old_break_label;
+	int id;
 	struct subarch* arch;
 };
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -22,6 +22,7 @@ extern int32_t number;
 
 enum
 {
+	TYPE_PARTIAL,
 	TYPE_NUMBER,
 	TYPE_POINTER,
 	TYPE_ARRAY,

--- a/src/main.c
+++ b/src/main.c
@@ -101,6 +101,7 @@ int main(int argc, char* argv[])
 	arch_init_subroutine(current_sub);
 	generate(mid_startfile());
 	generate(mid_startsub(current_sub));
+	emitter_declare_subroutine(current_sub);
 
 	void* parser = ParseAlloc(malloc);
 	// ParseTrace(stderr, "P:");

--- a/src/main.c
+++ b/src/main.c
@@ -131,7 +131,7 @@ int main(int argc, char* argv[])
 	generate(mid_endsub(current_sub));
 	generate(mid_endfile());
 
-	emitter_close_chunk();
+	emitter_close_chunk(current_sub);
 	emitter_close();
 
 	return 0;

--- a/src/parser.y
+++ b/src/parser.y
@@ -14,6 +14,7 @@
 
     static int break_label;
 	struct subroutine* current_sub;
+	static int id = 1;
 
 	struct iflabels
 	{
@@ -384,6 +385,7 @@ startsubroutine(oldsub) ::= SUB newid(sym).
 	struct subroutine* sub = calloc(1, sizeof(struct subroutine));
 	sub->name = sym->name;
 	sub->namespace.parent = &current_sub->namespace;
+	sub->id = id++;
 	arch_init_subroutine(sub);
 	break_label = 0;
 

--- a/src/parser.y
+++ b/src/parser.y
@@ -9,6 +9,7 @@
     #include "parser.h"
 	#include "compiler.h"
 	#include "codegen.h"
+	#include "emitter.h"
 
     int current_label = 1;
 
@@ -297,6 +298,7 @@ subroutinecallexpr(E) ::= subcall_begin(S) optionalinputarguments(EIN) CLOSEPARE
 	Symbol* param = get_output_parameters(S);
 	E = mid_call(param->u.var.type->u.type.width, EIN, S);
 	E->type = param->u.var.type;
+	emitter_reference_subroutine(current_sub, S);
 }
 
 %include
@@ -319,6 +321,7 @@ subroutinecallexpr(E) ::= subcall_begin(S) optionalinputarguments(EIN) CLOSEPARE
 
 		discard(node->left);
 		node->left = mid_call0(inputs, sub);
+		emitter_reference_subroutine(current_sub, sub);
 		return mid_calls(outputs);
 	}
 }
@@ -393,6 +396,10 @@ startsubroutine(oldsub) ::= SUB newid(sym).
 	sym->u.sub = sub;
 
 	current_sub = sub;
+
+	/* Make sure that this subroutine refers to its lexical parent. */
+
+	emitter_reference_subroutine(current_sub, oldsub);
 }
 
 statement ::= startrealsubroutine(oldsub) statements END SUB.

--- a/src/parser.y
+++ b/src/parser.y
@@ -307,6 +307,7 @@ subroutinecallexpr(E) ::= subcall_begin(S) optionalinputarguments(EIN) CLOSEPARE
 	{
 		check_input_parameters(sub, inputs);
 		check_output_parameters(sub, outputs);
+		emitter_reference_subroutine(current_sub, sub);
 
 		if (sub->outputparameters == 0)
 			return mid_calls(mid_call0(inputs, sub));
@@ -321,7 +322,6 @@ subroutinecallexpr(E) ::= subcall_begin(S) optionalinputarguments(EIN) CLOSEPARE
 
 		discard(node->left);
 		node->left = mid_call0(inputs, sub);
-		emitter_reference_subroutine(current_sub, sub);
 		return mid_calls(outputs);
 	}
 }

--- a/tests/shifts-16bit.test.cow
+++ b/tests/shifts-16bit.test.cow
@@ -22,7 +22,6 @@ sub rshiftu()
 end sub;
 rshiftu();
 
-
 sub rshifts()
 	print("mbig>>one == 0xc000"); if mbig>>one == 0xc000 then yes(); else no(); end if;
 	print("mbig>>two == 0xe000"); if mbig>>two == 0xe000 then yes(); else no(); end if;

--- a/tests/shifts-32bit.good
+++ b/tests/shifts-32bit.good
@@ -4,5 +4,7 @@ one32<<two == 4: yes
 seven32<<7 == 896: yes
 big>>one == 0x40000000: yes
 big>>two == 0x20000000: yes
-mbig>>one == 0xc000: no
-mbig>>two == 0xe000: no
+twodtwo>>seven == 5: yes
+mbig>>one == 0xc0000000: yes
+mbig>>two == 0xe0000000: yes
+twodtwo>>seven == 5: yes

--- a/tests/shifts-32bit.test.cow
+++ b/tests/shifts-32bit.test.cow
@@ -6,10 +6,12 @@ var one32: uint32 := 1;
 var seven32: uint32 := 7;
 var big: uint32 := 0x80000000;
 var mbig: int32 := 0x80000000;
+var twodtwo: uint32 := 0x2d2;
 
 var zero: uint8 := 0;
 var one: uint8 := 1;
 var two: uint8 := 2;
+var seven: uint8 := 7;
 
 sub lshift()
 	print("one32<<one == 2"); if one32<<one == 2 then yes(); else no(); end if;
@@ -22,12 +24,15 @@ lshift();
 sub rshiftu()
 	print("big>>one == 0x40000000"); if big>>one == 0x40000000 then yes(); else no(); end if;
 	print("big>>two == 0x20000000"); if big>>two == 0x20000000 then yes(); else no(); end if;
+	print("twodtwo>>seven == 5");    if twodtwo>>seven == 5 then yes(); else no(); end if;
+
 end sub;
 rshiftu();
 
 sub rshifts()
-	print("mbig>>one == 0xc000"); if mbig>>one == 0xc000 then yes(); else no(); end if;
-	print("mbig>>two == 0xe000"); if mbig>>two == 0xe000 then yes(); else no(); end if;
+	print("mbig>>one == 0xc0000000"); if mbig>>one == 0xc0000000 then yes(); else no(); end if;
+	print("mbig>>two == 0xe0000000"); if mbig>>two == 0xe0000000 then yes(); else no(); end if;
+	print("twodtwo>>seven == 5");     if twodtwo>>seven == 5 then yes(); else no(); end if;
 end sub;
 rshifts();
 


### PR DESCRIPTION
Switch the compiler output format to coofiles, plus all the machiner; cowlink now works well enough to load and walk the call graph from a coofile. Lots of knock-on changes and fixes including partial type support (needed for recursive types).