### PR TITLE
More cowwrap work.

### DIFF
--- a/mkninja.lua
+++ b/mkninja.lua
@@ -99,5 +99,6 @@ include "toolchains.lua"
 include "src/cowlink/build.lua"
 include "src/cowcom/build.lua"
 include "src/cowwrap/build.lua"
+include "rt/cpm/build.lua"
 include "tests/build.lua"
 

--- a/rt/cpm/build.lua
+++ b/rt/cpm/build.lua
@@ -1,0 +1,5 @@
+cowwrap {
+	ins = { "rt/cpm/cowgol.cos" },
+	outs = { "$OBJ/rt/cpm/cowgol.coo" }
+}
+

--- a/rt/cpm/cowgol.cos
+++ b/rt/cpm/cowgol.cos
@@ -1,0 +1,1032 @@
+&S @
+    org 0x100
+    cseg
+    lxi sp, stackend
+    call cmain
+_exit:
+    rst 0
+    dseg
+stack:
+    ds 128
+stackend:
+
+# Multiples two 8-bit values: A = B * D.
+# Uses DE.
+&X _mul1
+    cseg
+``:
+    mvi c, 0            ; initial result
+    mvi e, 9            ; number of bits
+``_again:
+    mov a, d
+    rar                 ; rotate D, leaving result in A
+    dcr e
+    rz                  ; if finished, return with result in A
+    mov d, a
+    mov a, c
+    jnc ``_nocarry
+    add b
+``_nocarry:
+    rar
+    mov c, a
+    jmp ``_again
+
+# Multiplies two 16-bit values: HL = HL * DE.
+# Uses A and BC.
+&X _mul2
+    cseg
+``:
+    mov b, h            ; BC = LHS
+    mov c, l
+    lxi h, 0            ; HL = result
+``_again:
+    mov a, b            ; if multiplier = 0 then finished
+    ora c
+    rz
+
+    xra a               ; clear carry and shift BC right
+    mov a, b 
+    rar
+    mov b, a
+    mov a, c
+    rar
+    mov c, a
+
+    jnc ``_nocarry      ; if carry, HL = HL + DE
+    dad d
+``_nocarry:
+    xchg                ; HL = HL * 2
+    dad h
+    xchg
+    jmp ``_again
+
+# A 12-byte block used for maths storage.
+&S block
+&W block 0 12
+
+# Multiplies two 32-bit values from the stack, leaving the result
+# on the stack.
+# Uses EVERYTHING.
+# This routine is taken from the ACK 8080 standard library:
+# https://github.com/davidgiven/ack/blob/default/mach/i80/libem/mli4.s
+# It's (c) 1987, 1990, 1993, 2005 Vrije Universiteit, Amsterdam, The Netherlands,
+# and is distributable under the 3-clause BSD license.
+&X _mul4
+    cseg
+``:
+    pop h
+    shld ``_return + 1
+
+    pop h                   ; store multiplier
+    shld `$block.0.0
+    pop h
+    shld `$block.0.0+2
+    pop h                   ; store multiplicand
+    shld `$block.0.4
+    pop h
+    shld `$block.0.4+2
+    lxi h,0
+    shld `$block.0.8        ; product = 0
+    shld `$block.0.8+2
+    lxi b,0
+``_lp1:
+    lxi h,`$block.0.0
+    dad b
+    mov a,m                 ; get next byte of multiplier
+    mvi b,8
+``_lp2:
+    rar
+    jnc ``_2
+    lhld `$block.0.4        ; add multiplicand to product
+    xchg
+    lhld `$block.0.8
+    dad d
+    shld `$block.0.8
+    lhld `$block.0.4+2
+    jnc ``_1
+    inx h
+``_1:
+    xchg
+    lhld `$block.0.8+2
+    dad d
+    shld `$block.0.8+2
+
+``_2:
+    lhld `$block.0.4        ; shift multiplicand left
+    dad h
+    shld `$block.0.4
+    lhld `$block.0.4+2
+    jnc ``_3
+    dad h
+    inx h
+    jmp ``_4
+``_3:
+    dad h
+``_4:
+    shld `$block.0.4+2
+
+    dcr b
+    jnz ``_lp2
+
+    inr c
+    mov a,c
+    cpi 4
+    jnz ``_lp1
+
+    lhld `$block.0.8+2
+    push h
+    lhld `$block.0.8
+    push h
+``_return:
+    jmp 0
+
+# Divides two eight-bit unsigned numbers: B / D.
+# The quotient is returned in A, the remainder in B.
+&X _dvrmu1
+    cseg
+``:
+    mvi c, 8            ; bit count
+    xra a               ; remainder
+``_1:
+    mov e, a            ; temporarily store remainder in E
+    mov a, b
+    add a
+    mov b, a
+    mov a, e
+    rla
+    cmp d
+    jc ``_2
+    inc b
+    sub d
+``_2:
+    dec c
+    jnz ``_1
+    ret
+
+# Divides two eight-bit signed numbers: B / D.
+# The quotient is returned in D, the remainder in B.
+&X _dvrms1
+    cseg
+``:
+    mov a, b
+    xor d                ; discover sign of result
+    push psw             ; save for later
+    xor d                ; recover sign of b (sign of remainder)
+    push psw             ; save for later
+    jp ``_b_positive
+    xra a                ; invert b to make it positive
+    sub b
+    mov b, a
+``_b_positive:
+    mov a, d
+    or d                 ; get sign of d
+    jp ``_d_positive
+    xra a                ; invert d to make it positive
+    sub d
+    mov d, a
+``_d_positive:
+    call `_dvrmu1        ; actually do the division
+    mov d, a
+    pop psw              ; get sign of remainder
+    jp ``_remainder_positive
+    xra a
+    sub d
+    mov d, a
+``_remainder_positive:
+    pop psw              ; get sign of result
+    rp                   ; finish now if we're good
+    xra a
+    sub b
+    mov b, a
+    ret
+
+# Divides two sixteen-bit unsigned numbers: DE / BC.
+# The quotient is returned in DE, the remainder in HL.
+&X _dvrmu2
+    cseg
+``:
+    xra a               ; negate BC
+    sub c
+    mov c,a
+    mvi a,0
+    sbb b
+    mov b,a
+
+    lxi h, 0            ; initial value of remainder
+    mvi a, 16           ; loop counter
+``2:
+    push psw            ; save loop counter
+    dad h               ; hl = hl << 1
+    xchg
+    dad h
+    xchg                ; de = de << 1
+    jnc ``4
+    inx h
+``4:
+    push h              ; save remainder
+    dad b               ; add negative divisor
+    jnc ``5
+    xthl
+    inx d
+``5:
+    pop h
+    pop psw
+    dcr a
+    jnz ``2
+    ret
+
+# Divides two eight-bit signed numbers: DE / BC.
+# The quotient is returned in DE, the remainder in HL.
+&X _dvrms2
+    cseg
+``:
+    mov a, d
+    xor b                ; discover sign of result
+    push psw             ; save for later
+    xor b                ; recover sign of b (sign of remainder)
+    push psw             ; save for later
+    jp ``_de_positive
+    xra a                ; invert de to make it positive
+    sub e
+    mov e, a
+    sbb a
+    sub d
+    mov d, a
+``_de_positive:
+    mov a, b
+    or b                 ; get sign of bc
+    jp ``_bc_positive
+    xra a                ; invert bc to make it positive
+    sub c
+    mov c, a
+    sbb a
+    sub b
+    mov b, a
+``_bc_positive:
+    call `_dvrmu2        ; actually do the division
+    pop psw              ; get sign of remainder
+    jp ``_remainder_positive
+    xra a
+    sub l
+    mov l, a
+    sbb a
+    sub h
+    mov h, a
+``_remainder_positive:
+    pop psw              ; get sign of result
+    rp                   ; finish now if we're good
+    xra a                ; invert bc to make it positive
+    sub e
+    mov e, a
+    sbb a
+    sub d
+    mov d, a
+    ret
+
+# Divides two four-byte unsigned values from the stack, leaving the
+# quotient then the remainder pushed.
+# Uses EVERYTHING.
+# This routine is taken from the ACK 8080 standard library:
+# https://github.com/davidgiven/ack/blob/default/mach/i80/libem/dvi4.s
+# It's (c) 1987, 1990, 1993, 2005 Vrije Universiteit, Amsterdam, The Netherlands,
+# and is distributable under the 3-clause BSD license.
+&X _dvrmu4
+    cseg
+``:
+    pop b
+
+    pop h               ; store divisor
+    shld `$block.0.8
+    xchg
+    pop h
+    shld `$block.0.8+2
+
+    pop h               ; store dividend
+    shld `$block.0.0
+    pop h
+    shld `$block.0.0+2
+
+    push b
+    call `dvrmu4core
+    pop d
+
+    lhld `$block.0.0+2
+    push h
+    lhld `$block.0.0+0
+    push h
+    lhld `$block.0.4+2
+    push h
+    lhld `$block.0.4+0
+    push h
+    xchg
+    pchl
+
+# Divides two four-byte signed values from the stack, leaving the quotient
+# then the remainder pushed.
+# Uses EVERYTHING.
+# This routine is taken from the ACK 8080 standard library:
+# https://github.com/davidgiven/ack/blob/default/mach/i80/libem/dvi4.s
+# It's (c) 1987, 1990, 1993, 2005 Vrije Universiteit, Amsterdam, The Netherlands,
+# and is distributable under the 3-clause BSD license.
+&X _dvrms4
+    cseg
+``:
+    pop b
+
+    pop h               ; store divisor
+    shld `$block.0.8
+    xchg
+    pop h
+    shld `$block.0.8+2
+
+    pop h               ; store dividend
+    shld `$block.0.0
+    pop h
+    shld `$block.0.0+2
+
+    push b              ; put return address back on stack
+
+    lxi h, `$block.0.8+3
+    lda `$block.0.0+3
+    xra m               ; discover sign of result
+    push psw            ; save for later
+    xra m               ; recover sign of divisor (sign of remainder)
+    push psw            ; save for later
+    lxi h, `$block.0.0
+    cm `neg4core        ; negate divisor if negative
+
+    lda `$block.0.8+3
+    ora a               ; get sign of dividend
+    lxi h, `$block.0.8
+    cm `neg4core        ; negate dividend if negative
+
+    call `dvrmu4core    ; actually perform the division
+
+    pop psw             ; get sign of remainder
+    lxi h, `$block.0.4
+    cm `neg4core
+
+    pop psw             ; get sign of result
+    lxi h, `$block.0.0
+    cm `neg4core
+
+    pop d               ; get return address
+    lhld `$block.0.0+2  ; push result and exit
+    push h
+    lhld `$block.0.0+0
+    push h
+    lhld `$block.0.4+2
+    push h
+    lhld `$block.0.4+0
+    push h
+    xchg
+    pchl
+
+# Core code for the 32-bit division. Divides block+8 / block+0, leaving
+# the quotient in block+0 and the remainder in block+4.
+&S dvrmu4core
+``:
+    lxi h,0             ; store initial value of remainder
+    shld `$block.0.4
+    shld `$block.0.4+2
+
+    mvi b,32
+``_again:
+    lxi h,`$block.0.0        ; left shift: `$block.0.4 <- `$block.0.0 <- 0
+    mvi c,8
+    xra a
+``_shiftloop:
+    mov a,m
+    ral
+    mov m,a
+    inx h
+    dcr c
+    jnz ``_shiftloop
+
+    lxi h,`$block.0.4+3      ; which is larger: divisor or remainder?
+    lxi d,`$block.0.8+3
+    mvi c,4
+``_cmploop:
+    ldax d
+    cmp m
+    jz ``_same
+    jnc ``_gt
+    jmp ``_le
+``_same:
+    dcx d
+    dcx h
+    dcr c
+    jnz ``_cmploop
+
+``_le:
+    lxi d,`$block.0.4        ; remainder is larger or equal: subtract divisor
+    lxi h,`$block.0.8
+    mvi c,4
+    xra a
+``_subloop:
+    ldax d
+    sbb m
+    stax d
+    inx d
+    inx h
+    dcr c
+    jnz ``_subloop
+    lxi h,`$block.0.0
+    inr m
+
+``_gt:
+    dcr b
+    jnz ``_again    ; keep looping
+    ret
+
+# Divides two four-byte unsigned values from the stack, 
+&X _divu4
+    cseg
+``:
+    pop h
+    shld ``_ret+1
+    call `_dvrmu4
+    pop h
+    pop h
+``_ret
+    jmp 0
+
+# Takes the remainder of two four-byte unsigned values from the stack, 
+&X _remu4
+    cseg
+``:
+    pop h
+    shld ``_ret+1
+    call `_dvrmu4
+    pop b
+    pop d
+    pop h
+    pop h
+    push d
+    push b
+``_ret
+    jmp 0
+
+# Divides two four-byte signed values from the stack, 
+&X _divs4
+    cseg
+``:
+    pop h
+    shld ``_ret+1
+    call `_dvrms4
+    pop h
+    pop h
+``_ret
+    jmp 0
+
+# Takes the remainder of two four-byte nsigned values from the stack, 
+&X _rems4
+    cseg
+``:
+    pop h
+    shld ``_ret+1
+    call ``_dvrms4
+    pop b
+    pop d
+    pop h
+    pop h
+    push d
+    push b
+``_ret
+    jmp 0
+
+# Adds two four-byte values from the stack.
+&X _add4
+    cseg
+``:
+    pop h
+    shld ``_ret
+
+    pop h               ; HL = RHS low
+    pop d               ; DE = RHS high
+    pop b               ; BC = LHS low
+    dad b               ; HL = RHS low + LHS low
+    pop b               ; BC = LHS high
+    xchg                ; DE = RHS low + LHS low, HL = RHS high
+    jnc ``_skip
+    inx h               ; carry adjust
+``_skip:
+    dad b               ; HL = RHS high + LHS high + carry
+    push h
+    push d
+``_ret equ $ + 1
+    jmp 0
+
+# Subtracts two four-byte values from the stack.
+&X _sub4
+    cseg
+``:
+    pop h
+    shld ``_ret
+
+    pop h               ; HL = RHS low
+    pop d               ; DE = RHS high
+    pop b               ; BC = LHS low
+    
+    mov a, c
+    sub l
+    mov c, a
+    mov a, b
+    sbb h
+    mov b, a            ; BC = result low
+
+    pop h               ; HL = LHS high
+
+    mov a, l
+    sbb e
+    mov l, a
+    mov a, h
+    sbb d
+    mov h, a
+
+    push h
+    push b
+
+``_ret equ $ + 1
+    jmp 0
+
+# ANDs two four-byte values from the stack.
+&X _and4
+    cseg
+``:
+    pop h
+    shld ``_ret
+
+    pop h               ; HL = RHS low
+    pop d               ; DE = RHS high
+    pop b               ; BC = LHS low
+    
+    mov a, c
+    ana l
+    mov c, a
+    mov a, b
+    ana h
+    mov b, a            ; BC = result low
+
+    pop h               ; HL = LHS high
+
+    mov a, l
+    ana e
+    mov l, a
+    mov a, h
+    ana d
+    mov h, a
+
+    push h
+    push b
+
+``_ret equ $ + 1
+    jmp 0
+
+# ORs two four-byte values from the stack.
+&X _or4
+    cseg
+``:
+    pop h
+    shld ``_ret
+
+    pop h               ; HL = RHS low
+    pop d               ; DE = RHS high
+    pop b               ; BC = LHS low
+    
+    mov a, c
+    ora l
+    mov c, a
+    mov a, b
+    ora h
+    mov b, a            ; BC = result low
+
+    pop h               ; HL = LHS high
+
+    mov a, l
+    ora e
+    mov l, a
+    mov a, h
+    ora d
+    mov h, a
+
+    push h
+    push b
+
+``_ret equ $ + 1
+    jmp 0
+
+# EORs two four-byte values from the stack.
+&X _eor4
+    cseg
+``:
+    pop h
+    shld ``_ret
+
+    pop h               ; HL = RHS low
+    pop d               ; DE = RHS high
+    pop b               ; BC = LHS low
+    
+    mov a, c
+    xra l
+    mov c, a
+    mov a, b
+    xra h
+    mov b, a            ; BC = result low
+
+    pop h               ; HL = LHS high
+
+    mov a, l
+    xra e
+    mov l, a
+    mov a, h
+    xra d
+    mov h, a
+
+    push h
+    push b
+
+``_ret equ $ + 1
+    jmp 0
+
+# NOTs the four-byte value on the stack.
+&X _not4
+    cseg
+``:
+    pop h
+    pop d               ; DE = low word
+    pop b               ; BC = high word
+
+    mov a, d
+    cpl
+    mov d, a
+    mov a, e
+    cpl
+    mov e, a
+
+    mov a, b
+    cpl
+    mov b, a
+    mov a, c
+    cpl
+    mov c, a
+
+    push b
+    push d
+    pchl
+
+# Negates the four-byte value on the stack.
+&X _neg4
+    cseg
+``:
+    pop d
+
+    lxi h, 0
+    dad sp
+    call `neg4core
+
+    xchg
+    pchl
+
+# Negates the four-byte value pointed to by hl.
+&S neg4core
+    xra a
+    sub m
+    mov m, a
+    inx h
+
+    mvi a, 0
+    sbb m
+    mov m, a
+    inx h
+
+    mvi a, 0
+    sbb m
+    mov m, a
+    inx h
+
+    mvi a, 0
+    sbb m
+    mov m, a
+    ret
+
+# Shifts A left B bits.
+# Corrupts A and B.
+&X _asl1
+    cseg
+``:
+    dec b
+    rm
+    add a
+    jmp ``
+
+# Arithmetic shift A right B bits.
+# Corrupts A, B and C.
+&X _asr1
+    cseg
+``:
+    mov c, a        ; old copy of A
+``_loop:
+    dec b
+    rm
+    rla
+    mov a, c
+    rra
+    mov c, a
+    jmp ``_loop
+
+# Logical shift A right B bits.
+# Corrupts A and B.
+&X _lsr1
+    cseg
+``:
+    dec b
+    rm
+    ora a
+    rar
+    jmp ``
+
+# Shifts HL left B bits.
+# Corrupts A and HL.
+&X _asl2
+    cseg
+``:
+    dec b
+    rm
+    dad h
+    jmp ``
+
+# Arithmetic shift HL right B bits.
+# Corrupts A, B and HL.
+&X _asr2
+    cseg
+``:
+    dec b
+    rm
+    mov a, h
+    rla
+    mov a, h
+    rra
+    mov h, a
+    mov a, l
+    rar
+    mov l, a
+    jmp ``
+
+# Logical shift HL right B bits.
+# Corrupts A, B and HL.
+&X _lsr2
+    cseg
+``:
+    dec b
+    rm
+    ora a
+    mov a, h
+    rar
+    mov h, a
+    mov a, l
+    rar
+    mov l, a
+    jmp ``
+
+# Logical shift the value at the top of the stack left B bits.
+# Corrupts A, B, HL, DE.
+&X _asl4
+    cseg
+``:
+    pop h
+    shld ``_ret
+
+    pop h               ; HL = low
+    pop d               ; DE = high
+``_loop:
+    dec b
+    jm ``_exit
+
+    dad h
+    jnc ``_skip
+    inx d
+``_skip:
+    xchg
+    dad h
+    xchg
+
+    jmp ``_loop
+``_exit:
+    push d
+    push h
+``_ret equ $ + 1
+    jmp 0
+
+# Arithmetic shift the value at the top of the stack right B bits.
+# Corrupts A, B, HL, DE.
+&X _asr4
+    cseg
+``:
+    pop h
+    shld ``_ret
+
+    pop h               ; HL = low
+    pop d               ; DE = high
+``_loop:
+    dec b
+    jm ``_exit
+    mov a, d
+    rla
+    mov a, d
+    rar
+    mov d, a
+    mov a, e
+    rar
+    mov e, a
+    mov a, h
+    rar
+    mov h, a
+    mov a, l
+    rar
+    mov l, a
+    jmp ``_loop
+``_exit:
+    push d
+    push h
+``_ret equ $ + 1
+    jmp 0
+
+# Logical shift the value at the top of the stack right B bits.
+# Corrupts A, B, HL, DE.
+&X _lsr4
+    cseg
+``:
+    pop h
+    shld ``_ret
+
+    pop h               ; HL = low
+    pop d               ; DE = high
+``_loop:
+    dec b
+    jm ``_exit
+    ora a
+    mov a, d
+    rar
+    mov d, a
+    mov a, e
+    rar
+    mov e, a
+    mov a, h
+    rar
+    mov h, a
+    mov a, l
+    rar
+    mov l, a
+    jmp ``_loop
+``_exit:
+    push d
+    push h
+``_ret equ $ + 1
+    jmp 0
+
+# Loads a 32-bit value at HL and pushes it.
+# Corrupts BC, DE.
+&X _load4
+    cseg
+``:
+    mov e, m
+    inx h
+    mov d, m
+    inx h
+    mov c, m
+    inx h
+    mov b, m
+    pop h
+    push b
+    push d
+    pchl
+
+# Pops a 32-bit value and stores it at HL.
+# Corrupts BC, DE.
+&X _store4
+    cseg
+``:
+    pop d               ; return address
+    pop b               ; low word
+    xchg                ; d = address, h = return address
+    xthl                ; d = address, b = low word, h = high word
+    xchg                ; d = high word, b = low word, h = address
+    mov m, c
+    inx h
+    mov m, b
+    inx h
+    mov m, e
+    inx h
+    mov m, d
+    ret
+
+# Does a tristate signed comparison of a <> b.
+# Returns m flag if a < b.
+# Returns p flag if a >= b.
+# This doesn't set z coherently.
+&X _cmps1
+    cseg
+``:
+    xra b               ; test signs
+    jp ``u              ; signs are the same
+    xra b               ; undo munged A and set C=0
+    ret
+``u:
+    xra b               ; undo munged A
+    sub b
+    ret
+
+# Signed comparison of de <> hl.
+# Returns c if de < hl.
+# Returns !c if de >= hl.
+&X _cmps2
+    cseg
+``:
+    mov a, d
+    xra h               ; test signs
+    jp ``u             ; jump if the signs are the same
+    xra d               ; make A=H and set !C
+    rm                  ; return with !C if de >= hl
+    stc
+    ret                 ; return with C if de < hl
+``u:
+    ; Here, we know the signs are the same, which means we can
+    ; do a simple unsigned comparison.
+    mov a, e
+    sub l
+    mov a, d
+    sbb h
+    ret
+    
+# Equality comparison of HL and DE.
+# Returns z if a == b.
+# Uses A.
+&X _cmpeq2
+    cseg
+``:
+    ld a, e
+    cmp l
+    ret nz
+    ld a, d
+    cmp h
+    ret
+
+# Unsigned comparison of the two numbers on the top of the stack.
+# Returns z if a == b.
+# Returns c if a < b.
+&X _cmpu4
+    cseg
+``:
+    pop h
+    shld ``_ret
+
+    call sub4           ; leaves the value on the stack, sets C on overflow
+    pop b               ; low
+    pop d               ; high
+    push af             ; save flags
+
+    mov a, b
+    or c
+    or d
+    or e                ; a = 0 if the value was zero
+
+    mov b, a
+    inc b               ; a = 1 if the value was zero
+    pop af              ; restore carry flag
+    dec b               ; set Z flag, but don't disturb the carry flag
+``_ret equ $ + 1
+    jmp 0
+
+# Signed comparison of the two numbers on the top of the stack.
+# Returns c if lhs < rhs.
+&X _cmps4
+    cseg
+``:
+    pop d
+
+    lxi h, 7
+    dad sp
+    mov a, m            ; a = high byte of lhs
+    mov b, a
+    lxi h, 3
+    dad sp
+    xra m               ; xor with high byte of rhs
+    jp ``_u             ; jump if the signs are the same
+    ; The signs are different, so determining C can be done from
+    ; just the top bytes. Discard the data.
+    lxi h, 8
+    dad sp
+    sphl                ; sp = sp + 8
+    push d              ; push the return address
+    xra b               ; make A=high byte of lhs and set !C
+    rm                  ; return with !C if lhs >= rhs
+    stc
+    ret                 ; return with C if lhs < rhs
+``_u:
+    ; The signs are the same, so do a simple unsigned comparison.
+    push d
+    jmp `_cmpu4
+
+# vim: ts=4 sw=4 et
+

--- a/src/build.lua
+++ b/src/build.lua
@@ -185,3 +185,15 @@ function cowlink(e)
 	}
 end
 
+function cowwrap(e)
+	rule {
+		ins = concat {
+			"scripts/quiet",
+			"bin/cowwrap.ocgen.exe",
+			e.ins
+		},
+		outs = e.outs,
+		cmd = "@1 @2 @3 &1"
+	}
+end
+

--- a/src/cowwrap/reader.coh
+++ b/src/cowwrap/reader.coh
@@ -1,11 +1,13 @@
 const SYM_UNDECLARED := 0;
-const SYM_DEFINED    := 0b01;
-const SYM_EXPORTED   := 0b10;
+const SYM_DEFINED    := 0b001;
+const SYM_PUBLIC     := 0b010;
+const SYM_DECLARED   := 0b100;
 
 record Symbol
 	next: [Symbol];
 	name: string;
 	id: SubId;
+	workspace: Size;
 	state: uint8;
 end record;
 
@@ -35,6 +37,7 @@ end sub;
 	
 sub ProcessFile()
 	main_symbol.name := "@";
+	main_symbol.state := SYM_DEFINED | SYM_DECLARED;
 	EmitterPushChunk();
 	E_h16(current_subr.id);
 
@@ -44,6 +47,13 @@ sub ProcessFile()
 
 	sub GetC()
 		c := FCBGetChar(&infcb);
+	end sub;
+
+	sub ExpectC(want: uint8)
+		if c != want then
+			FatalError("malformed cowwrap directive");
+		end if;
+		GetC();
 	end sub;
 
 	sub SkipToEndOfLine()
@@ -68,7 +78,11 @@ sub ProcessFile()
 		SkipWhitespace();
 		var p := &buffer[0];
 		loop
-			if (c == 0) or (c == 26) or (c == 10) or (c == ' ') or (c == '\t') then
+			if ((c < '0') or (c > '9'))
+					and ((c < 'a') or (c > 'z'))
+					and ((c < 'A') or (c > 'Z'))
+					and (c != '_')
+					and (c != '@') then
 				break;
 			end if;
 
@@ -92,36 +106,73 @@ sub ProcessFile()
 		end if;
 	end sub;
 
-	sub ExportSubroutine()
-		GetC();
-		ReadWord();
-		var symbol := GetSymbol(&buffer[0]);
-		if (symbol.state & SYM_EXPORTED) == 0 then
-			symbol.state := symbol.state | SYM_EXPORTED;
+	sub MarkSubroutinePublic(symbol: [Symbol])
+		if (symbol.state & SYM_PUBLIC) == 0 then
+			symbol.state := symbol.state | SYM_PUBLIC;
 			EmitterDeclareExternal(symbol.id, symbol.name);
 		end if;
 	end sub;
 
-	sub CloseSubroutine()
+	sub ImportSubroutine()
+		GetC();
+		ReadWord();
+		MarkSubroutinePublic(GetSymbol(&buffer[0]));
+	end sub;
+
+	sub CloseChunk()
 		if current_subr != (0 as [Symbol]) then
 			EmitterPopChunk('S');
 			current_subr := (0 as [Symbol]);
 		end if;
 	end sub;
 
-	sub DefineSubroutine()
-		CloseSubroutine();
+	sub DeclareSubroutine(exported: uint8)
+		CloseChunk();
 
 		GetC();
 		ReadWord();
 		current_subr := GetSymbol(&buffer[0]);
 		current_subr.state := current_subr.state | SYM_DEFINED;
 
-		if current_subr != &main_symbol then
-			EmitterDeclareSubroutine(current_subr.id, current_subr.name);
+		if exported != 0 then
+			MarkSubroutinePublic(current_subr);
 		end if;
+		if (current_subr.state & SYM_DECLARED) == 0 then
+			EmitterDeclareSubroutine(current_subr.id, current_subr.name);
+			current_subr.state := current_subr.state | SYM_DECLARED;
+		end if;
+
 		EmitterPushChunk();
 		E_h16(current_subr.id);
+	end sub;
+
+	sub SetSubroutineWorkspace()
+		GetC();
+		ReadWord();
+		var symbol := GetSymbol(&buffer[0]);
+		SkipWhitespace();
+		var wid := ReadNumber() as uint8;
+		SkipWhitespace();
+		symbol.workspace := ReadNumber() as Size;
+	end sub;
+
+	sub EmitWorkspaceRef()
+		GetC();
+		ReadWord();
+		var symbol := current_subr;
+		if buffer[0] != 0 then
+			symbol := GetSymbol(&buffer[0]);
+			EmitterReferenceSubroutine(current_subr.id, symbol.id);
+		end if;
+		ExpectC('.');
+		var wid := ReadNumber() as uint8;
+		ExpectC('.');
+		var woff := ReadNumber() as Size;
+		EmitByte('`');
+		EmitByte('$');
+		E_h16(symbol.id);
+		E_h8(wid);
+		E_h16(woff);
 	end sub;
 
 	sub SourceLine()
@@ -132,11 +183,22 @@ sub ProcessFile()
 			if c != 13 then
 				if c == '`' then
 					GetC();
-					ReadWord();
-					var subr := GetSymbol(&buffer[0]);
-					EmitByte('`');
-					E_h16(subr.id);
-					EmitterReferenceSubroutine(current_subr.id, subr.id);
+					case c is
+						when '`':
+							EmitByte('`');
+							E_h16(current_subr.id);
+							GetC();
+
+						when '$':
+							EmitWorkspaceRef();
+
+						when else:
+							ReadWord();
+							var subr := GetSymbol(&buffer[0]);
+							EmitByte('`');
+							E_h16(subr.id);
+							EmitterReferenceSubroutine(current_subr.id, subr.id);
+					end case;
 				else
 					EmitByte(c);
 					GetC();
@@ -156,10 +218,13 @@ sub ProcessFile()
 				GetC();
 				case c is
 					when 'X':
-						ExportSubroutine();
+						DeclareSubroutine(1);
 
 					when 'S':
-						DefineSubroutine();
+						DeclareSubroutine(0);
+
+					when 'W':
+						SetSubroutineWorkspace();
 
 					when else:
 						FatalError("bad cowwrap command");
@@ -174,7 +239,7 @@ sub ProcessFile()
 		end case;
 		GetC();
 	end loop;
-	CloseSubroutine();
+	CloseChunk();
 end sub;
 
 sub CheckSymbols()

--- a/src/cowwrap/reader.coh
+++ b/src/cowwrap/reader.coh
@@ -7,7 +7,6 @@ record Symbol
 	next: [Symbol];
 	name: string;
 	id: SubId;
-	workspace: Size;
 	state: uint8;
 end record;
 
@@ -153,7 +152,8 @@ sub ProcessFile()
 		SkipWhitespace();
 		var wid := ReadNumber() as uint8;
 		SkipWhitespace();
-		symbol.workspace := ReadNumber() as Size;
+		var woff := ReadNumber() as Size;
+		EmitterDeclareWorkspace(symbol.id, wid, woff);
 	end sub;
 
 	sub EmitWorkspaceRef()


### PR DESCRIPTION
It should now actually work, with cross-references and everything (although the output coofiles could use optimisation). Port the CP/M standard library into cos format.