### PR TITLE
Implement the register cache

### DIFF
--- a/src/cowcom/arch8080.cow.ng
+++ b/src/cowcom/arch8080.cow.ng
@@ -93,12 +93,22 @@
 		EmitByte('\n');
 	end sub;
 
+	sub R_flushall()
+		RegCacheFlush(ALL_REGS);
+	end sub;
+
+	sub R_flush(reg: RegId)
+		RegCacheFlush(FindConflictingRegisters(reg));
+	end sub;
+
 	sub E_label(label: LabelRef)
+		R_flushall();
 		E_labelref(label);
 		E(":\n");
 	end sub;
 
 	sub E_jump(insn: string, label: LabelRef)
+		R_flushall();
 		E_tab();
 		E(insn);
 		E_space();
@@ -115,6 +125,7 @@
 	end sub;
 
 	sub E_call(subr: [Subroutine])
+		R_flushall();
 		E_tab();
 		E("call ");
 		E_subref(subr);
@@ -123,6 +134,7 @@
 
 	sub loreg(reg: RegId): (result: RegId)
 		case reg is
+			when REG_A:  result := REG_A;
 			when REG_BC: result := REG_C;
 			when REG_DE: result := REG_E;
 			when REG_HL: result := REG_L;
@@ -133,6 +145,7 @@
 
 	sub hireg(reg: RegId): (result: RegId)
 		case reg is
+			when REG_A:  result := REG_A;
 			when REG_BC: result := REG_B;
 			when REG_DE: result := REG_D;
 			when REG_HL: result := REG_H;
@@ -174,6 +187,7 @@
 	end sub;
 
 	sub E_mov(dest: RegId, src: RegId)
+		R_flush(dest);
 		E_tab();
 		E("mov ");
 		E_reg(dest);
@@ -190,6 +204,7 @@
 	end sub;
 
 	sub E_pop(dest: RegId)
+		R_flush(dest);
 		E_tab();
 		E("pop ");
 		E_stackreg(dest);
@@ -197,14 +212,32 @@
 	end sub;
 
 	sub E_mvi(reg: RegId, value: uint8)
+		if (reg & (REG_HL|REG_BC|REG_DE)) != 0 then
+			SimpleError("mvi with 16-bit reg");
+		end if;
+
+		var cache := RegCacheFindConstant(value as Arith)
+			& (REG_A|REG_B|REG_C|REG_D|REG_H|REG_L);
+		if (cache & reg) != 0 then
+			# Already in the desired register.
+			return;
+		elseif cache != 0 then
+			# Already in a register, but not the one we want.
+			E_mov(reg, FindFirst(cache));
+			return;
+		end if;
+
+		R_flush(reg);
 		E("\tmvi ");
 		E_reg(reg);
 		E_comma();
 		E_u8(value);
 		E_nl();
+		RegCacheLeavesConstant(reg, value as Arith);
 	end sub;
 
 	sub E_alu(insn: string, rhs: RegId)
+		R_flush(REG_A);
 		E_tab();
 		E(insn);
 		E_space();
@@ -214,6 +247,9 @@
 
 	sub E_xra(rhs: RegId)
 		E_alu("xra", rhs);
+		if rhs == REG_A then
+			RegCacheLeavesConstant(REG_A, 0);
+		end if;
 	end sub;
 
 	sub E_ora(rhs: RegId)
@@ -237,6 +273,7 @@
 	end sub;
 
 	sub E_alui(insn: string, value: uint8)
+		R_flush(REG_A);
 		E_tab();
 		E(insn);
 		E_space();
@@ -277,14 +314,31 @@
 	end sub;
 
 	sub E_lxi(reg: RegId, value: uint16);
+		var cache := RegCacheFindConstant(value as Arith) & (REG_HL|REG_BC|REG_DE);
+		if (cache & reg) != 0 then
+			# The value is already in the desired register.
+			return;
+		elseif cache != 0 then
+			# The value is already in a register, but not this one.
+			cache := FindFirst(cache);
+			E_mov(loreg(reg), loreg(cache));
+			E_mov(hireg(reg), hireg(cache));
+			return;
+		end if;
+
+		R_flush(reg);
 		E("\tlxi ");
 		E_reg(reg);
 		E_comma();
 		E_u16(value);
 		E_nl();
+		RegCacheLeavesConstant(reg, value as Arith);
+		RegCacheLeavesConstant(loreg(reg), value as uint8 as Arith);
+		RegCacheLeavesConstant(hireg(reg), (value>>8) as uint8 as Arith);
 	end sub;
 
 	sub E_lxia(reg: RegId, sym: [Symbol], off: Size)
+		R_flush(reg);
 		E("\tlxi ");
 		E_reg(reg);
 		E_comma();
@@ -293,6 +347,7 @@
 	end sub;
 
 	sub E_lda(sym: [Symbol], off: Size)
+		R_flush(REG_A);
 		E("\tlda ");
 		E_symref(sym, off);
 		E_nl();
@@ -305,6 +360,7 @@
 	end sub;
 
 	sub E_lhld(sym: [Symbol], off: Size)
+		R_flush(REG_HL);
 		E("\tlhld ");
 		E_symref(sym, off);
 		E_nl();
@@ -317,6 +373,7 @@
 	end sub;
 
 	sub E_loadm(reg: RegId)
+		R_flush(reg);
 		E("\tmov ");
 		E_reg(reg);
 		E(",m\n");
@@ -335,56 +392,67 @@
 	end sub;
 
 	sub E_ldax(ptr: RegId)
+		R_flush(REG_A);
 		E("\tldax ");
 		E_reg(ptr);
 		E_nl();
 	end sub;
 
 	sub E_inc(reg: RegId)
+		R_flush(reg);
 		E("\tinc ");
 		E_reg(reg);
 		E_nl();
 	end sub;
 
 	sub E_dec(reg: RegId)
+		R_flush(reg);
 		E("\tdec ");
 		E_reg(reg);
 		E_nl();
 	end sub;
 
 	sub E_inx(reg: RegId)
+		R_flush(reg);
 		E("\tinx ");
 		E_reg(reg);
 		E_nl();
 	end sub;
 
 	sub E_dcx(reg: RegId)
+		R_flush(reg);
 		E("\tdcx ");
 		E_reg(reg);
 		E_nl();
 	end sub;
 
 	sub E_xchg()
+		R_flush(REG_HL|REG_DE);
 		E("\txchg\n");
 	end sub;
 
 	sub E_pchl()
+		R_flushall();
 		E("\tpchl\n");
 	end sub;
 
 	sub E_cma()
+		R_flush(REG_A);
 		E("\tcma\n");
 	end sub;
 
 	sub E_ral()
+		R_flush(REG_A);
 		E("\tral\n");
 	end sub;
 
 	sub E_rar()
+		R_flush(REG_A);
 		E("\trar\n");
 	end sub;
 
 	sub E_dad(reg: RegId)
+		R_flush(REG_HL);
 		E("\tdad ");
 		E_reg(reg);
 		E_nl();
@@ -415,6 +483,7 @@
 		E_h16(e.id);
 		EmitterPopChunk('R');
 
+		R_flushall();
 		E("\tcall ");
 		EmitByte(COO_ESCAPE_SUBREF);
 		E_h16(e.id);
@@ -464,23 +533,27 @@
 				or ((src == REG_DE) and (dest == REG_HL)) then
 			E_xchg();
 		else
-			sub mov()
-				E("\tmov ");
-			end sub;
-			mov();
-			E_reg(dest);
-			E_comma();
-			E_reg(src);
+			E_mov(dest, src);
 
 			if (src & (REG_HL|REG_BC|REG_DE)) != 0 then
-				E_nl();
-				mov();
-				E_reg(loreg(dest));
-				E_comma();
-				E_reg(loreg(src));
+				E_mov(loreg(dest), loreg(src));
 			end if;
-			E_nl();
 		end if;
+	end sub;
+
+	sub ArchEndInstruction()
+		#var p := &register_cache[0];
+		#while p != &register_cache[@sizeof register_cache] loop
+		#	case p.state is
+		#		when CACHE_SLOT_CONSTANT:
+		#			E("; reg 0x");
+		#			E_h16(p.reg);
+		#			E("=0x");
+		#			E_h32(p.number as uint32);
+		#			E_nl();
+		#	end case;
+		#	p := @next p;
+		#end loop;
 	end sub;
 %}
 
@@ -516,6 +589,8 @@ gen JUMP():j
 
 gen STARTSUB():s
 {
+	RegCacheReset();
+
 	EmitterPushChunk();
 	E_h16($s.subr.id);
 
@@ -573,6 +648,8 @@ gen STARTSUB():s
 
 gen ENDSUB():s
 {
+	R_flushall();
+
 	E("end_");
 	E_subref($s.subr);
 	E(":\n");
@@ -683,7 +760,11 @@ gen RETURN()
 
 gen a|b|d|h := CONSTANT():rhs
 {
-	E_mvi($$, $rhs.value as uint8);
+	if ($rhs.value == 0) and ($$ == REG_A) then
+		E_xra(REG_A);
+	else
+		E_mvi($$, $rhs.value as uint8);
+	end if;
 }
 
 gen bc|de|hl := CONSTANT():rhs
@@ -694,9 +775,9 @@ gen bc|de|hl := CONSTANT():rhs
 gen stk4 := CONSTANT():rhs uses hl
 {
 	E_lxi(REG_HL, ($rhs.value >> 16) as uint16);
-	ArchEmitMove(REG_HL, 0);
+	E_push(REG_HL);
 	E_lxi(REG_HL, $rhs.value as uint16);
-	ArchEmitMove(REG_HL, 0);
+	E_push(REG_HL);
 }
 
 gen bc|de|hl := ADDRESS():a
@@ -1313,7 +1394,7 @@ gen WHENCASE4():c uses a
 gen hl|bc|de := CAST12(a, sext==0)
 {
 	E_mov(loreg($$), REG_A);
-	E_mvi($$, 0);
+	E_mvi(hireg($$), 0);
 }
 
 gen hl|bc|de := CAST12(a, sext!=0)
@@ -1397,6 +1478,7 @@ gen hl|bc|de := CAST42(LOAD4(hl))
 
 gen bc|de|hl := STRING():s
 {
+	R_flush($$);
 	E("\tlxi ");
 	E_reg($$);
 	E_comma();
@@ -1452,6 +1534,7 @@ gen INITS():s
 
 gen ASMSTART()
 {
+	R_flushall();
 	E_tab();
 }
 

--- a/src/cowcom/arch8080.cow.ng
+++ b/src/cowcom/arch8080.cow.ng
@@ -216,7 +216,7 @@
 			SimpleError("mvi with 16-bit reg");
 		end if;
 
-		var cache := RegCacheFindConstant(value as Arith)
+		var cache := RegCacheFindConstant(value as CacheValue)
 			& (REG_A|REG_B|REG_C|REG_D|REG_H|REG_L);
 		if (cache & reg) != 0 then
 			# Already in the desired register.
@@ -233,7 +233,7 @@
 		E_comma();
 		E_u8(value);
 		E_nl();
-		RegCacheLeavesConstant(reg, value as Arith);
+		RegCacheLeavesConstant(reg, value as CacheValue);
 	end sub;
 
 	sub E_alu(insn: string, rhs: RegId)
@@ -314,7 +314,7 @@
 	end sub;
 
 	sub E_lxi(reg: RegId, value: uint16);
-		var cache := RegCacheFindConstant(value as Arith) & (REG_HL|REG_BC|REG_DE);
+		var cache := RegCacheFindConstant(value as CacheValue) & (REG_HL|REG_BC|REG_DE);
 		if (cache & reg) != 0 then
 			# The value is already in the desired register.
 			return;
@@ -332,9 +332,9 @@
 		E_comma();
 		E_u16(value);
 		E_nl();
-		RegCacheLeavesConstant(reg, value as Arith);
-		RegCacheLeavesConstant(loreg(reg), value as uint8 as Arith);
-		RegCacheLeavesConstant(hireg(reg), (value>>8) as uint8 as Arith);
+		RegCacheLeavesConstant(reg, value as CacheValue);
+		RegCacheLeavesConstant(loreg(reg), value as uint8 as CacheValue);
+		RegCacheLeavesConstant(hireg(reg), (value>>8) as uint8 as CacheValue);
 	end sub;
 
 	sub E_lxia(reg: RegId, sym: [Symbol], off: Size)
@@ -578,6 +578,8 @@
 	sub ArchEndInstruction()
 	end sub;
 %}
+
+width 16;
 
 register a b c d e h l hl de bc;
 register stk4 param;

--- a/src/cowcom/arch8080.cow.ng
+++ b/src/cowcom/arch8080.cow.ng
@@ -338,12 +338,25 @@
 	end sub;
 
 	sub E_lxia(reg: RegId, sym: [Symbol], off: Size)
+		var cache := RegCacheFindAddress(sym, off) & (REG_HL|REG_BC|REG_DE);
+		if (cache & reg) != 0 then
+			# The value is already in the desired register.
+			return;
+		elseif cache != 0 then
+			# The value is already in a register, but not this one.
+			cache := FindFirst(cache);
+			E_mov(loreg(reg), loreg(cache));
+			E_mov(hireg(reg), hireg(cache));
+			return;
+		end if;
+
 		R_flush(reg);
 		E("\tlxi ");
 		E_reg(reg);
 		E_comma();
 		E_symref(sym, off);
 		E_nl();
+		RegCacheLeavesAddress(reg, sym, off);
 	end sub;
 
 	sub E_lda(sym: [Symbol], off: Size)

--- a/src/cowcom/arch8080.cow.ng
+++ b/src/cowcom/arch8080.cow.ng
@@ -576,18 +576,6 @@
 	end sub;
 
 	sub ArchEndInstruction()
-		#var p := &register_cache[0];
-		#while p != &register_cache[@sizeof register_cache] loop
-		#	case p.state is
-		#		when CACHE_SLOT_CONSTANT:
-		#			E("; reg 0x");
-		#			E_h16(p.reg);
-		#			E("=0x");
-		#			E_h32(p.number as uint32);
-		#			E_nl();
-		#	end case;
-		#	p := @next p;
-		#end loop;
 	end sub;
 %}
 

--- a/src/cowcom/arch8080.cow.ng
+++ b/src/cowcom/arch8080.cow.ng
@@ -338,17 +338,18 @@
 	end sub;
 
 	sub E_lxia(reg: RegId, sym: [Symbol], off: Size)
-		var cache := RegCacheFindAddress(sym, off) & (REG_HL|REG_BC|REG_DE);
-		if (cache & reg) != 0 then
-			# The value is already in the desired register.
-			return;
-		elseif cache != 0 then
-			# The value is already in a register, but not this one.
-			cache := FindFirst(cache);
-			E_mov(loreg(reg), loreg(cache));
-			E_mov(hireg(reg), hireg(cache));
-			return;
-		end if;
+		# This optimisation is essentially not worth it on the 8080.
+		#var cache := RegCacheFindAddress(sym, off) & (REG_HL|REG_BC|REG_DE);
+		#if (cache & reg) != 0 then
+		#	# The value is already in the desired register.
+		#	return;
+		#elseif cache != 0 then
+		#	# The value is already in a register, but not this one.
+		#	cache := FindFirst(cache);
+		#	E_mov(loreg(reg), loreg(cache));
+		#	E_mov(hireg(reg), hireg(cache));
+		#	return;
+		#end if;
 
 		R_flush(reg);
 		E("\tlxi ");
@@ -356,33 +357,49 @@
 		E_comma();
 		E_symref(sym, off);
 		E_nl();
-		RegCacheLeavesAddress(reg, sym, off);
+		#RegCacheLeavesAddress(reg, sym, off);
 	end sub;
 
 	sub E_lda(sym: [Symbol], off: Size)
+		var cache := RegCacheFindValue(sym, off);
+		if (cache & REG_A) != 0 then
+			# Value already in the right register.
+			return;
+		end if; # Other cases don't happen on the 8080.
+
 		R_flush(REG_A);
 		E("\tlda ");
 		E_symref(sym, off);
 		E_nl();
+		RegCacheLeavesValue(REG_A, sym, off);
 	end sub;
 
 	sub E_sta(sym: [Symbol], off: Size)
 		E("\tsta ");
 		E_symref(sym, off);
 		E_nl();
+		RegCacheLeavesValue(REG_A, sym, off);
 	end sub;
 
 	sub E_lhld(sym: [Symbol], off: Size)
+		var cache := RegCacheFindValue(sym, off);
+		if (cache & REG_HL) != 0 then
+			# Value already in the right register.
+			return;
+		end if; # Other cases don't happen on the 8080.
+
 		R_flush(REG_HL);
 		E("\tlhld ");
 		E_symref(sym, off);
 		E_nl();
+		RegCacheLeavesValue(REG_HL, sym, off);
 	end sub;
 
 	sub E_shld(sym: [Symbol], off: Size)
 		E("\tshld ");
 		E_symref(sym, off);
 		E_nl();
+		RegCacheLeavesValue(REG_HL, sym, off);
 	end sub;
 
 	sub E_loadm(reg: RegId)
@@ -393,18 +410,22 @@
 	end sub;
 
 	sub E_storem(reg: RegId)
+		RegCacheFlushValues();
 		E("\tmov m,");
 		E_reg(reg);
 		E_nl();
 	end sub;
 
 	sub E_stax(ptr: RegId)
+		RegCacheFlushValues();
 		E("\tstax ");
 		E_reg(ptr);
 		E_nl();
+		RegCacheFlushValues();
 	end sub;
 
 	sub E_ldax(ptr: RegId)
+		RegCacheFlushValues();
 		R_flush(REG_A);
 		E("\tldax ");
 		E_reg(ptr);

--- a/src/cowcom/build.lua
+++ b/src/cowcom/build.lua
@@ -30,6 +30,7 @@ for _, toolchain in ipairs(ALL_TOOLCHAINS) do
 				"src/cowcom/expressions.coh",
 				"src/cowcom/lexer.coh",
 				"src/cowcom/midcodec.coh",
+				"src/cowcom/regcache.coh",
 				"src/cowcom/symbols.coh",
 				"src/cowcom/types.coh",
 				"$OBJ/src/cowcom/parser.coh",

--- a/src/cowcom/codegen.coh
+++ b/src/cowcom/codegen.coh
@@ -1,14 +1,6 @@
 const RULE_HAS_PREDICATES := 0x01;
 const MAX_MOVE_COUNT := REGISTER_COUNT;
 
-record Register
-	name: string;
-	id: RegId;
-	uses: RegId;
-	compatible: RegId;
-	is_stacked: uint8;
-end record;
-
 record Rule
 	flags: uint8;
 	compatible_producable_regs: RegId;
@@ -51,6 +43,28 @@ sub AllocSubrId(): (id: uint16)
 	next_subr_id := next_subr_id + 1;
 end sub;
 
+sub FindConflictingRegisters(inreg: RegId): (conflicting: RegId)
+	conflicting := 0;
+	var reg := &registers[0];
+	while reg != &registers[REGISTER_COUNT] loop
+		if (reg.id & inreg) != 0 then
+			conflicting := conflicting | reg.uses;
+		end if;
+		reg := @next reg;
+	end loop;
+end sub;
+
+sub FindFirst(inreg: RegId): (outreg: RegId)
+	outreg := 1;
+	while outreg != 0 loop
+		if (inreg & outreg) != 0 then
+			return;
+		end if;
+		outreg := outreg << 1;
+	end loop;
+	SimpleError("failed to allocate register");
+end sub;
+
 include "inssel.coh";
 
 sub PushNode(node: [Node])
@@ -88,33 +102,11 @@ sub IsStackedRegister(regid: RegId): (result: uint8)
 	end loop;
 end sub;
 
-sub FindFirst(inreg: RegId): (outreg: RegId)
-	outreg := 1;
-	while outreg != 0 loop
-		if (inreg & outreg) != 0 then
-			return;
-		end if;
-		outreg := outreg << 1;
-	end loop;
-	SimpleError("failed to allocate register");
-end sub;
-
 sub CalculateBlockedRegisters(insn: [Instruction], last: [Instruction]): (blocked: RegId)
 	blocked := 0;
 	while insn <= last loop
 		blocked := blocked | insn.input_regs | insn.output_regs;
 		insn := @next insn;
-	end loop;
-end sub;
-
-sub FindConflictingRegisters(inreg: RegId): (conflicting: RegId)
-	conflicting := 0;
-	var reg := &registers[0];
-	while reg != &registers[REGISTER_COUNT] loop
-		if (reg.id & inreg) != 0 then
-			conflicting := conflicting | reg.uses;
-		end if;
-		reg := @next reg;
 	end loop;
 end sub;
 
@@ -520,6 +512,7 @@ sub Generate(rootnode: [Node])
 		ShuffleRegisters(&next_instruction.reloads[0]);
 		EmitOneInstruction(next_instruction.ruleid, next_instruction);
 		ShuffleRegisters(&next_instruction.spills[0]);
+		ArchEndInstruction();
 	end loop;
 
 	Discard(rootnode);

--- a/src/cowcom/emitter.coh
+++ b/src/cowcom/emitter.coh
@@ -85,6 +85,10 @@ sub E_h16(value: uint16)
 	E_h(value as uint32, 4);
 end sub;
 
+sub E_h32(value: uint32)
+	E_h(value as uint32, 8);
+end sub;
+
 sub EmitterPushChunk()
 	var chunk := Alloc(@bytesof EmitterChunk) as [EmitterChunk];
 	chunk.current_record := Alloc(@bytesof EmitterRecord) as [EmitterRecord];

--- a/src/cowcom/main.cow
+++ b/src/cowcom/main.cow
@@ -17,6 +17,7 @@ include "parser.tokens.coh";
 include "src/cowcom/lexer.coh";
 include "src/cowcom/midcodec.coh";
 include "src/cowcom/emitter.coh";
+include "src/cowcom/regcache.coh";
 include "src/cowcom/codegen.coh";
 include "src/cowcom/symbols.coh";
 include "src/cowcom/expressions.coh";

--- a/src/cowcom/regcache.coh
+++ b/src/cowcom/regcache.coh
@@ -3,6 +3,7 @@ const CACHE_SIZE := REGISTER_COUNT;
 const CACHE_SLOT_EMPTY    := 0;
 const CACHE_SLOT_CONSTANT := 1;
 const CACHE_SLOT_ADDRESS  := 2;
+const CACHE_SLOT_VALUE    := 3;
 
 record CacheSlot
 	symbol: [Symbol];
@@ -21,6 +22,16 @@ sub RegCacheFlush(reg: RegId)
 	var p := &register_cache[0];
 	while p != &register_cache[@sizeof register_cache] loop
 		if (p.state != CACHE_SLOT_EMPTY) and ((reg & p.reg) != 0) then
+			p.state := CACHE_SLOT_EMPTY;
+		end if;
+		p := @next p;
+	end loop;
+end sub;
+
+sub RegCacheFlushValues()
+	var p := &register_cache[0];
+	while p != &register_cache[@sizeof register_cache] loop
+		if (p.state == CACHE_SLOT_VALUE) then
 			p.state := CACHE_SLOT_EMPTY;
 		end if;
 		p := @next p;
@@ -76,6 +87,31 @@ sub RegCacheLeavesAddress(reg: RegId, sym: [Symbol], off: Size)
 	# The cache is full, so just drop this value on the floor.
 end sub;
 
+sub RegCacheLeavesValue(reg: RegId, sym: [Symbol], off: Size)
+	var p := &register_cache[0];
+	while p != &register_cache[@sizeof register_cache] loop
+		if (p.state == CACHE_SLOT_VALUE) and (p.symbol == sym) and (p.number == (off as Arith)) then
+			p.reg := p.reg | reg;
+			return;
+		end if;
+		p := @next p;
+	end loop;
+
+	p := &register_cache[0];
+	while p != &register_cache[@sizeof register_cache] loop
+		if (p.state == CACHE_SLOT_EMPTY) then
+			p.state := CACHE_SLOT_VALUE;
+			p.symbol := sym;
+			p.number := off as Arith;
+			p.reg := reg;
+			return;
+		end if;
+		p := @next p;
+	end loop;
+
+	# The cache is full, so just drop this value on the floor.
+end sub;
+
 sub RegCacheFindConstant(value: Arith): (reg: RegId)
 	reg := 0;
 	var p := &register_cache[0];
@@ -93,6 +129,18 @@ sub RegCacheFindAddress(sym: [Symbol], off: Size): (reg: RegId)
 	var p := &register_cache[0];
 	while p != &register_cache[@sizeof register_cache] loop
 		if (p.state == CACHE_SLOT_ADDRESS) and (p.symbol == sym) and (p.number == (off as Arith)) then
+			reg := p.reg;
+			return;
+		end if;
+		p := @next p;
+	end loop;
+end sub;
+
+sub RegCacheFindValue(sym: [Symbol], off: Size): (reg: RegId)
+	reg := 0;
+	var p := &register_cache[0];
+	while p != &register_cache[@sizeof register_cache] loop
+		if (p.state == CACHE_SLOT_VALUE) and (p.symbol == sym) and (p.number == (off as Arith)) then
 			reg := p.reg;
 			return;
 		end if;

--- a/src/cowcom/regcache.coh
+++ b/src/cowcom/regcache.coh
@@ -2,8 +2,10 @@ const CACHE_SIZE := REGISTER_COUNT;
 
 const CACHE_SLOT_EMPTY    := 0;
 const CACHE_SLOT_CONSTANT := 1;
+const CACHE_SLOT_ADDRESS  := 2;
 
 record CacheSlot
+	symbol: [Symbol];
 	number: Arith;
 	reg: RegId;
 	state: uint8;
@@ -49,11 +51,48 @@ sub RegCacheLeavesConstant(reg: RegId, value: Arith)
 	# The cache is full, so just drop this value on the floor.
 end sub;
 
+sub RegCacheLeavesAddress(reg: RegId, sym: [Symbol], off: Size)
+	var p := &register_cache[0];
+	while p != &register_cache[@sizeof register_cache] loop
+		if (p.state == CACHE_SLOT_ADDRESS) and (p.symbol == sym) and (p.number == (off as Arith)) then
+			p.reg := p.reg | reg;
+			return;
+		end if;
+		p := @next p;
+	end loop;
+
+	p := &register_cache[0];
+	while p != &register_cache[@sizeof register_cache] loop
+		if (p.state == CACHE_SLOT_EMPTY) then
+			p.state := CACHE_SLOT_ADDRESS;
+			p.symbol := sym;
+			p.number := off as Arith;
+			p.reg := reg;
+			return;
+		end if;
+		p := @next p;
+	end loop;
+
+	# The cache is full, so just drop this value on the floor.
+end sub;
+
 sub RegCacheFindConstant(value: Arith): (reg: RegId)
 	reg := 0;
 	var p := &register_cache[0];
 	while p != &register_cache[@sizeof register_cache] loop
 		if (p.state == CACHE_SLOT_CONSTANT) and (p.number == value) then
+			reg := p.reg;
+			return;
+		end if;
+		p := @next p;
+	end loop;
+end sub;
+
+sub RegCacheFindAddress(sym: [Symbol], off: Size): (reg: RegId)
+	reg := 0;
+	var p := &register_cache[0];
+	while p != &register_cache[@sizeof register_cache] loop
+		if (p.state == CACHE_SLOT_ADDRESS) and (p.symbol == sym) and (p.number == (off as Arith)) then
 			reg := p.reg;
 			return;
 		end if;

--- a/src/cowcom/regcache.coh
+++ b/src/cowcom/regcache.coh
@@ -38,6 +38,17 @@ sub RegCacheFlushValues()
 	end loop;
 end sub;
 
+sub reg_i_find_empty_slot(): (slot: [CacheSlot])
+	slot := &register_cache[0];
+	while slot != &register_cache[@sizeof register_cache] loop
+		if (slot.state == CACHE_SLOT_EMPTY) then
+			return;
+		end if;
+		slot := @next slot;
+	end loop;
+	slot := 0 as [CacheSlot];
+end sub;
+
 sub RegCacheLeavesConstant(reg: RegId, value: Arith)
 	var p := &register_cache[0];
 	while p != &register_cache[@sizeof register_cache] loop
@@ -48,18 +59,12 @@ sub RegCacheLeavesConstant(reg: RegId, value: Arith)
 		p := @next p;
 	end loop;
 
-	p := &register_cache[0];
-	while p != &register_cache[@sizeof register_cache] loop
-		if (p.state == CACHE_SLOT_EMPTY) then
-			p.state := CACHE_SLOT_CONSTANT;
-			p.number := value;
-			p.reg := reg;
-			return;
-		end if;
-		p := @next p;
-	end loop;
-
-	# The cache is full, so just drop this value on the floor.
+	p := reg_i_find_empty_slot();
+	if p != (0 as [CacheSlot]) then
+		p.state := CACHE_SLOT_CONSTANT;
+		p.number := value;
+		p.reg := reg;
+	end if;
 end sub;
 
 sub RegCacheLeavesAddress(reg: RegId, sym: [Symbol], off: Size)
@@ -72,19 +77,13 @@ sub RegCacheLeavesAddress(reg: RegId, sym: [Symbol], off: Size)
 		p := @next p;
 	end loop;
 
-	p := &register_cache[0];
-	while p != &register_cache[@sizeof register_cache] loop
-		if (p.state == CACHE_SLOT_EMPTY) then
-			p.state := CACHE_SLOT_ADDRESS;
-			p.symbol := sym;
-			p.number := off as Arith;
-			p.reg := reg;
-			return;
-		end if;
-		p := @next p;
-	end loop;
-
-	# The cache is full, so just drop this value on the floor.
+	p := reg_i_find_empty_slot();
+	if p != (0 as [CacheSlot]) then
+		p.state := CACHE_SLOT_ADDRESS;
+		p.symbol := sym;
+		p.number := off as Arith;
+		p.reg := reg;
+	end if;
 end sub;
 
 sub RegCacheLeavesValue(reg: RegId, sym: [Symbol], off: Size)
@@ -97,19 +96,13 @@ sub RegCacheLeavesValue(reg: RegId, sym: [Symbol], off: Size)
 		p := @next p;
 	end loop;
 
-	p := &register_cache[0];
-	while p != &register_cache[@sizeof register_cache] loop
-		if (p.state == CACHE_SLOT_EMPTY) then
+	p := reg_i_find_empty_slot();
+	if p != (0 as [CacheSlot]) then
 			p.state := CACHE_SLOT_VALUE;
 			p.symbol := sym;
 			p.number := off as Arith;
 			p.reg := reg;
-			return;
-		end if;
-		p := @next p;
-	end loop;
-
-	# The cache is full, so just drop this value on the floor.
+	end if;
 end sub;
 
 sub RegCacheFindConstant(value: Arith): (reg: RegId)

--- a/src/cowcom/regcache.coh
+++ b/src/cowcom/regcache.coh
@@ -1,0 +1,63 @@
+const CACHE_SIZE := REGISTER_COUNT;
+
+const CACHE_SLOT_EMPTY    := 0;
+const CACHE_SLOT_CONSTANT := 1;
+
+record CacheSlot
+	number: Arith;
+	reg: RegId;
+	state: uint8;
+end record;
+
+var register_cache: CacheSlot[CACHE_SIZE];
+
+sub RegCacheReset()
+	MemZero(&register_cache[0] as [uint8], @bytesof register_cache);
+end sub;
+
+sub RegCacheFlush(reg: RegId)
+	var p := &register_cache[0];
+	while p != &register_cache[@sizeof register_cache] loop
+		if (p.state != CACHE_SLOT_EMPTY) and ((reg & p.reg) != 0) then
+			p.state := CACHE_SLOT_EMPTY;
+		end if;
+		p := @next p;
+	end loop;
+end sub;
+
+sub RegCacheLeavesConstant(reg: RegId, value: Arith)
+	var p := &register_cache[0];
+	while p != &register_cache[@sizeof register_cache] loop
+		if (p.state == CACHE_SLOT_CONSTANT) and (p.number == value) then
+			p.reg := p.reg | reg;
+			return;
+		end if;
+		p := @next p;
+	end loop;
+
+	p := &register_cache[0];
+	while p != &register_cache[@sizeof register_cache] loop
+		if (p.state == CACHE_SLOT_EMPTY) then
+			p.state := CACHE_SLOT_CONSTANT;
+			p.number := value;
+			p.reg := reg;
+			return;
+		end if;
+		p := @next p;
+	end loop;
+
+	# The cache is full, so just drop this value on the floor.
+end sub;
+
+sub RegCacheFindConstant(value: Arith): (reg: RegId)
+	reg := 0;
+	var p := &register_cache[0];
+	while p != &register_cache[@sizeof register_cache] loop
+		if (p.state == CACHE_SLOT_CONSTANT) and (p.number == value) then
+			reg := p.reg;
+			return;
+		end if;
+		p := @next p;
+	end loop;
+end sub;
+

--- a/src/cowcom/regcache.coh
+++ b/src/cowcom/regcache.coh
@@ -5,9 +5,11 @@ const CACHE_SLOT_CONSTANT := 1;
 const CACHE_SLOT_ADDRESS  := 2;
 const CACHE_SLOT_VALUE    := 3;
 
+typedef CacheValue := int(0, (1<<MACHINE_WIDTH)-1);
+
 record CacheSlot
 	symbol: [Symbol];
-	number: Arith;
+	number: CacheValue;
 	reg: RegId;
 	state: uint8;
 end record;
@@ -49,7 +51,7 @@ sub reg_i_find_empty_slot(): (slot: [CacheSlot])
 	slot := 0 as [CacheSlot];
 end sub;
 
-sub RegCacheLeavesConstant(reg: RegId, value: Arith)
+sub RegCacheLeavesConstant(reg: RegId, value: CacheValue)
 	var p := &register_cache[0];
 	while p != &register_cache[@sizeof register_cache] loop
 		if (p.state == CACHE_SLOT_CONSTANT) and (p.number == value) then
@@ -70,7 +72,7 @@ end sub;
 sub RegCacheLeavesAddress(reg: RegId, sym: [Symbol], off: Size)
 	var p := &register_cache[0];
 	while p != &register_cache[@sizeof register_cache] loop
-		if (p.state == CACHE_SLOT_ADDRESS) and (p.symbol == sym) and (p.number == (off as Arith)) then
+		if (p.state == CACHE_SLOT_ADDRESS) and (p.symbol == sym) and (p.number == (off as CacheValue)) then
 			p.reg := p.reg | reg;
 			return;
 		end if;
@@ -81,7 +83,7 @@ sub RegCacheLeavesAddress(reg: RegId, sym: [Symbol], off: Size)
 	if p != (0 as [CacheSlot]) then
 		p.state := CACHE_SLOT_ADDRESS;
 		p.symbol := sym;
-		p.number := off as Arith;
+		p.number := off as CacheValue;
 		p.reg := reg;
 	end if;
 end sub;
@@ -89,7 +91,7 @@ end sub;
 sub RegCacheLeavesValue(reg: RegId, sym: [Symbol], off: Size)
 	var p := &register_cache[0];
 	while p != &register_cache[@sizeof register_cache] loop
-		if (p.state == CACHE_SLOT_VALUE) and (p.symbol == sym) and (p.number == (off as Arith)) then
+		if (p.state == CACHE_SLOT_VALUE) and (p.symbol == sym) and (p.number == (off as CacheValue)) then
 			p.reg := p.reg | reg;
 			return;
 		end if;
@@ -100,12 +102,12 @@ sub RegCacheLeavesValue(reg: RegId, sym: [Symbol], off: Size)
 	if p != (0 as [CacheSlot]) then
 			p.state := CACHE_SLOT_VALUE;
 			p.symbol := sym;
-			p.number := off as Arith;
+			p.number := off as CacheValue;
 			p.reg := reg;
 	end if;
 end sub;
 
-sub RegCacheFindConstant(value: Arith): (reg: RegId)
+sub RegCacheFindConstant(value: CacheValue): (reg: RegId)
 	reg := 0;
 	var p := &register_cache[0];
 	while p != &register_cache[@sizeof register_cache] loop
@@ -121,7 +123,7 @@ sub RegCacheFindAddress(sym: [Symbol], off: Size): (reg: RegId)
 	reg := 0;
 	var p := &register_cache[0];
 	while p != &register_cache[@sizeof register_cache] loop
-		if (p.state == CACHE_SLOT_ADDRESS) and (p.symbol == sym) and (p.number == (off as Arith)) then
+		if (p.state == CACHE_SLOT_ADDRESS) and (p.symbol == sym) and (p.number == (off as CacheValue)) then
 			reg := p.reg;
 			return;
 		end if;
@@ -133,7 +135,7 @@ sub RegCacheFindValue(sym: [Symbol], off: Size): (reg: RegId)
 	reg := 0;
 	var p := &register_cache[0];
 	while p != &register_cache[@sizeof register_cache] loop
-		if (p.state == CACHE_SLOT_VALUE) and (p.symbol == sym) and (p.number == (off as Arith)) then
+		if (p.state == CACHE_SLOT_VALUE) and (p.symbol == sym) and (p.number == (off as CacheValue)) then
 			reg := p.reg;
 			return;
 		end if;

--- a/src/oldcom/arch80386.ng
+++ b/src/oldcom/arch80386.ng
@@ -369,7 +369,6 @@ gen param := PUSHPARAM4(param, CONSTANT():c)
 			emitter_close_chunk(current_sub);
 		}
 
-		arch_emit_comment("subroutine with %d input parameters", sub->inputparameters);
 		E("\tcall %s\n", subref(sub));
 	}
 

--- a/src/oldcom/compiler.c
+++ b/src/oldcom/compiler.c
@@ -268,14 +268,14 @@ void init_var(struct symbol* sym, struct symbol* type)
 	check_non_partial_type(type);
 	sym->u.var.type = type;
 	sym->u.var.sub = current_sub;
-	arch_emit_comment("workspace[0] is 0x%x", current_sub->workspace[0]);
+	//arch_emit_comment("workspace[0] is 0x%x", current_sub->workspace[0]);
 	arch_init_variable(sym);
-	arch_emit_comment("declare variable %s at %s 0x%x+0x%x aligned 0x%x",
-		sym->name,
-		sym->u.var.sub->name,
-		sym->u.var.offset,
-		sym->u.var.type->u.type.width,
-		sym->u.var.type->u.type.alignment);
+	//arch_emit_comment("declare variable %s at %s 0x%x+0x%x aligned 0x%x",
+	//	sym->name,
+	//	sym->u.var.sub->name,
+	//	sym->u.var.offset,
+	//	sym->u.var.type->u.type.width,
+	//	sym->u.var.type->u.type.alignment);
 }
 
 void symbol_redeclaration(Symbol* sym)

--- a/src/oldcom/parser.y
+++ b/src/oldcom/parser.y
@@ -810,6 +810,8 @@ cvalue(value) ::= cvalue(lhs) PERCENT cvalue(rhs).   { value = lhs % rhs; }
 cvalue(value) ::= cvalue(lhs) AMPERSAND cvalue(rhs). { value = lhs & rhs; }
 cvalue(value) ::= cvalue(lhs) CARET cvalue(rhs).     { value = lhs ^ rhs; }
 cvalue(value) ::= cvalue(lhs) PIPE cvalue(rhs).      { value = lhs | rhs; }
+cvalue(value) ::= cvalue(lhs) LSHIFT cvalue(rhs).    { value = lhs << rhs; }
+cvalue(value) ::= cvalue(lhs) RSHIFT cvalue(rhs).    { value = lhs >> rhs; }
 
 cvalue(value) ::= oldid(sym).
 {

--- a/tools/newgen/globals.h
+++ b/tools/newgen/globals.h
@@ -123,6 +123,8 @@ extern void warning(const char* msg, ...);
 extern void yyerror(const char* msg, ...);
 extern int yydebug;
 
+extern int machine_width;
+
 extern void* open_file(FILE* fp);
 extern void include_file(void* buffer);
 

--- a/tools/newgen/lexer.l
+++ b/tools/newgen/lexer.l
@@ -40,14 +40,15 @@ ID [A-Za-z][A-Za-z0-9_$]*
 "~"                       { return TILDE; }
 "$$"                      { return STRINGSTRING; }
 "compatible"              { return COMPATIBLE; }
-"register"                { return REGISTER; }
+"gen"                     { return GEN; }
+"is"                      { return IS; }
 "regclass"                { return REGCLASS; }
 "regdata"                 { return REGDATA; }
-"uses"                    { return USES; }
-"stacked"                 { return STACKED; }
-"gen"                     { return GEN; }
+"register"                { return REGISTER; }
 "rewrite"                 { return REWRITE; }
-"is"                      { return IS; }
+"stacked"                 { return STACKED; }
+"uses"                    { return USES; }
+"width"                   { return WIDTH; }
 
 \"                        { BEGIN(STRINGSTATE); return BEGINSTRING; }
 <STRINGSTATE>([^\"\\$]|\\.)* { string = strdup(yytext); return CSTRING; }

--- a/tools/newgen/main.c
+++ b/tools/newgen/main.c
@@ -24,6 +24,8 @@ static const char* infilename;
 FILE* outfp;
 FILE* outhfp;
 
+int machine_width = 0;
+
 #if defined COWGOL
 	#define DEREF "."
 #else
@@ -842,6 +844,9 @@ int main(int argc, const char* argv[])
 	sort_rules();
 
 	#if defined COWGOL
+		if (machine_width != 0)
+			fprintf(outhfp, "const MACHINE_WIDTH := %d;\n", machine_width);
+
 		fprintf(outhfp, "const INSTRUCTION_TEMPLATE_DEPTH := %d;\n", maxdepth);
 		fprintf(outhfp, "const INSTRUCTION_TEMPLATE_COUNT := %d;\n", rulescount);
 		fprintf(outhfp, "const REGISTER_COUNT := %d;\n", registercount);

--- a/tools/newgen/main.c
+++ b/tools/newgen/main.c
@@ -333,9 +333,7 @@ static void print_upper(FILE* fp, const char* s)
 static void dump_registers(void)
 {
 	#if defined COWGOL
-		fprintf(outfp, "var registers: Register[] := {\n");
 	#else
-		fprintf(outfp, "const Register registers[] = {\n");
 		fprintf(outhfp, "enum {\n");
 	#endif
 
@@ -344,9 +342,6 @@ static void dump_registers(void)
 	{
 		if (reg->sym.kind == SYM_REGISTER)
 		{
-			fprintf(outfp, "\t{ \"%s\", 0x%x, 0x%x, 0x%x, %d },\n",
-				reg->sym.name, reg->id, reg->uses, reg->compatible, reg->isstacked);
-
 			#if defined COWGOL
 				fprintf(outhfp, "const REG_");
 				print_upper(outhfp, reg->sym.name);
@@ -360,10 +355,35 @@ static void dump_registers(void)
 		reg = (Register*) reg->sym.next;
 	}
 	#if defined COWGOL
-		fprintf(outfp, "};\n");
+	#else
+		fprintf(outhfp, "};\n");
+	#endif
+
+	#if defined COWGOL
+		fprintf(outhfp, "var registers: Register[] := {\n");
+	#else
+		fprintf(outfp, "const Register registers[] = {\n");
+	#endif
+
+	reg = (Register*) symbol_table;
+	while(reg)
+	{
+		if (reg->sym.kind == SYM_REGISTER)
+		{
+			#if defined COWGOL
+				fprintf(outhfp, "\t{ \"%s\", 0x%x, 0x%x, 0x%x, %d },\n",
+					reg->sym.name, reg->id, reg->uses, reg->compatible, reg->isstacked);
+			#else
+				fprintf(outfp, "\t{ \"%s\", 0x%x, 0x%x, 0x%x, %d },\n",
+					reg->sym.name, reg->id, reg->uses, reg->compatible, reg->isstacked);
+			#endif
+		}
+		reg = (Register*) reg->sym.next;
+	}
+	#if defined COWGOL
+		fprintf(outhfp, "};\n");
 	#else
 		fprintf(outfp, "};\n");
-		fprintf(outhfp, "};\n");
 	#endif
 }
 
@@ -825,7 +845,16 @@ int main(int argc, const char* argv[])
 		fprintf(outhfp, "const INSTRUCTION_TEMPLATE_DEPTH := %d;\n", maxdepth);
 		fprintf(outhfp, "const INSTRUCTION_TEMPLATE_COUNT := %d;\n", rulescount);
 		fprintf(outhfp, "const REGISTER_COUNT := %d;\n", registercount);
-		fprintf(outhfp, "typedef RegId := int(0, 0x%x);\n", (1<<registercount) - 1);
+		fprintf(outhfp, "const ALL_REGS := 0x%x;\n", (1<<registercount) - 1);
+		fprintf(outhfp, "typedef RegId := int(0, ALL_REGS);\n");
+		fprintf(outhfp, "record Register\n");
+		fprintf(outhfp, "	name: string;\n");
+		fprintf(outhfp, "	id: RegId;\n");
+		fprintf(outhfp, "	uses: RegId;\n");
+		fprintf(outhfp, "	compatible: RegId;\n");
+		fprintf(outhfp, "	is_stacked: uint8;\n");
+		fprintf(outhfp, "end record;\n");
+
 	#else
 		fprintf(outhfp, "#ifndef NEWGEN_H\n");
 		fprintf(outhfp, "#define NEWGEN_H\n");

--- a/tools/newgen/parser.y
+++ b/tools/newgen/parser.y
@@ -74,6 +74,13 @@ regdata(R) ::= regdata(R1) STACKED.
     R->isstacked = true;
 }
 
+/* --- Width ------------------------------------------------------------- */
+
+rules ::= rules WIDTH int(R) SEMICOLON.
+{
+    machine_width = R;
+}
+
 /* --- Rewrite rules ----------------------------------------------------- */
 
 rules ::= rules REWRITE(R) rewritetree(TS) ASSIGN rewritetree(TD) SEMICOLON.


### PR DESCRIPTION
This adds a really simplistic register cache mechanism to avoid reloading values if they're already available in a register. It works, but not as well as I hoped: after adding the cache the binary size is actually bigger, at 51185 bytes (up from 50927 bytes).