### PR TITLE
Add a Z80 backend

### DIFF
--- a/mkninja.lua
+++ b/mkninja.lua
@@ -100,5 +100,6 @@ include "src/cowlink/build.lua"
 include "src/cowcom/build.lua"
 include "src/cowwrap/build.lua"
 include "rt/cpm/build.lua"
+include "rt/cpmz/build.lua"
 include "tests/build.lua"
 

--- a/rt/cpm/cowgol.cos
+++ b/rt/cpm/cowgol.cos
@@ -129,7 +129,7 @@
     jmp 0
 
 # Divides two eight-bit unsigned numbers: B / D.
-# The quotient is returned in A, the remainder in B.
+# The quotient is returned in B, the remainder in A.
 &X _dvrmu1
     cseg ; _dvrmu1
 ``:

--- a/rt/cpmz/argv.coh
+++ b/rt/cpmz/argv.coh
@@ -1,0 +1,48 @@
+var argv_pointer: [uint8];
+
+sub ArgvInit()
+	argv_pointer := 0x81 as [uint8];
+	[argv_pointer + [0x80 as [uint8]] as intptr] := 0;
+end sub;
+
+# Returns null is there's no next argument.
+sub ArgvNext(): (arg: [uint8])
+	# No more arguments?
+
+	if argv_pointer == (0 as [uint8]) then
+		arg := argv_pointer;
+		return;
+	end if;
+
+	# Skip leading whitespace.
+
+	var c: uint8;
+	loop
+		c := [argv_pointer];
+		if c != ' ' then
+			break;
+		end if;
+		argv_pointer := argv_pointer + 1;
+	end loop;
+
+	arg := argv_pointer;
+
+	# Skip to end of word and terminate.
+
+	loop
+		c := [argv_pointer];
+		if (c == ' ') or (c == '\n') or (c == 0) then
+			break;
+		end if;
+		argv_pointer := argv_pointer + 1;
+	end loop;
+	[argv_pointer] := 0;
+
+	if c == ' ' then
+		argv_pointer := argv_pointer + 1;
+	else
+		argv_pointer := 0 as [uint8];
+	end if;
+end sub;
+
+

--- a/rt/cpmz/build.lua
+++ b/rt/cpmz/build.lua
@@ -1,0 +1,5 @@
+cowwrap {
+	ins = { "rt/cpmz/cowgol.cos" },
+	outs = { "$OBJ/rt/cpmz/cowgol.coo" }
+}
+

--- a/rt/cpmz/cowgol.coh
+++ b/rt/cpmz/cowgol.coh
@@ -1,0 +1,41 @@
+var LOMEM: [uint8];
+@asm "ld hl, LOMEM";
+@asm "ld (", LOMEM, "), hl";
+
+var HIMEM: [uint8];
+@asm "ld hl, (6)";
+@asm "ld (", HIMEM, "), hl";
+
+sub Exit()
+	@asm "jp _exit";
+end sub;
+
+sub ExitWithError()
+	@asm "jp _exit";
+end sub;
+
+sub AlignUp(in: intptr): (out: intptr)
+	out := in;
+end sub;
+
+sub print_char(c: uint8)
+	@asm "ld a, ", c;
+	@asm "ld e, a";
+	@asm "ld c, 2";
+	@asm "call 5";
+end sub;
+
+sub MemSet(buf: [uint8], byte: uint8, len: uint16)
+	var bufend := buf + len;
+	loop
+		if buf == bufend then
+			return;
+		end if;
+		[buf] := byte;
+		buf := buf + 1;
+	end loop;
+end sub;
+
+include "common.coh";
+
+

--- a/rt/cpmz/cowgol.coh
+++ b/rt/cpmz/cowgol.coh
@@ -19,7 +19,7 @@ sub AlignUp(in: intptr): (out: intptr)
 end sub;
 
 sub print_char(c: uint8)
-	@asm "ld a, ", c;
+	@asm "ld a, (", c, ")";
 	@asm "ld e, a";
 	@asm "ld c, 2";
 	@asm "call 5";

--- a/rt/cpmz/cowgol.cos
+++ b/rt/cpmz/cowgol.cos
@@ -483,6 +483,7 @@
     cpl
     ld h, a
     exx
+
     ld a, l
     cpl
     ld l, a
@@ -507,7 +508,7 @@
 # Returns z if HLHL == DEDE.
 # Returns c if HLHL < DEDE.
 &X _cmpu4
-    cseg ; _cmpeq4
+    cseg ; _cmpu4
 ``:
     and a               ; clear carry
     sbc hl, de

--- a/rt/cpmz/cowgol.cos
+++ b/rt/cpmz/cowgol.cos
@@ -26,6 +26,15 @@
     rr l
     jr ``
 
+# Logic shift HL right A bits.
+&X _asl2
+    cseg ; _asl2
+``:
+    dec a
+    ret m
+	add hl, hl
+    jr ``
+
 # Arithmetic shift HL right A bits.
 &X _asr2
     cseg ; _asr2
@@ -49,6 +58,19 @@
     rr h
     rr l
     jr ``
+
+# Shifts HLHL left by B bits.
+&X _asl4
+	cseg ; _asl4
+``:
+	add hl, hl
+	exx
+	ex de, hl
+	adc hl, hl
+	ex de, hl
+	exx
+	djnz ``
+	ret
 
 # Arithmetic shift HLHL right A bits.
 &X _asr4
@@ -85,6 +107,25 @@
     ld a, h
     ret
 
+# 16-bit multiplication: HL = BC * DE.
+&X _mul2
+	cseg ; _mul2
+``:
+	; no need to reset HL as the existing contents will be shifted out
+	ld a, 16			; number of iterations
+``_loop:
+	sra b				; right shift lhs
+	rr c
+	jr nc, ``_noadd
+	add hl, de			; result += rhs
+``_noadd:
+	ex de, hl			; left shift rhs
+	add hl, hl
+	ex de, hl
+	dec a
+	jr nz, ``_loop
+	ret
+
 # 32-bit multiplication: HLHL = BCBC * DEDE.
 &X _mul4
     cseg ; _mul4
@@ -113,17 +154,349 @@
     dec a
     jr nz, ``_loop
     ret
-#
-# Compares HLHL and DEDE, setting Z or NZ. Uses A.
-&X _cmpeq4
+
+# Divides two eight-bit unsigned numbers: A = H / D.
+# The quotient is returned in H, the remainder in A.
+&X _dvrmu1
+    cseg ; _dvrmu1
+``:
+	ld b, 8				; bit count
+	xor a				; remainder
+``_1:
+	sla h				; left shift H
+
+	add hl, hl			; left shift H
+    mvi c, 8            ; bit count
+    xra a               ; remainder
+``_1:
+	sla h
+	rla					; shift top bit of H into remainder
+	cp d
+	jr c, ``_noadd
+	inc h
+	sub d
+``_noadd:
+	djnz ``_1
+	ret
+
+# Divides two eight-bit signed numbers: A = H / D.
+# The quotient is returned in H, the remainder in D.
+&X _dvrms1
+    cseg ; _dvrms1
+``:
+	ld a, h
+	xor d				; discover sign of result
+	push af				; save for later
+	xor d				; recover h (sign of remainder)
+	push af				; save for later
+
+	jp p, ``_h_positive
+	xor a
+	sub h				; invert h to make it positive
+	ld h, a
+
+``_h_positive:
+	ld a, d
+	or d				; get sign of d
+	jp p, ``_d_positive
+	xor a
+	sub d				; invert d to make it positive
+	ld d, a
+
+``_d_positive:
+	call `_dvrmu1		; actually do the division
+	ld d, a				; put remainder in a
+
+	pop af				; get sign of remainder
+	jp p, ``_remainder_positive
+	xor a
+	sub d				; invert remainder
+	ld d, a
+
+``_remainder_positive:
+	pop af				; get sign of result
+	ret p				; finish now if we're good
+	xor a
+	sub h				; invert result
+	ld h, a
+	ret
+
+# Divides two sixteen-bit unsigned numbers: DE = DE / BC.
+# The quotient is returned in DE, the remainder in HL.
+&X _dvrmu2
+	cseg ; _dvrmu2
+``:
+	ld a, 16			; bit count
+	ld hl, 0			; reset remainder
+	jr ``_entry
+``_loop:
+	add hl, bc
+	dec a
+	ret z
+``_entry:
+	sla e
+	rl d
+	adc hl, hl
+	sbc hl, bc
+	jr nc, ``_loop
+	inc e				; can never overflow, only increment low byte
+	jr ``_loop
+
+# Divides two 16-bit signed numbers: DE = DE / BC.
+# The quotient is returned in DE, the remainder in BC.
+&X _dvrms2
+	cseg ; _dvrms2
+``:
+	ld a, d
+	xor b				; discover sign of result
+	push af				; save for later
+	xor b				; recover d (and sign of remainder)
+	push af				; save for later
+
+	jp p, ``_de_positive
+	ld hl, 0
+	and a
+	sbc hl, de			; negate de
+	ex de, hl
+``_de_positive:
+
+	bit 7, b			; get sign of bc
+	jr z, ``_bc_positive
+	ld hl, 0
+	and a
+	sbc hl, bc			; negate bc
+	ld b, h
+	ld c, l
+``_bc_positive:
+
+	call ``_dvrmu2		; actually do the division
+	ld b, h				; put remainder in bc as we need hl
+	ld c, l
+
+	pop af				; recover sign of remainder
+	jp p, ``_remainder_positive
+	ld hl, 0
+	and a
+	sbc hl, bc			; invert remainder
+	ld b, h
+	ld c, l
+``_remainder_positive:
+
+	pop af				; recover sign of result
+	ret p				; return now if we're good
+	ld hl, 0
+	and a
+	sbc hl, de			; invert result
+	ex de, hl
+	ret
+
+# Divides two thirty-two-bit unsigned number: DEDE = DEDE / BCBC.
+# The quotient is returned in DEDE, the remainder in HLHL.
+&X _dvrmu4
+	cseg ; _dvrmu4
+``:
+	ld a, 32			; bit count
+	ld hl, 0			; reset remainder
+	exx
+	ld hl, 0
+	exx
+	jr ``_entry
+``_loop:
+	add hl, bc
+	exx
+	adc hl, bc
+	exx
+	dec a
+	ret z
+``_entry:
+	sla e
+	rl d
+	exx
+	rl e
+	rl d
+	exx
+	adc hl, hl
+	exx
+	adc hl, hl
+	exx
+	sbc hl, bc
+	exx
+	sbc hl, bc
+	exx
+	jr nc, ``_loop
+	inc de				; can never overflow, only increment low word
+	jr ``_loop
+
+# Divides two 32-bit signed numbers: DEDE = DEDE / BCBC.
+# The quotient is returned in DEDE, the remainder in BCBC.
+&X _dvrms4
+	cseg ; _dvrms4
+``:
+	exx
+	ld a, d
+	xor b				; discover sign of result
+	push af				; save for later
+	xor b				; recover d (and sign of remainder)
+	push af				; save for later
+	exx
+
+	jp p, ``_dede_positive
+	ld hl, 0
+	and a
+	sbc hl, de
+	ex de, hl
+	exx
+	ld hl, 0
+	sbc hl, de
+	ex de, hl
+	exx					; negate dede
+``_dede_positive:
+
+	exx
+	bit 7, b			; get sign of bcbc
+	exx
+	jr z, ``_bcbc_positive
+	ld hl, 0
+	and a
+	sbc hl, bc
+	ld b, h
+	ld c, l
+	exx
+	ld hl, 0
+	sbc hl, bc
+	ld b, h
+	ld c, l
+	exx					; negate bcbc
+``_bcbc_positive:
+
+	call `_dvrmu4		; actually do the division
+	ld b, h				; put remainder in bc as we need hl
+	ld c, l
+	exx
+	ld b, h
+	ld c, l
+	exx
+
+	pop af				; recover sign of remainder
+	jp p, ``_remainder_positive
+	ld hl, 0
+	and a
+	sbc hl, bc			; invert remainder
+	ld b, h
+	ld c, l
+	exx
+	ld hl, 0
+	sbc hl, bc
+	ld b, h
+	ld c, l
+	exx
+``_remainder_positive:
+
+	pop af				; recover sign of result
+	ret p				; return now if we're good
+	ld hl, 0
+	and a
+	sbc hl, de			; invert result
+	ex de, hl
+	exx
+	ld hl, 0
+	sbc hl, de
+	ex de, hl
+	exx
+	ret
+
+# ANDs two 32-bit numbers: HLHL = HLHL & DEDE. Uses A.
+&X _and4
+	cseg ; _and4
+``:
+	ld a, l
+	and e
+	ld l, a
+	ld a, h
+	and d
+	ld h, a
+	exx
+
+	ld a, l
+	and e
+	ld l, a
+	ld a, h
+	and d
+	ld h, a
+	exx
+	ret
+
+# ORs two 32-bit numbers: HLHL = HLHL & DEDE. Uses A.
+&X _or4
+	cseg ; _or4
+``:
+	ld a, l
+	or e
+	ld l, a
+	ld a, h
+	or d
+	ld h, a
+	exx
+
+	ld a, l
+	or e
+	ld l, a
+	ld a, h
+	or d
+	ld h, a
+	exx
+	ret
+
+# EORs two 32-bit numbers: HLHL = HLHL & DEDE. Uses A.
+&X _eor4
+	cseg ; _eor4
+``:
+	ld a, l
+	xor e
+	ld l, a
+	ld a, h
+	xor d
+	ld h, a
+	exx
+
+	ld a, l
+	xor e
+	ld l, a
+	ld a, h
+	xor d
+	ld h, a
+	exx
+	ret
+
+# Compares HLHL and DEDE.
+# Returns z if HLHL == DEDE.
+# Returns c if HLHL < DEDE.
+&X _cmpu4
     cseg ; _cmpeq4
 ``:
-    xor a
+    and a				; clear carry
     sbc hl, de
     ret nz
     exx
-    xor a
     sbc hl, de
     exx
     ret
+
+# Signed comparison of HLHL and DEDE. Uses A.
+# Returns m if HLHL < DEDE.
+&X _cmps4
+    cseg ; _cmps4
+``:
+	and a				; clear carry
+	sbc hl, de
+	exx
+	sbc hl, de			; leaves C set on unsigned overflow
+	ld a, h				; preserve high byte
+	exx
+	jp po, $+5
+	xor 0x80			; invert sign byte
+	ret
+
+# vim: ts=4 sw=4 et
+
 

--- a/rt/cpmz/cowgol.cos
+++ b/rt/cpmz/cowgol.cos
@@ -7,6 +7,15 @@
     srl a
     jr ``
 
+# Shift A left B bits.
+&X _asl1
+    cseg ; _asl1
+``:
+    dec b
+    ret m
+    add a
+    jr ``
+
 # Arithmetic shift A right B bits.
 &X _asr1
     cseg ; _asr1
@@ -32,7 +41,7 @@
 ``:
     dec a
     ret m
-	add hl, hl
+    add hl, hl
     jr ``
 
 # Arithmetic shift HL right A bits.
@@ -61,16 +70,16 @@
 
 # Shifts HLHL left by B bits.
 &X _asl4
-	cseg ; _asl4
+    cseg ; _asl4
 ``:
-	add hl, hl
-	exx
-	ex de, hl
-	adc hl, hl
-	ex de, hl
-	exx
-	djnz ``
-	ret
+    add hl, hl
+    exx
+    ex de, hl
+    adc hl, hl
+    ex de, hl
+    exx
+    djnz ``
+    ret
 
 # Arithmetic shift HLHL right A bits.
 &X _asr4
@@ -90,41 +99,37 @@
 &X _mul1
     cseg ; _mul1
 ``:
-    ld e, d             ; move D to low byte of DE
-    ld d, 0             ; clear top byte
-    sla h               ; first iteration
-    sbc a
-    and e
-    ld l, a
-
-    ld b, 7
+    xor a
+    ld b, 8
+``_loop:
+    add a
+    rl h
+    jr nc, ``_1
+    add d
+    jr nc, ``_1
+    inc h
 ``_1:
-    add hl, hl
-    jr nc, $ + 3
-    add hl, de
-    djnc ``_1
-
-    ld a, h
+    djnz ``_loop
     ret
 
-# 16-bit multiplication: HL = BC * DE.
+# 16-bit multiplication: DE = BC * DE. Corrupts HL.
 &X _mul2
-	cseg ; _mul2
+    cseg ; _mul2
 ``:
-	; no need to reset HL as the existing contents will be shifted out
-	ld a, 16			; number of iterations
+    ld hl, 0
+    ld a, 16            ; number of iterations
 ``_loop:
-	sra b				; right shift lhs
-	rr c
-	jr nc, ``_noadd
-	add hl, de			; result += rhs
+    add hl, hl
+    rl e
+    rl d
+    jr nc, ``_noadd
+    add hl, bc
+    jr nc, $+3
+    inc de              ; if carry increment high word
 ``_noadd:
-	ex de, hl			; left shift rhs
-	add hl, hl
-	ex de, hl
-	dec a
-	jr nz, ``_loop
-	ret
+    dec a
+    jr nz, ``_loop
+    ret
 
 # 32-bit multiplication: HLHL = BCBC * DEDE.
 &X _mul4
@@ -134,8 +139,10 @@
     sbc hl, hl          ; lower result to 0
     exx
     sbc hl, hl          ; upper result to 0
+    exx
     ld a, 32            ; number of iterations
 ``_loop:
+    exx
     sra b               ; right shift lhs
     rr c
     exx
@@ -145,12 +152,14 @@
     add hl, de          ; result += rhs
     exx
     adc hl, de
+    exx
 ``_noadd:
     sla e               ; left shift rhs
     rl d
     exx
     rl e
     rl d
+    exx
     dec a
     jr nz, ``_loop
     ret
@@ -160,313 +169,339 @@
 &X _dvrmu1
     cseg ; _dvrmu1
 ``:
-	ld b, 8				; bit count
-	xor a				; remainder
+    ld b, 8             ; bit count
+    xor a               ; remainder
 ``_1:
-	sla h				; left shift H
-
-	add hl, hl			; left shift H
-    mvi c, 8            ; bit count
-    xra a               ; remainder
-``_1:
-	sla h
-	rla					; shift top bit of H into remainder
-	cp d
-	jr c, ``_noadd
-	inc h
-	sub d
+    sla h               ; left shift H
+    rla                 ; shift top bit of H into remainder
+    cp d
+    jr c, ``_noadd
+    inc h
+    sub d
 ``_noadd:
-	djnz ``_1
-	ret
+    djnz ``_1
+    ret
 
 # Divides two eight-bit signed numbers: A = H / D.
 # The quotient is returned in H, the remainder in D.
 &X _dvrms1
     cseg ; _dvrms1
 ``:
-	ld a, h
-	xor d				; discover sign of result
-	push af				; save for later
-	xor d				; recover h (sign of remainder)
-	push af				; save for later
+    ld a, h
+    xor d               ; discover sign of result
+    push af             ; save for later
+    xor d               ; recover h (sign of remainder)
+    push af             ; save for later
 
-	jp p, ``_h_positive
-	xor a
-	sub h				; invert h to make it positive
-	ld h, a
+    jp p, ``_h_positive
+    xor a
+    sub h               ; invert h to make it positive
+    ld h, a
 
 ``_h_positive:
-	ld a, d
-	or d				; get sign of d
-	jp p, ``_d_positive
-	xor a
-	sub d				; invert d to make it positive
-	ld d, a
+    ld a, d
+    or d                ; get sign of d
+    jp p, ``_d_positive
+    xor a
+    sub d               ; invert d to make it positive
+    ld d, a
 
 ``_d_positive:
-	call `_dvrmu1		; actually do the division
-	ld d, a				; put remainder in a
+    call `_dvrmu1       ; actually do the division
+    ld d, a             ; put remainder in a
 
-	pop af				; get sign of remainder
-	jp p, ``_remainder_positive
-	xor a
-	sub d				; invert remainder
-	ld d, a
+    pop af              ; get sign of remainder
+    jp p, ``_remainder_positive
+    xor a
+    sub d               ; invert remainder
+    ld d, a
 
 ``_remainder_positive:
-	pop af				; get sign of result
-	ret p				; finish now if we're good
-	xor a
-	sub h				; invert result
-	ld h, a
-	ret
+    pop af              ; get sign of result
+    ret p               ; finish now if we're good
+    xor a
+    sub h               ; invert result
+    ld h, a
+    ret
 
-# Divides two sixteen-bit unsigned numbers: DE = DE / BC.
-# The quotient is returned in DE, the remainder in HL.
+# Divides two sixteen-bit unsigned numbers: BC = BC / DE
+# The quotient is returned in BC, the remainder in HL.
 &X _dvrmu2
-	cseg ; _dvrmu2
+    cseg ; _dvrmu2
 ``:
-	ld a, 16			; bit count
-	ld hl, 0			; reset remainder
-	jr ``_entry
-``_loop:
-	add hl, bc
-	dec a
-	ret z
+    ld a, 16            ; bit count
+    ld hl, 0            ; reset remainder
+    jr ``_entry
+``_loop1:
+    add hl, de
+``_loop2:
+    dec a
+    ret z
 ``_entry:
-	sla e
-	rl d
-	adc hl, hl
-	sbc hl, bc
-	jr nc, ``_loop
-	inc e				; can never overflow, only increment low byte
-	jr ``_loop
+    sla c               ; left shift LHS
+    rl b
+    adc hl, hl          ; top bit of LHS goes into remainder
+    or a                ; clear carry
+    sbc hl, de          ; sets carry if remainder(hl) < de
+    jr c, ``_loop1      ; if remainder < de, undo add and go round again
+    inc c               ; we know the bottom bit is clear
+    jr ``_loop2
 
-# Divides two 16-bit signed numbers: DE = DE / BC.
-# The quotient is returned in DE, the remainder in BC.
+# Divides two 16-bit signed numbers: BC = BC / DE
+# The quotient is returned in BC, the remainder in DE..
 &X _dvrms2
-	cseg ; _dvrms2
+    cseg ; _dvrms2
 ``:
-	ld a, d
-	xor b				; discover sign of result
-	push af				; save for later
-	xor b				; recover d (and sign of remainder)
-	push af				; save for later
+    ld a, b
+    xor d               ; discover sign of result
+    push af             ; save for later
+    xor d               ; recover b (and sign of remainder)
+    push af             ; save for later
 
-	jp p, ``_de_positive
-	ld hl, 0
-	and a
-	sbc hl, de			; negate de
-	ex de, hl
-``_de_positive:
-
-	bit 7, b			; get sign of bc
-	jr z, ``_bc_positive
-	ld hl, 0
-	and a
-	sbc hl, bc			; negate bc
-	ld b, h
-	ld c, l
+    jp p, ``_bc_positive
+    ld hl, 0
+    and a
+    sbc hl, bc          ; negate bc
+    ld b, h
+    ld c, l
 ``_bc_positive:
 
-	call ``_dvrmu2		; actually do the division
-	ld b, h				; put remainder in bc as we need hl
-	ld c, l
+    bit 7, d            ; get sign of de
+    jr z, ``_de_positive
+    ld hl, 0
+    and a
+    sbc hl, de          ; negate de
+    ex de, hl
+``_de_positive:
 
-	pop af				; recover sign of remainder
-	jp p, ``_remainder_positive
-	ld hl, 0
-	and a
-	sbc hl, bc			; invert remainder
-	ld b, h
-	ld c, l
+    call `_dvrmu2       ; actually do the division
+    ex de, hl           ; put remainder in de as we need hl
+
+    pop af              ; recover sign of remainder
+    jp p, ``_remainder_positive
+    ld hl, 0
+    and a
+    sbc hl, de          ; invert remainder
+    ex de, hl
 ``_remainder_positive:
 
-	pop af				; recover sign of result
-	ret p				; return now if we're good
-	ld hl, 0
-	and a
-	sbc hl, de			; invert result
-	ex de, hl
-	ret
+    pop af              ; recover sign of result
+    ret p               ; return now if we're good
+    ld hl, 0
+    and a
+    sbc hl, bc          ; invert result
+    ld b, h
+    ld c, l
+    ret
 
-# Divides two thirty-two-bit unsigned number: DEDE = DEDE / BCBC.
-# The quotient is returned in DEDE, the remainder in HLHL.
+# Divides two thirty-two-bit unsigned number: BCBC = BCBC / DEDE
+# The quotient is returned in BCBC, the remainder in HLHL.
 &X _dvrmu4
-	cseg ; _dvrmu4
+    cseg ; _dvrmu4
 ``:
-	ld a, 32			; bit count
-	ld hl, 0			; reset remainder
-	exx
-	ld hl, 0
-	exx
-	jr ``_entry
-``_loop:
-	add hl, bc
-	exx
-	adc hl, bc
-	exx
-	dec a
-	ret z
+    ld a, 32            ; bit count
+    and a               ; reset carry
+    sbc hl, hl          ; reset remainder
+    exx
+    sbc hl, hl
+    exx
+    jr ``_entry
+``_loop1:
+    add hl, de
+    exx
+    adc hl, de
+    exx
+``_loop2:
+    dec a
+    ret z
 ``_entry:
-	sla e
-	rl d
-	exx
-	rl e
-	rl d
-	exx
-	adc hl, hl
-	exx
-	adc hl, hl
-	exx
-	sbc hl, bc
-	exx
-	sbc hl, bc
-	exx
-	jr nc, ``_loop
-	inc de				; can never overflow, only increment low word
-	jr ``_loop
+    sla c               ; left shift LHS
+    rl b
+    exx
+    rl c
+    rl b
+    exx
+    adc hl, hl          ; top bit of LHS goes into remainder
+    exx
+    adc hl, hl
+    exx
+    or a                ; clear carry
+    sbc hl, de          ; sets carry if remainder < RHS
+    exx
+    sbc hl, de
+    exx
+    jr c, ``_loop1      ; if remainder < RHS, undo add and go round again
+    inc c               ; we know the bottom bit is clear
+    jr ``_loop2
 
-# Divides two 32-bit signed numbers: DEDE = DEDE / BCBC.
-# The quotient is returned in DEDE, the remainder in BCBC.
+# Divides two 32-bit signed numbers: BCBC = BCBC / DEDE
+# The quotient is returned in BCBC, the remainder in DEDE.
 &X _dvrms4
-	cseg ; _dvrms4
+    cseg ; _dvrms4
 ``:
-	exx
-	ld a, d
-	xor b				; discover sign of result
-	push af				; save for later
-	xor b				; recover d (and sign of remainder)
-	push af				; save for later
-	exx
+    exx
+    ld a, b
+    xor d               ; discover sign of result
+    push af             ; save for later
+    xor d               ; recover b (and sign of remainder) (and clear carry)
+    push af             ; save for later
+    exx
 
-	jp p, ``_dede_positive
-	ld hl, 0
-	and a
-	sbc hl, de
-	ex de, hl
-	exx
-	ld hl, 0
-	sbc hl, de
-	ex de, hl
-	exx					; negate dede
-``_dede_positive:
-
-	exx
-	bit 7, b			; get sign of bcbc
-	exx
-	jr z, ``_bcbc_positive
-	ld hl, 0
-	and a
-	sbc hl, bc
-	ld b, h
-	ld c, l
-	exx
-	ld hl, 0
-	sbc hl, bc
-	ld b, h
-	ld c, l
-	exx					; negate bcbc
+    jp p, ``_bcbc_positive
+    sbc hl, hl          ; set hl to 0
+    sbc hl, bc          ; negate bc
+    ld b, h
+    ld c, l
+    exx
+    ld hl, 0
+    sbc hl, bc
+    ld b, h
+    ld c, l
+    exx
 ``_bcbc_positive:
 
-	call `_dvrmu4		; actually do the division
-	ld b, h				; put remainder in bc as we need hl
-	ld c, l
-	exx
-	ld b, h
-	ld c, l
-	exx
+    exx
+    bit 7, d            ; get sign of dede
+    exx
+    jr z, ``_dede_positive
+    ld hl, 0
+    and a
+    sbc hl, de
+    ex de, hl
+    exx
+    ld hl, 0
+    sbc hl, de
+    ex de, hl
+    exx                 ; negate dede
+``_dede_positive:
 
-	pop af				; recover sign of remainder
-	jp p, ``_remainder_positive
-	ld hl, 0
-	and a
-	sbc hl, bc			; invert remainder
-	ld b, h
-	ld c, l
-	exx
-	ld hl, 0
-	sbc hl, bc
-	ld b, h
-	ld c, l
-	exx
+    call `_dvrmu4       ; actually do the division
+    ex de, hl           ; put remainder in de as we need hl
+    exx
+    ex de, hl
+    exx
+
+    pop af              ; recover sign of remainder
+    jp p, ``_remainder_positive
+    and a               ; clear carry
+    sbc hl, hl
+    sbc hl, de          ; invert remainder
+    ex de, hl
+    exx
+    ld hl, 0
+    sbc hl, de
+    ex de, hl
+    exx
 ``_remainder_positive:
 
-	pop af				; recover sign of result
-	ret p				; return now if we're good
-	ld hl, 0
-	and a
-	sbc hl, de			; invert result
-	ex de, hl
-	exx
-	ld hl, 0
-	sbc hl, de
-	ex de, hl
-	exx
-	ret
+    pop af              ; recover sign of result
+    ret p               ; return now if we're good
+    and a
+    sbc hl, hl
+    sbc hl, bc          ; invert result
+    ld b, h
+    ld c, l
+    exx
+    ld hl, 0
+    sbc hl, bc
+    ld b, h
+    ld c, l
+    exx
+    ret
 
 # ANDs two 32-bit numbers: HLHL = HLHL & DEDE. Uses A.
 &X _and4
-	cseg ; _and4
+    cseg ; _and4
 ``:
-	ld a, l
-	and e
-	ld l, a
-	ld a, h
-	and d
-	ld h, a
-	exx
+    ld a, l
+    and e
+    ld l, a
+    ld a, h
+    and d
+    ld h, a
+    exx
 
-	ld a, l
-	and e
-	ld l, a
-	ld a, h
-	and d
-	ld h, a
-	exx
-	ret
+    ld a, l
+    and e
+    ld l, a
+    ld a, h
+    and d
+    ld h, a
+    exx
+    ret
 
 # ORs two 32-bit numbers: HLHL = HLHL & DEDE. Uses A.
 &X _or4
-	cseg ; _or4
+    cseg ; _or4
 ``:
-	ld a, l
-	or e
-	ld l, a
-	ld a, h
-	or d
-	ld h, a
-	exx
+    ld a, l
+    or e
+    ld l, a
+    ld a, h
+    or d
+    ld h, a
+    exx
 
-	ld a, l
-	or e
-	ld l, a
-	ld a, h
-	or d
-	ld h, a
-	exx
-	ret
+    ld a, l
+    or e
+    ld l, a
+    ld a, h
+    or d
+    ld h, a
+    exx
+    ret
 
 # EORs two 32-bit numbers: HLHL = HLHL & DEDE. Uses A.
 &X _eor4
-	cseg ; _eor4
+    cseg ; _eor4
 ``:
-	ld a, l
-	xor e
-	ld l, a
-	ld a, h
-	xor d
-	ld h, a
-	exx
+    ld a, l
+    xor e
+    ld l, a
+    ld a, h
+    xor d
+    ld h, a
+    exx
 
-	ld a, l
-	xor e
-	ld l, a
-	ld a, h
-	xor d
-	ld h, a
-	exx
-	ret
+    ld a, l
+    xor e
+    ld l, a
+    ld a, h
+    xor d
+    ld h, a
+    exx
+    ret
+
+# NOTs the 32-bit number in HLHL. Uses A.
+&X _not4
+    cseg ; _not4
+``:
+    ld a, l
+    cpl
+    ld l, a
+    ld a, h
+    cpl
+    ld h, a
+    exx
+    ld a, l
+    cpl
+    ld l, a
+    ld a, h
+    cpl
+    ld h, a
+    exx
+    ret
+
+# Signed comparison of HL and DE. Uses A.
+# Returns m if HL < DE.
+&X _cmps2
+    cseg ; _cmps2
+``:
+    and a               ; clear carry
+    sbc hl, de
+    jp po, $+5
+    xor 0x80            ; ruins Z
+    ret
 
 # Compares HLHL and DEDE.
 # Returns z if HLHL == DEDE.
@@ -474,7 +509,7 @@
 &X _cmpu4
     cseg ; _cmpeq4
 ``:
-    and a				; clear carry
+    and a               ; clear carry
     sbc hl, de
     ret nz
     exx
@@ -487,15 +522,15 @@
 &X _cmps4
     cseg ; _cmps4
 ``:
-	and a				; clear carry
-	sbc hl, de
-	exx
-	sbc hl, de			; leaves C set on unsigned overflow
-	ld a, h				; preserve high byte
-	exx
-	jp po, $+5
-	xor 0x80			; invert sign byte
-	ret
+    and a               ; clear carry
+    sbc hl, de
+    exx
+    sbc hl, de          ; leaves C set on unsigned overflow
+    ld a, h             ; preserve high byte
+    exx
+    jp po, $+5
+    xor 0x80            ; invert sign byte, spoil Z
+    ret
 
 # vim: ts=4 sw=4 et
 

--- a/rt/cpmz/cowgol.cos
+++ b/rt/cpmz/cowgol.cos
@@ -1,0 +1,129 @@
+# Logical shift A right B bits.
+&X _lsr1
+    cseg ; _lsr1
+``:
+    dec b
+    ret m
+    srl a
+    jr ``
+
+# Arithmetic shift A right B bits.
+&X _asr1
+    cseg ; _asr1
+``:
+    dec b
+    ret m
+    sra a
+    jr ``
+
+# Logical shift HL right A bits.
+&X _lsr2
+    cseg ; _lsr2
+``:
+    dec a
+    ret m
+    srl h
+    rr l
+    jr ``
+
+# Arithmetic shift HL right A bits.
+&X _asr2
+    cseg ; _asr2
+``:
+    dec a
+    ret m
+    sra h
+    rr l
+    jr ``
+
+# Logical shift HLHL right A bits.
+&X _lsr4
+    cseg ; _lsr4
+``:
+    dec a
+    ret m
+    exx
+    srl h
+    rr l
+    exx
+    rr h
+    rr l
+    jr ``
+
+# Arithmetic shift HLHL right A bits.
+&X _asr4
+    cseg ; _asr4
+``:
+    dec a
+    ret m
+    exx
+    sra h
+    rr l
+    exx
+    rr h
+    rr l
+    jr ``
+
+# 8-bit multiplication: A = D * H.
+&X _mul1
+    cseg ; _mul1
+``:
+    ld e, d             ; move D to low byte of DE
+    ld d, 0             ; clear top byte
+    sla h               ; first iteration
+    sbc a
+    and e
+    ld l, a
+
+    ld b, 7
+``_1:
+    add hl, hl
+    jr nc, $ + 3
+    add hl, de
+    djnc ``_1
+
+    ld a, h
+    ret
+
+# 32-bit multiplication: HLHL = BCBC * DEDE.
+&X _mul4
+    cseg ; _mul4
+``:
+    and a               ; reset carry
+    sbc hl, hl          ; lower result to 0
+    exx
+    sbc hl, hl          ; upper result to 0
+    ld a, 32            ; number of iterations
+``_loop:
+    sra b               ; right shift lhs
+    rr c
+    exx
+    rr b
+    rr c                ; lowest bit to carry
+    jr nc, ``_noadd
+    add hl, de          ; result += rhs
+    exx
+    adc hl, de
+``_noadd:
+    sla e               ; left shift rhs
+    rl d
+    exx
+    rl e
+    rl d
+    dec a
+    jr nz, ``_loop
+    ret
+#
+# Compares HLHL and DEDE, setting Z or NZ. Uses A.
+&X _cmpeq4
+    cseg ; _cmpeq4
+``:
+    xor a
+    sbc hl, de
+    ret nz
+    exx
+    xor a
+    sbc hl, de
+    exx
+    ret
+

--- a/rt/cpmz/file.coh
+++ b/rt/cpmz/file.coh
@@ -1,0 +1,196 @@
+# vim: ts=4 sw=4 et
+
+record CpmFCB
+	dr: uint8;
+	f: uint8[11];
+	ex: uint8;
+	s1: uint8;
+	s2: uint8;
+	rc: uint8;
+	d: uint8[16];
+	cr: uint8;
+	r: uint16;
+	r2: uint8;
+end record;
+
+record FCB
+	bufferptr: uint8; # byte just read
+	dirty: uint8;
+	cpm: CpmFCB;
+	buffer: uint8[128];
+end record;
+
+sub file_i_init(fcb: [FCB], filename: [uint8])
+	sub fill(dest: [uint8], src: [uint8], len: uint8): (srcout: [uint8])
+		loop
+			var c := [src];
+			if (c < 32) or (c == '.') then
+				c := ' ';
+			elseif (c == '*') then
+				c := '?';
+			else
+				src := src + 1;
+			end if;
+			if (c >= 'a') and (c <= 'z') then
+				c := c - ('a' - 'A');
+			end if;
+			[dest] := c;
+			dest := dest + 1;
+
+			len := len - 1;
+			if len == 0 then
+				break;
+			end if;
+		end loop;
+		srcout := src;
+	end sub;
+
+	MemSet(fcb as [uint8], 0, @bytesof FCB);
+	MemSet(&fcb.cpm.f[0] as [uint8], ' ', 11);
+	filename := fill(&fcb.cpm.f[0], filename, 8);
+
+	var c: uint8;
+	loop
+		c := [filename];
+		if (c < 32) or (c == '.') then
+			break;
+		end if;
+		filename := filename + 1;
+	end loop;
+
+	if c == '.' then
+		filename := fill(&fcb.cpm.f[8], filename+1, 3);
+	end if;
+	fcb.cpm.r := 0xffff;
+	fcb.bufferptr := 127;
+end sub;
+
+sub fcb_i_gbpb(fcb: [FCB], c: uint8)
+	var cpmfcb := &fcb.cpm;
+	var dma := &fcb.buffer[0];
+
+	@asm "ld c, 26"; # SET DMA
+	@asm "ld de, (", dma, ")";
+	@asm "call 5";
+
+	@asm "ld a, (", c, ")";
+	@asm "mov c, a";
+	@asm "ld de, (", cpmfcb, ")";
+	@asm "call 5";
+end sub;
+
+sub fcb_i_blockin(fcb: [FCB])
+	MemSet(&fcb.buffer[0], 0, 128);
+	fcb_i_gbpb(fcb, 33); # READ RANDOM
+	fcb.dirty := 0;
+end sub;
+
+sub fcb_i_blockout(fcb: [FCB])
+	if fcb.dirty != 0 then
+		fcb_i_gbpb(fcb, 34); # WRITE RANDOM
+		fcb.dirty := 0;
+	end if;
+end sub;
+
+sub fcb_i_changeblock(fcb: [FCB], newblock: uint16)
+	if newblock != fcb.cpm.r then
+		fcb_i_blockout(fcb);
+		fcb.cpm.r := newblock;
+		fcb_i_blockin(fcb);
+	end if;
+end sub;
+
+sub fcb_i_convert_a_to_error()
+	@asm "cp 0xff";
+	@asm "ld a, 0";
+	@asm "ret nz";
+	@asm "inc a";
+end sub;
+
+sub FCBOpenIn(fcb: [FCB], filename: [uint8]): (errno: uint8)
+	file_i_init(fcb, filename);
+
+	var cpmfcb := &fcb.cpm;
+	@asm "mov c, 15"; # OPEN_FILE
+	@asm "ld de, (", cpmfcb, ")";
+	@asm "call 5";
+	@asm "call", fcb_i_convert_a_to_error;
+	@asm "ld (", errno, "), a";
+end sub;
+
+sub FCBOpenUp(fcb: [FCB], filename: [uint8]): (errno: uint8)
+	(errno) := FCBOpenIn(fcb, filename);
+end sub;
+
+sub FCBOpenOut(fcb: [FCB], filename: [uint8]): (errno: uint8)
+	file_i_init(fcb, filename);
+
+	var cpmfcb := &fcb.cpm;
+	@asm "ld c, 19"; # DELETE_FILE
+	@asm "ld de, (", cpmfcb, ")";
+	@asm "call 5";
+
+	@asm "ld c, 22"; # CREATE_FILE
+	@asm "ld de, (", cpmfcb, ")";
+	@asm "call 5";
+	@asm "call", fcb_i_convert_a_to_error;
+	@asm "ld (", errno, "), a";
+end sub;
+	
+sub FCBClose(fcb: [FCB]): (errno: uint8)
+	fcb_i_blockout(fcb);
+
+	var cpmfcb := &fcb.cpm;
+	@asm "ld c, 16"; # CLOSE_FILE
+	@asm "ld de, (", cpmfcb, ")";
+	@asm "call 5";
+	@asm "call", fcb_i_convert_a_to_error;
+	@asm "ld (", errno, "), a";
+end sub;
+
+sub FCBSeek(fcb: [FCB], pos: uint32)
+	pos := pos - 1; # seek to *previous* character
+	var newblock := (pos >> 7) as uint16;
+	var newptr := (pos as uint8) & 127;
+	fcb_i_changeblock(fcb, newblock);
+	fcb.bufferptr := newptr;
+end sub;
+
+sub FCBPos(fcb: [FCB]): (pos: uint32)
+	pos := (((fcb.cpm.r as uint32) << 7) | (fcb.bufferptr as uint32)) + 1;
+end sub;
+
+sub FCBExt(fcb: [FCB]): (len: uint32)
+	fcb_i_blockout(fcb);
+	var oldblock := fcb.cpm.r;
+
+	var cpmfcb := &fcb.cpm;
+	@asm "ld c, 35"; # COMPUTE FILE SIZE
+	@asm "ld de, (", cpmfcb, ")";
+	@asm "call 5";
+
+	len := ([&fcb.cpm.r as [uint32]] & 0x00ffffff) << 7;
+	fcb.cpm.r := oldblock;
+end sub;
+
+sub fcb_i_nextchar(fcb: [FCB])
+	fcb.bufferptr := fcb.bufferptr + 1;
+	if fcb.bufferptr == 128 then
+		fcb_i_changeblock(fcb, fcb.cpm.r + 1);
+		fcb.bufferptr := 0;
+	end if;
+end sub;
+
+sub FCBGetChar(fcb: [FCB]): (c: uint8)
+	fcb_i_nextchar(fcb);
+	c := fcb.buffer[fcb.bufferptr];
+end sub;
+
+sub FCBPutChar(fcb: [FCB], c: uint8)
+	fcb_i_nextchar(fcb);
+	fcb.buffer[fcb.bufferptr] := c;
+	fcb.dirty := 1;
+end sub;
+
+include "common-file.coh";
+

--- a/rt/cpmz/file.coh
+++ b/rt/cpmz/file.coh
@@ -74,7 +74,7 @@ sub fcb_i_gbpb(fcb: [FCB], c: uint8)
 	@asm "call 5";
 
 	@asm "ld a, (", c, ")";
-	@asm "mov c, a";
+	@asm "ld c, a";
 	@asm "ld de, (", cpmfcb, ")";
 	@asm "call 5";
 end sub;
@@ -111,7 +111,7 @@ sub FCBOpenIn(fcb: [FCB], filename: [uint8]): (errno: uint8)
 	file_i_init(fcb, filename);
 
 	var cpmfcb := &fcb.cpm;
-	@asm "mov c, 15"; # OPEN_FILE
+	@asm "ld c, 15"; # OPEN_FILE
 	@asm "ld de, (", cpmfcb, ")";
 	@asm "call 5";
 	@asm "call", fcb_i_convert_a_to_error;

--- a/src/build.lua
+++ b/src/build.lua
@@ -178,11 +178,27 @@ function cowlink(e)
 		ins = concat {
 			"scripts/quiet",
 			"bin/cowlink.8080.ocgen.exe",
-			"$OBJ/rt/cpm/cowgol.coo",
+			e.runtime,
 			e.ins
 		},
 		outs = e.outs,
 		cmd = "@1 @2 -o &1 @3 @4"
+	}
+end
+
+function cowlink_cpm(e)
+	cowlink {
+		ins = e.ins,
+		outs = e.outs,
+		runtime = "$OBJ/rt/cpm/cowgol.coo",
+	}
+end
+
+function cowlink_cpmz(e)
+	cowlink {
+		ins = e.ins,
+		outs = e.outs,
+		runtime = "$OBJ/rt/cpmz/cowgol.coo",
 	}
 end
 

--- a/src/cowcom/arch8080.cow.ng
+++ b/src/cowcom/arch8080.cow.ng
@@ -139,7 +139,10 @@
 			when REG_DE: result := REG_E;
 			when REG_HL: result := REG_L;
 			when else:
-				SimpleError("bad loreg");
+				StartError();
+				print("bad loreg ");
+				print_hex_i16(reg);
+				EndError();
 		end case;
 	end sub;
 

--- a/src/cowcom/arch8080.cow.ng
+++ b/src/cowcom/arch8080.cow.ng
@@ -588,7 +588,7 @@
 	end sub;
 %}
 
-width 16;
+wordsize 0xffff;
 
 register a b c d e h l hl de bc;
 register stk4 param;

--- a/src/cowcom/archz80.cow.ng
+++ b/src/cowcom/archz80.cow.ng
@@ -170,6 +170,16 @@
 		end case;
 	end sub;
 
+	sub wordreg(reg: RegId): (result: RegId)
+		case reg is
+			when REG_BCBC: result := REG_BC;
+			when REG_DEDE: result := REG_DE;
+			when REG_HLHL: result := REG_HL;
+			when else:
+				SimpleError("bad wordreg");
+		end case;
+	end sub;
+
 	sub E_reg(reg: RegId)
 		case reg is
 			when REG_A:    E("a");
@@ -313,6 +323,16 @@
 		E("), ");
 		E_u8(val);
 		E_nl();
+	end sub;
+
+	sub E_loada(ptr: RegId)
+		if ptr == REG_HL then
+			E_loadm(REG_A);
+		elseif (ptr & (REG_IX|REG_IY)) != 0 then
+			E_load8i(REG_A, ptr, 0);
+		else
+			E_ldax(ptr);
+		end if;
 	end sub;
 
 	sub E_load16(dest: RegId, sym: [Symbol], off: Size)
@@ -686,7 +706,7 @@
 	end sub;
 %}
 
-width 16;
+wordsize 0xffffffff;
 
 register a b c d e h l hl de bc hlhl dede bcbc ix iy;
 register param;
@@ -783,6 +803,7 @@ gen STARTSUB():s
 					E_exx();
 					E_store16(REG_HL, param, 2);
 					E_exx();
+					RegCacheLeavesValue(REG_HLHL, param, 0);
 				end if;
 		end case;
 	end loop;
@@ -935,29 +956,47 @@ gen r16 := ADDRESS():a
 
 gen r32 := CONSTANT():c
 {
-	E_lxi($$, $c.value as uint16);
-	E_exx();
-	E_lxi($$, ($c.value>>16) as uint16);
-	E_exx();
+	var cache := RegCacheFindConstant($c.value as uint32);
+	if (cache & $$) != 0 then
+		# Value already in the right register.
+		return;
+	end if;
+
+	if ($c.value == 0) and ($$ == REG_HLHL) then
+		E_rcf();
+		E_sbc(REG_HL, REG_HL);
+		E_exx();
+		E_sbc(REG_HL, REG_HL);
+		E_exx();
+	else
+		E_lxi(wordreg($$), $c.value as uint16);
+		E_exx();
+		E_lxi(wordreg($$), ($c.value>>16) as uint16);
+		E_exx();
+	end if;
+	RegCacheLeavesConstant($$, $c.value as uint32);
 }
 
 // --- 8-bit loads and stores -----------------------------------------------
+
+%{
+	sub is_indexable_8bit(value: Arith): (result: uint8)
+		result := 1;
+		if (value < -128) or (value > 127) then
+			result := 0;
+		end if;
+	end sub;
+%}
 
 gen a := LOAD1(ADDRESS():a)
 {
 	E_lda($a.sym, $a.off);
 }
 
-gen a := LOAD1(hl|bc|de:ptr)
-{
-	if $ptr == REG_HL then
-		E_loadm(REG_A);
-	else
-		E_ldax($ptr);
-	end if;
-}
+gen a := LOAD1(r16:ptr)
+		{ E_loada($ptr); }
 
-gen r8 := LOAD1(ADD2(ix|iy:ptr, CONSTANT():c))
+gen r8 := LOAD1(ADD2(ix|iy:ptr, CONSTANT(value is indexable_8bit):c))
 {
 	E_load8i($$, $ptr, $c.value as int8);
 }
@@ -976,17 +1015,26 @@ gen STORE1(a, hl|bc|de:ptr)
 	end if;
 }
 
-gen STORE1(r8:r, ADD2(ix|iy:ptr, CONSTANT():c))
+gen STORE1(r8:r, ADD2(ix|iy:ptr, CONSTANT(value is indexable_8bit):c))
 {
 	E_store8i($r, $ptr, $c.value as int8);
 }
 
-gen STORE1(CONSTANT():v, ADD2(ix|iy:ptr, CONSTANT():c))
+gen STORE1(CONSTANT():v, ADD2(ix|iy:ptr, CONSTANT(value is indexable_8bit):c))
 {
 	E_store8ic($v.value as uint8, $ptr, $c.value as int8);
 }
 
 // --- 16-bit loads and stores ----------------------------------------------
+
+%{
+	sub is_indexable_16bit(value: Arith): (result: uint8)
+		result := 1;
+		if (value < -128) or (value > 126) then
+			result := 0;
+		end if;
+	end sub;
+%}
 
 gen r16 := LOAD2(ADDRESS():a)
 {
@@ -1010,7 +1058,7 @@ gen hl|bc|de := LOAD2(hl|ix|iy:rhs) uses a
 	end if;
 }
 
-gen hl|bc|de := LOAD2(ADD2(ix|iy:rhs, CONSTANT():c))
+gen hl|bc|de := LOAD2(ADD2(ix|iy:rhs, CONSTANT(value is indexable_16bit):c))
 {
 	E_load8i(loreg($$), $rhs, ($c.value as int8)+0);
 	E_load8i(hireg($$), $rhs, ($c.value as int8)+1);
@@ -1033,13 +1081,28 @@ gen STORE2(bc|de:val, hl|ix|iy:rhs) uses a
 	end if;
 }
 
-gen STORE2(hl|bc|de:val, ADD2(ix|iy:rhs, CONSTANT():c)) uses a
+gen STORE2(hl|bc|de:val, ADD2(ix|iy:rhs, CONSTANT(value is indexable_16bit):c)) uses a
 {
 	E_store8i(loreg($val), $rhs, ($c.value as int8)+0);
 	E_store8i(hireg($val), $rhs, ($c.value as int8)+1);
 }
 
+gen STORE2(CONSTANT():v, ADD2(ix|iy:rhs, CONSTANT(value is indexable_16bit):c)) uses a
+{
+	E_store8ic($v.value as uint8, $rhs, ($c.value as int8)+0);
+	E_store8ic(($v.value>>8) as uint8, $rhs, ($c.value as int8)+1);
+}
+
 // --- 32-bit loads and stores ----------------------------------------------
+
+%{
+	sub is_indexable_32bit(value: Arith): (result: uint8)
+		result := 1;
+		if (value < -128) or (value > 124) then
+			result := 0;
+		end if;
+	end sub;
+%}
 
 gen r32 := LOAD4(ix|iy:ptr)
 {
@@ -1051,7 +1114,7 @@ gen r32 := LOAD4(ix|iy:ptr)
 	E_exx();
 }
 
-gen r32 := LOAD4(ADD2(ix|iy:ptr, CONSTANT():c))
+gen r32 := LOAD4(ADD2(ix|iy:ptr, CONSTANT(value is indexable_32bit):c))
 {
 	E_load8i(loreg($$), $ptr, ($c.value as int8)+0);
 	E_load8i(hireg($$), $ptr, ($c.value as int8)+1);
@@ -1063,10 +1126,17 @@ gen r32 := LOAD4(ADD2(ix|iy:ptr, CONSTANT():c))
 
 gen r32 := LOAD4(ADDRESS():a)
 {
-	E_load16($$, $a.sym, $a.off);
+	var cache := RegCacheFindValue($a.sym, $a.off);
+	if (cache & $$) != 0 then
+		# Value already in the right register.
+		return;
+	end if;
+
+	E_load16(wordreg($$), $a.sym, $a.off);
 	E_exx();
-	E_load16($$, $a.sym, $a.off+2);
+	E_load16(wordreg($$), $a.sym, $a.off+2);
 	E_exx();
+	RegCacheLeavesValue($$, $a.sym, $a.off);
 }
 
 gen STORE4(r32:val, ix|iy:ptr)
@@ -1079,7 +1149,7 @@ gen STORE4(r32:val, ix|iy:ptr)
 	E_exx();
 }
 
-gen STORE4(r32:val, ADD2(ix|iy:ptr, CONSTANT():c))
+gen STORE4(r32:val, ADD2(ix|iy:ptr, CONSTANT(value is indexable_32bit):c))
 {
 	E_store8i(loreg($val), $ptr, ($c.value as int8)+0);
 	E_store8i(hireg($val), $ptr, ($c.value as int8)+1);
@@ -1091,10 +1161,19 @@ gen STORE4(r32:val, ADD2(ix|iy:ptr, CONSTANT():c))
 
 gen STORE4(r32:val, ADDRESS():a)
 {
-	E_store16($val, $a.sym, $a.off);
+	E_store16(wordreg($val), $a.sym, $a.off);
 	E_exx();
-	E_store16($val, $a.sym, $a.off+2);
+	E_store16(wordreg($val), $a.sym, $a.off+2);
 	E_exx();
+	RegCacheLeavesValue($$, $a.sym, $a.off);
+}
+
+gen STORE4(CONSTANT():c, ADDRESS():a) uses hl
+{
+	E_lxi(REG_HL, $c.value as uint16);
+	E_store16(REG_HL, $a.sym, $a.off);
+	E_lxi(REG_HL, ($c.value >> 16) as uint16);
+	E_store16(REG_HL, $a.sym, $a.off+2);
 }
 
 // --- 8-bit arithmetic -----------------------------------------------------
@@ -1471,18 +1550,46 @@ gen hlhl := RSHIFTS4(hlhl, b)
 		E_jumps_jz_jnz(node);
 	end sub;
 
-	sub bequ2c(node: [Node], value: uint16)
+	sub cmpeq2(value: uint16)
 		if value != 0 then
 			E_lxi(REG_DE, -value);
 			E_add(REG_HL, REG_DE);
 		end if;
 		E_mov(REG_A, REG_H);
 		E_or(REG_L);
+	end sub;
+
+	sub bequ2c(node: [Node], value: uint16)
+		cmpeq2(value);
+		E_jumps_jz_jnz(node);
+	end sub;
+
+	sub bequ2(node: [Node], lhs: RegId)
+		E_rcf();
+		E_sbc(REG_HL, lhs);
 		E_jumps_jz_jnz(node);
 	end sub;
 
 	sub bequ4(node: [Node])
 		E_callhelper("_cmpu4");
+		E_jumps_jz_jnz(node);
+	end sub;
+
+	sub bequ4c(node: [Node], value: Arith)
+		if value == 0 then
+			E_mov(REG_A, REG_H);
+			E_or(REG_L);
+			E_exx();
+			E_or(REG_H);
+			E_or(REG_L);
+		else
+			E_rcf();
+			cmpeq2(value as uint16);
+			E_jump("jp nz,", node.beqs0.falselabel);
+			E_exx();
+			cmpeq2((value>>16) as uint16);
+		end if;
+		E_exx();
 		E_jumps_jz_jnz(node);
 	end sub;
 
@@ -1540,19 +1647,25 @@ gen BLTS1(a, b|d|h:rhs):b
 	E_jumps_jm_jp(self.n[0]);
 }
 
-%{
-	sub bequ2(node: [Node], lhs: RegId)
-		E_rcf();
-		E_sbc(REG_HL, lhs);
-		E_jumps_jz_jnz(node);
-	end sub;
-%}
+gen BLTS1(a, CONSTANT():c):b
+{
+	E_subi($c.value as uint8);
+	E("\tjp po, $+5\n");
+	E_xori(0x80);
+	E_jumps_jm_jp(self.n[0]);
+}
 
 gen BEQU2(bc|de:lhs, hl):a
 		{ bequ2(self.n[0], $lhs); }
 
 gen BEQS2(bc|de:lhs, hl):a
 		{ bequ2(self.n[0], $lhs); }
+
+gen BEQU2(hl, CONSTANT():c) uses a|de
+		{ bequ2c(self.n[0], $c.value as uint16); }
+
+gen BEQS2(hl, CONSTANT():c) uses a|de
+		{ bequ2c(self.n[0], $c.value as uint16); }
 
 gen BLTU2(hl, bc|de:rhs):b
 {
@@ -1568,16 +1681,16 @@ gen BLTS2(hl, de):b uses a|bc
 }
 
 gen BEQU4(dede, hlhl):b uses a
-{
-	E_callhelper("_cmpu4");
-	E_jumps_jz_jnz(self.n[0]);
-}
+		{ bequ4(self.n[0]); }
 
 gen BEQS4(dede, hlhl):b uses a
-{
-	E_callhelper("_cmpu4");
-	E_jumps_jz_jnz(self.n[0]);
-}
+		{ bequ4(self.n[0]); }
+
+gen BEQU4(hlhl, CONSTANT():c):b uses dede|a
+		{ bequ4c(self.n[0], $c.value); }
+
+gen BEQS4(hlhl, CONSTANT():c):b uses dede|a
+		{ bequ4c(self.n[0], $c.value); }
 
 gen BLTU4(hlhl, dede):b
 {
@@ -1710,11 +1823,20 @@ gen hlhl := CAST24(hl, sext!=0) uses a
 gen a := CAST21(hl|bc|de:rhs)
 		{ E_mov(REG_A, loreg($rhs)); }
 
-gen a := CAST21(ADDRESS():a)
+gen a := CAST21(LOAD2(ADDRESS():a))
 		{ E_lda($a.sym, $a.off); }
+
+gen a := CAST21(LOAD2(r16:ptr))
+		{ E_loada($ptr); }
 
 gen a := CAST41(r32:rhs)
 		{ E_mov(REG_A, loreg($rhs)); }
+
+gen a := CAST41(LOAD4(ADDRESS():a))
+		{ E_lda($a.sym, $a.off); }
+
+gen a := CAST41(LOAD4(r16:ptr))
+		{ E_loada($ptr); }
 
 gen hl := CAST42(hlhl);
 

--- a/src/cowcom/archz80.cow.ng
+++ b/src/cowcom/archz80.cow.ng
@@ -146,7 +146,10 @@
 			when REG_DEDE: result := REG_E;
 			when REG_HLHL: result := REG_L;
 			when else:
-				SimpleError("bad loreg");
+				StartError();
+				print("bad loreg ");
+				print_hex_i16(reg);
+				EndError();
 		end case;
 	end sub;
 
@@ -160,7 +163,10 @@
 			when REG_DEDE: result := REG_D;
 			when REG_HLHL: result := REG_H;
 			when else:
-				SimpleError("bad hireg");
+				StartError();
+				print("bad hireg ");
+				print_hex_i16(reg);
+				EndError();
 		end case;
 	end sub;
 
@@ -655,12 +661,11 @@
 		elseif ((src|dest) & (REG_IX|REG_IY)) != 0 then
 			E_push(src);
 			E_pop(dest);
+		elseif (src & (REG_HL|REG_BC|REG_DE)) != 0 then
+			E_mov(hireg(dest), hireg(src));
+			E_mov(loreg(dest), loreg(src));
 		else
 			E_mov(dest, src);
-
-			if (src & (REG_HL|REG_BC|REG_DE)) != 0 then
-				E_mov(loreg(dest), loreg(src));
-			end if;
 		end if;
 	end sub;
 
@@ -961,24 +966,21 @@ gen r16 := LOAD2(ADDRESS():a)
 	E_load16($$, $a.sym, $a.off);
 }
 
-%{
-	sub load2(dest: RegId)
-		if dest == REG_HL then
-			E_loadm(REG_A);
-			E_inc(REG_HL);
-			E_loadm(dest);
-			E_mov(loreg(dest), REG_A);
-		else
-			E_loadm(loreg(dest));
-			E_inc(REG_HL);
-			E_loadm(dest);
-		end if;
-	end sub;
-%}
-
-gen r16 := LOAD2(hl) uses a
+gen hl|bc|de := LOAD2(hl|ix|iy:rhs) uses a
 {
-	load2($$);
+	if ($rhs & (REG_IX|REG_IY)) != 0 then
+		E_load8i(loreg($$), $rhs, 0);
+		E_load8i(hireg($$), $rhs, 1);
+	elseif $rhs == $$ then
+		E_loadm(REG_A);
+		E_inc(REG_HL);
+		E_loadm(hireg($$));
+		E_mov(loreg($$), REG_A);
+	else
+		E_loadm(loreg($$));
+		E_inc(REG_HL);
+		E_loadm(hireg($$));
+	end if;
 }
 
 gen STORE2(r16:ptr, ADDRESS():a)
@@ -986,11 +988,16 @@ gen STORE2(r16:ptr, ADDRESS():a)
 	E_store16($ptr, $a.sym, $a.off);
 }
 
-gen STORE2(bc|de:val, hl) uses a
+gen STORE2(bc|de:val, hl|ix|iy:rhs) uses a
 {
-	E_storem(loreg($val));
-	E_inc(REG_HL);
-	E_storem($val);
+	if ($rhs & (REG_IX|REG_IY)) != 0 then
+		E_store8i(loreg($val), $rhs, 0);
+		E_store8i(hireg($val), $rhs, 1);
+	else
+		E_storem(loreg($val));
+		E_inc(REG_HL);
+		E_storem(hireg($val));
+	end if;
 }
 
 // --- 32-bit loads and stores ----------------------------------------------
@@ -1084,16 +1091,16 @@ gen a := EOR1(a, b|d|h:lhs)
 gen a := EOR1(a, CONSTANT():c)
 		{ E_xori($c.value as uint8); }
 
-gen b := DIVU1(b, d) uses a
+gen h := DIVU1(h, d) uses a
 		{ E_callhelper("_dvrmu1"); }
 
-gen a := REMU1(b, d)
+gen a := REMU1(h, d)
 		{ E_callhelper("_dvrmu1"); }
 
 gen b := DIVS1(b, d) uses a
 		{ E_callhelper("_dvrms1"); }
 
-gen d := REMS1(b, d)
+gen d := REMS1(b, d) // note, result not in A
 		{ E_callhelper("_dvrms1"); }
 
 gen a := RSHIFTS1(a, b)
@@ -1213,18 +1220,18 @@ gen hl := SUB2(hl:lhs, bc|de:rhs)
 		E_mov(REG_A, loreg(lhs));
 		E_alu(loinsn, loreg(rhs));
 		E_mov(loreg(dest), REG_A);
-		E_mov(REG_A, lhs);
-		E_alu(hiinsn, rhs);
-		E_mov(dest, REG_A);
+		E_mov(REG_A, hireg(lhs));
+		E_alu(hiinsn, hireg(rhs));
+		E_mov(hireg(dest), REG_A);
 	end sub;
 
 	sub aluop2i(lhs: RegId, value: uint16, dest: RegId, loinsn: string, hiinsn: string)
 		E_mov(REG_A, loreg(lhs));
 		E_alui(loinsn, value as uint8);
 		E_mov(loreg(dest), REG_A);
-		E_mov(REG_A, lhs);
+		E_mov(REG_A, hireg(lhs));
 		E_alui(hiinsn, (value >> 8) as uint8);
-		E_mov(dest, REG_A);
+		E_mov(hireg(dest), REG_A);
 	end sub;
 %}
 
@@ -1237,10 +1244,10 @@ gen hl := REMU2(de, bc) uses a
 gen de := DIVS2(de, bc) uses a
 		{ E_callhelper("_dvrms2"); }
 
-gen hl := REMS2(de, bc) uses a
+gen bc := REMS2(de, bc) uses a|hl // note, remainder not in hl
 		{ E_callhelper("_dvrms2"); }
 
-gen hl := MUL2(hl, de) uses a|bc
+gen hl := MUL2(de, bc) uses a
 		{ E_callhelper("_mul2"); }
 
 %{
@@ -1276,9 +1283,9 @@ gen bc|de|hl := NOT2(bc|de|hl:lhs) uses a
 	E_mov(REG_A, loreg($lhs));
 	E_cpl();
 	E_mov(loreg($$), REG_A);
-	E_mov(REG_A, $lhs);
+	E_mov(REG_A, hireg($lhs));
 	E_cpl();
-	E_mov($$, REG_A);
+	E_mov(hireg($$), REG_A);
 }
 
 gen hl := RSHIFTU2(hl, a)
@@ -1331,28 +1338,28 @@ gen hlhl := NEG4(hlhl) uses a|bcbc
 	E_exx();
 }
 
-gen hlhl := MUL4(bcbc, dede)
+gen hlhl := MUL4(bcbc, dede) uses a
         { E_callhelper("_mul4"); }
 
-gen r32 := DIVU4(r32, r32)
-        { E_callhelper("_divu4"); }
+gen dede := DIVU4(dede, bcbc) uses a|hlhl
+        { E_callhelper("_dvrmu4"); }
 
-gen r32 := REMU4(r32, r32)
-        { E_callhelper("_remu4"); }
+gen hlhl := REMU4(dede, bcbc) uses a
+        { E_callhelper("_dvrmu4"); }
 
-gen r32 := DIVS4(r32, r32)
-        { E_callhelper("_divs4"); }
+gen dede := DIVS4(dede, bcbc) uses a|hlhl
+        { E_callhelper("_dvrms4"); }
 
-gen r32 := REMS4(r32, r32)
-        { E_callhelper("_rems4"); }
+gen bcbc := REMS4(dede, bcbc) uses a|hlhl // note, remainder in bcbc
+        { E_callhelper("_dvrms4"); }
 
-gen hlhl := AND4(dede, hlhl)
+gen hlhl := AND4(dede, hlhl) uses a
         { E_callhelper("_and4"); }
 
-gen hlhl := OR4(dede, hlhl)
+gen hlhl := OR4(dede, hlhl) uses a
         { E_callhelper("_or4"); }
 
-gen hlhl := EOR4(dede, hlhl)
+gen hlhl := EOR4(dede, hlhl) uses a
         { E_callhelper("_eor4"); }
 
 gen r32 := NOT4($$)
@@ -1363,13 +1370,13 @@ gen r32 := NOT4($$)
 	E_exx();
 }
 
-gen hlhl := LSHIFT4(hlhl, a)
+gen hlhl := LSHIFT4(hlhl, b)
         { E_callhelper("_asl4"); }
 
-gen hlhl := RSHIFTU4(hlhl, a)
+gen hlhl := RSHIFTU4(hlhl, b)
         { E_callhelper("_lsr4"); }
 
-gen hlhl := RSHIFTS4(hlhl, a)
+gen hlhl := RSHIFTS4(hlhl, b)
         { E_callhelper("_asr4"); }
 
 // --- Conditionals ---------------------------------------------------------
@@ -1390,6 +1397,10 @@ gen hlhl := RSHIFTS4(hlhl, a)
 
 	sub E_jumps_jc_jnc(node: [Node])
 		E_jumps_with_fallthrough("jp c,", "jp nc,", node);
+	end sub;
+
+	sub E_jumps_jm_jp(node: [Node])
+		E_jumps_with_fallthrough("jp m,", "jp p,", node);
 	end sub;
 
 	sub bequ1(node: [Node], nota: RegId)
@@ -1469,8 +1480,10 @@ gen BLTU1(a, CONSTANT():c):b
 
 gen BLTS1(a, b):b
 {
-	E_callhelper("_cmps1");
-	E_jumps_with_fallthrough("jp m,", "jp p,", self.n[0]);
+	E_sub(REG_B);
+	E("\tjp p, $+5\n");
+	E_xori(0x80);
+	E_jumps_jm_jp(self.n[0]);
 }
 
 %{
@@ -1494,21 +1507,21 @@ gen BLTU2(hl, bc|de:rhs):b
 	E_jumps_jc_jnc(self.n[0]);
 }
 
-gen BLTS2(de, hl):b uses a|bc
+gen BLTS2(hl, de):b uses a|bc
 {
 	E_callhelper("_cmps2");
-	E_jumps_jc_jnc(self.n[0]);
+	E_jumps_jm_jp(self.n[0]);
 }
 
-gen BEQU4(hlhl, dede):b uses a
+gen BEQU4(dede, hlhl):b uses a
 {
-	E_callhelper("_cmpeq4");
+	E_callhelper("_cmpu4");
 	E_jumps_jz_jnz(self.n[0]);
 }
 
-gen BEQS4(hlhl, dede):b uses a
+gen BEQS4(dede, hlhl):b uses a
 {
-	E_callhelper("_cmpeq4");
+	E_callhelper("_cmpu4");
 	E_jumps_jz_jnz(self.n[0]);
 }
 
@@ -1521,7 +1534,7 @@ gen BLTU4(hlhl, dede):b
 gen BLTS4(hlhl, dede):b
 {
 	E_callhelper("_cmps4");
-	E_jumps_jc_jnc(self.n[0]);
+	E_jumps_jm_jp(self.n[0]);
 }
 	
 // --- Case -----------------------------------------------------------------
@@ -1625,7 +1638,7 @@ gen hlhl := CAST24(hl, sext==0)
 	E_exx();
 }
 
-gen hlhl := CAST24(hl, sext==0) uses a
+gen hlhl := CAST24(hl, sext!=0) uses a
 {
 	E_mov(REG_A, REG_L);
 	E_rra();

--- a/src/cowcom/archz80.cow.ng
+++ b/src/cowcom/archz80.cow.ng
@@ -116,12 +116,16 @@
 		E_nl();
 	end sub;
 
-	sub E_jmp(label: LabelRef)
-		E_jump("jmp", label);
+	sub E_jp(label: LabelRef)
+		E_jump("jp", label);
 	end sub;
 
 	sub E_jnz(label: LabelRef)
-		E_jump("jnz", label);
+		E_jump("jp nz,", label);
+	end sub;
+
+	sub E_ret()
+		E("\tret\n");
 	end sub;
 
 	sub E_call(subr: [Subroutine])
@@ -134,10 +138,13 @@
 
 	sub loreg(reg: RegId): (result: RegId)
 		case reg is
-			when REG_A:  result := REG_A;
-			when REG_BC: result := REG_C;
-			when REG_DE: result := REG_E;
-			when REG_HL: result := REG_L;
+			when REG_A:    result := REG_A;
+			when REG_BC:   result := REG_C;
+			when REG_DE:   result := REG_E;
+			when REG_HL:   result := REG_L;
+			when REG_BCBC: result := REG_C;
+			when REG_DEDE: result := REG_E;
+			when REG_HLHL: result := REG_L;
 			when else:
 				SimpleError("bad loreg");
 		end case;
@@ -145,10 +152,13 @@
 
 	sub hireg(reg: RegId): (result: RegId)
 		case reg is
-			when REG_A:  result := REG_A;
-			when REG_BC: result := REG_B;
-			when REG_DE: result := REG_D;
-			when REG_HL: result := REG_H;
+			when REG_A:    result := REG_A;
+			when REG_BC:   result := REG_B;
+			when REG_DE:   result := REG_D;
+			when REG_HL:   result := REG_H;
+			when REG_BCBC: result := REG_B;
+			when REG_DEDE: result := REG_D;
+			when REG_HLHL: result := REG_H;
 			when else:
 				SimpleError("bad hireg");
 		end case;
@@ -156,59 +166,188 @@
 
 	sub E_reg(reg: RegId)
 		case reg is
-			when REG_A: EmitByte('a');
-			when REG_B: EmitByte('b');
-			when REG_C: EmitByte('c');
-			when REG_D: EmitByte('d');
-			when REG_E: EmitByte('e');
-			when REG_H: EmitByte('h');
-			when REG_L: EmitByte('l');
-			when REG_BC: EmitByte('b');
-			when REG_DE: EmitByte('d');
-			when REG_HL: EmitByte('h');
+			when REG_A:    E("a");
+			when REG_B:    E("b");
+			when REG_C:    E("c");
+			when REG_D:    E("d");
+			when REG_E:    E("e");
+			when REG_H:    E("h");
+			when REG_L:    E("l");
+			when REG_BC:   E("bc");
+			when REG_DE:   E("de");
+			when REG_HL:   E("hl");
+			when REG_IX:   E("ix");
+			when REG_IY:   E("iy");
+			when REG_BCBC: E("bc");
+			when REG_DEDE: E("de");
+			when REG_HLHL: E("hl");
 			when else:
-				StartError();
-				print("invalid register 0x");
-				print_hex_i16(reg);
-				EndError();
+				SimpleError("bad reg");
 		end case;
 	end sub;
 
-	sub E_stackreg(reg: RegId)
+	sub E_stackref(reg: RegId)
 		if reg == REG_A then
-			E("psw");
+			E("af");
 		else
 			E_reg(reg);
 		end if;
 	end sub;
 
-	sub E_ret()
-		E("\tret\n");
-	end sub;
-
 	sub E_mov(dest: RegId, src: RegId)
 		R_flush(dest);
 		E_tab();
-		E("mov ");
+		E("ld ");
 		E_reg(dest);
 		E_comma();
 		E_reg(src);
 		E_nl();
 	end sub;
 
+	sub E_ex()
+		R_flush(REG_HL|REG_DE);
+		E("\tex de,hl\n");
+	end sub;
+
+	sub E_exx()
+		R_flush(REG_HL|REG_DE|REG_BC);
+		E("\texx\n");
+	end sub;
+
 	sub E_push(src: RegId)
-		E_tab();
-		E("push ");
-		E_stackreg(src);
+		if (src & (REG_HLHL|REG_BCBC|REG_DEDE)) != 0 then
+			E_exx();
+			E("\tpush ");
+			E_stackref(src);
+			E_nl();
+			E_exx();
+		end if;
+
+		E("\tpush ");
+		E_stackref(src);
 		E_nl();
 	end sub;
 
 	sub E_pop(dest: RegId)
 		R_flush(dest);
-		E_tab();
-		E("pop ");
-		E_stackreg(dest);
+		E("\tpop ");
+		E_stackref(dest);
 		E_nl();
+
+		if (dest & (REG_HLHL|REG_BCBC|REG_DEDE)) != 0 then
+			E_exx();
+			E("\tpop ");
+			E_stackref(dest);
+			E_nl();
+			E_exx();
+		end if;
+	end sub;
+
+	sub E_loadm(reg: RegId)
+		R_flush(reg);
+		E("\tld ");
+		E_reg(reg);
+		E(",(hl)\n");
+	end sub;
+
+	sub E_storem(reg: RegId)
+		RegCacheFlushValues();
+		E("\tld (hl),");
+		E_reg(reg);
+		E_nl();
+	end sub;
+
+	sub E_stax(ptr: RegId)
+		RegCacheFlushValues();
+		E("\tld a, (");
+		E_reg(ptr);
+		E(")\n");
+		RegCacheFlushValues();
+	end sub;
+
+	sub E_ldax(ptr: RegId)
+		RegCacheFlushValues();
+		R_flush(REG_A);
+		E("\tld (");
+		E_reg(ptr);
+		E("), a\n");
+		E_nl();
+	end sub;
+
+	sub E_lda(sym: [Symbol], off: Size)
+		var cache := RegCacheFindValue(sym, off);
+		if (cache & REG_A) != 0 then
+			# Value already in the right register.
+			return;
+		end if; # Other cases don't happen on the 8080.
+
+		R_flush(REG_A);
+		E("\tld a, (");
+		E_symref(sym, off);
+		E(")\n");
+		RegCacheLeavesValue(REG_A, sym, off);
+	end sub;
+
+	sub E_sta(sym: [Symbol], off: Size)
+		E("\tld (");
+		E_symref(sym, off);
+		E("), a\n");
+		RegCacheLeavesValue(REG_A, sym, off);
+	end sub;
+
+	sub E_load8i(dest: RegId, index: RegId, off: int8)
+		RegCacheFlushValues();
+		E("\tld ");
+		E_reg(dest);
+		E(", (");
+		E_reg(index);
+		E_i8(off);
+		E(")\n");
+	end sub;
+
+	sub E_store8i(src: RegId, index: RegId, off: int8)
+		RegCacheFlushValues();
+		E("\tld (");
+		E_reg(index);
+		E_i8(off);
+		E("), ");
+		E_reg(src);
+		E_nl();
+	end sub;
+
+	sub E_store8ic(val: uint8, index: RegId, off: int8)
+		RegCacheFlushValues();
+		E("\tld (");
+		E_reg(index);
+		E_i8(off);
+		E("), ");
+		E_u8(val);
+		E_nl();
+	end sub;
+
+	sub E_load16(dest: RegId, sym: [Symbol], off: Size)
+		var cache := RegCacheFindValue(sym, off);
+		if (cache & dest) != 0 then
+			# Value already in the right register.
+			return;
+		end if;
+
+		R_flush(dest);
+		E("\tld ");
+		E_reg(dest);
+		E(", (");
+		E_symref(sym, off);
+		E(")\n");
+		RegCacheLeavesValue(REG_HL, sym, off);
+	end sub;
+
+	sub E_store16(src: RegId, sym: [Symbol], off: Size)
+		E("\tld (");
+		E_symref(sym, off);
+		E("), ");
+		E_reg(src);
+		E_nl();
+		RegCacheLeavesValue(REG_HL, sym, off);
 	end sub;
 
 	sub E_mvi(reg: RegId, value: uint8)
@@ -228,12 +367,63 @@
 		end if;
 
 		R_flush(reg);
-		E("\tmvi ");
+		E("\tld ");
 		E_reg(reg);
 		E_comma();
 		E_u8(value);
 		E_nl();
 		RegCacheLeavesConstant(reg, value as CacheValue);
+	end sub;
+
+	sub E_lxi(reg: RegId, value: uint16);
+		var cache := RegCacheFindConstant(value as CacheValue) & (REG_HL|REG_BC|REG_DE|REG_IX|REG_IY);
+		if (cache & reg) != 0 then
+			# The value is already in the desired register.
+			return;
+		elseif cache != 0 then
+			# The value is already in a register, but not this one.
+			cache := FindFirst(cache);
+			if ((reg | cache) & (REG_IX|REG_IY)) != 0 then
+				E_mov(loreg(reg), loreg(cache));
+				E_mov(hireg(reg), hireg(cache));
+			else
+				E_push(cache);
+				E_pop(reg);
+			end if;
+			return;
+		end if;
+
+		R_flush(reg);
+		E("\tld ");
+		E_reg(reg);
+		E_comma();
+		E_u16(value);
+		E_nl();
+		RegCacheLeavesConstant(reg, value as CacheValue);
+		RegCacheLeavesConstant(loreg(reg), value as uint8 as CacheValue);
+		RegCacheLeavesConstant(hireg(reg), (value>>8) as uint8 as CacheValue);
+	end sub;
+
+	sub E_lxia(reg: RegId, sym: [Symbol], off: Size)
+		var cache := RegCacheFindAddress(sym, off) & (REG_HL|REG_BC|REG_DE|REG_IX|REG_IY);
+		if (cache & reg) != 0 then
+			# The value is already in the desired register.
+			return;
+		#elseif cache != 0 then
+		#	# The value is already in a register, but not this one.
+		#	cache := FindFirst(cache);
+		#	E_mov(loreg(reg), loreg(cache));
+		#	E_mov(hireg(reg), hireg(cache));
+		#	return;
+		end if;
+
+		R_flush(reg);
+		E("\tld ");
+		E_reg(reg);
+		E_comma();
+		E_symref(sym, off);
+		E_nl();
+		#RegCacheLeavesAddress(reg, sym, off);
 	end sub;
 
 	sub E_alu(insn: string, rhs: RegId)
@@ -245,31 +435,39 @@
 		E_nl();
 	end sub;
 
-	sub E_xra(rhs: RegId)
-		E_alu("xra", rhs);
-		if rhs == REG_A then
-			RegCacheLeavesConstant(REG_A, 0);
-		end if;
+	sub E_cp(rhs: RegId)
+		E("\tcp ");
+		E_reg(rhs);
+		E_nl();
 	end sub;
 
-	sub E_ora(rhs: RegId)
-		E_alu("ora", rhs);
+	sub E_rra()
+		R_flush(REG_A);
+		E("\trra\n");
 	end sub;
 
-	sub E_ana(rhs: RegId)
-		E_alu("ana", rhs);
-	end sub;
-
-	sub E_add(rhs: RegId)
-		E_alu("add", rhs);
+	sub E_cpl()
+		R_flush(REG_A);
+		E("\tcpl\n");
 	end sub;
 
 	sub E_sub(rhs: RegId)
 		E_alu("sub", rhs);
 	end sub;
 
-	sub E_sbb(rhs: RegId)
-		E_alu("sbb", rhs);
+	sub E_and(rhs: RegId)
+		E_alu("and", rhs);
+	end sub;
+
+	sub E_or(rhs: RegId)
+		E_alu("or", rhs);
+	end sub;
+
+	sub E_xor(rhs: RegId)
+		E_alu("xor", rhs);
+		if rhs == REG_A then
+			RegCacheLeavesConstant(REG_A, 0);
+		end if;
 	end sub;
 
 	sub E_alui(insn: string, value: uint8)
@@ -281,161 +479,37 @@
 		E_nl();
 	end sub;
 
-	sub E_cmp(reg: RegId);
-		E_alu("cmp", reg);
+	sub E_addi(value: uint8)
+		E_alui("add", value);
 	end sub;
 
-	sub E_cpi(value: uint8)
-		E_alui("cpi", value);
+	sub E_adci(value: uint8)
+		E_alui("adc", value);
 	end sub;
 
-	sub E_adi(value: uint8)
-		E_alui("adi", value);
+	sub E_subi(value: uint8)
+		E_alui("sub", value);
 	end sub;
 
-	sub E_sui(value: uint8)
-		E_alui("sui", value);
-	end sub;
-
-	sub E_sbi(value: uint8)
-		E_alui("sbi", value);
+	sub E_sbci(value: uint8)
+		E_alui("sbc", value);
 	end sub;
 
 	sub E_ori(value: uint8)
-		E_alui("ori", value);
+		E_alui("or", value);
 	end sub;
 
-	sub E_ani(value: uint8)
-		E_alui("ani", value);
+	sub E_xori(value: uint8)
+		E_alui("xor", value);
 	end sub;
 
-	sub E_xri(value: uint8)
-		E_alui("xri", value);
+	sub E_andi(value: uint8)
+		E_alui("and", value);
 	end sub;
 
-	sub E_lxi(reg: RegId, value: uint16);
-		var cache := RegCacheFindConstant(value as CacheValue) & (REG_HL|REG_BC|REG_DE);
-		if (cache & reg) != 0 then
-			# The value is already in the desired register.
-			return;
-		elseif cache != 0 then
-			# The value is already in a register, but not this one.
-			cache := FindFirst(cache);
-			E_mov(loreg(reg), loreg(cache));
-			E_mov(hireg(reg), hireg(cache));
-			return;
-		end if;
-
-		R_flush(reg);
-		E("\tlxi ");
-		E_reg(reg);
-		E_comma();
-		E_u16(value);
-		E_nl();
-		RegCacheLeavesConstant(reg, value as CacheValue);
-		RegCacheLeavesConstant(loreg(reg), value as uint8 as CacheValue);
-		RegCacheLeavesConstant(hireg(reg), (value>>8) as uint8 as CacheValue);
-	end sub;
-
-	sub E_lxia(reg: RegId, sym: [Symbol], off: Size)
-		# This optimisation is essentially not worth it on the 8080.
-		#var cache := RegCacheFindAddress(sym, off) & (REG_HL|REG_BC|REG_DE);
-		#if (cache & reg) != 0 then
-		#	# The value is already in the desired register.
-		#	return;
-		#elseif cache != 0 then
-		#	# The value is already in a register, but not this one.
-		#	cache := FindFirst(cache);
-		#	E_mov(loreg(reg), loreg(cache));
-		#	E_mov(hireg(reg), hireg(cache));
-		#	return;
-		#end if;
-
-		R_flush(reg);
-		E("\tlxi ");
-		E_reg(reg);
-		E_comma();
-		E_symref(sym, off);
-		E_nl();
-		#RegCacheLeavesAddress(reg, sym, off);
-	end sub;
-
-	sub E_lda(sym: [Symbol], off: Size)
-		var cache := RegCacheFindValue(sym, off);
-		if (cache & REG_A) != 0 then
-			# Value already in the right register.
-			return;
-		end if; # Other cases don't happen on the 8080.
-
-		R_flush(REG_A);
-		E("\tlda ");
-		E_symref(sym, off);
-		E_nl();
-		RegCacheLeavesValue(REG_A, sym, off);
-	end sub;
-
-	sub E_sta(sym: [Symbol], off: Size)
-		E("\tsta ");
-		E_symref(sym, off);
-		E_nl();
-		RegCacheLeavesValue(REG_A, sym, off);
-	end sub;
-
-	sub E_lhld(sym: [Symbol], off: Size)
-		var cache := RegCacheFindValue(sym, off);
-		if (cache & REG_HL) != 0 then
-			# Value already in the right register.
-			return;
-		end if; # Other cases don't happen on the 8080.
-
-		R_flush(REG_HL);
-		E("\tlhld ");
-		E_symref(sym, off);
-		E_nl();
-		RegCacheLeavesValue(REG_HL, sym, off);
-	end sub;
-
-	sub E_shld(sym: [Symbol], off: Size)
-		E("\tshld ");
-		E_symref(sym, off);
-		E_nl();
-		RegCacheLeavesValue(REG_HL, sym, off);
-	end sub;
-
-	sub E_loadm(reg: RegId)
-		R_flush(reg);
-		E("\tmov ");
-		E_reg(reg);
-		E(",m\n");
-	end sub;
-
-	sub E_storem(reg: RegId)
-		RegCacheFlushValues();
-		E("\tmov m,");
-		E_reg(reg);
-		E_nl();
-	end sub;
-
-	sub E_storemc(value: uint8)
-		RegCacheFlushValues();
-		E("\tmvi m,");
+	sub E_cpi(value: uint8)
+		E("\tcp ");
 		E_u8(value);
-		E_nl();
-	end sub;
-
-	sub E_stax(ptr: RegId)
-		RegCacheFlushValues();
-		E("\tstax ");
-		E_reg(ptr);
-		E_nl();
-		RegCacheFlushValues();
-	end sub;
-
-	sub E_ldax(ptr: RegId)
-		RegCacheFlushValues();
-		R_flush(REG_A);
-		E("\tldax ");
-		E_reg(ptr);
 		E_nl();
 	end sub;
 
@@ -453,50 +527,44 @@
 		E_nl();
 	end sub;
 
-	sub E_inx(reg: RegId)
+	sub E_alu2(insn: string, lhs: RegId, rhs: RegId)
+		R_flush(lhs);
+		E_tab();
+		E(insn);
+		E_space();
+		E_reg(lhs);
+		E_comma();
+		E_reg(rhs);
+		E_nl();
+	end sub;
+
+	sub E_add(lhs: RegId, rhs: RegId)
+		E_alu2("add", lhs, rhs);
+	end sub;
+
+	sub E_adc(lhs: RegId, rhs: RegId)
+		E_alu2("adc", lhs, rhs);
+	end sub;
+
+	sub E_sbc(lhs: RegId, rhs: RegId)
+		E_alu2("sbc", lhs, rhs);
+	end sub;
+
+	sub E_shift(insn: string, reg: RegId)
 		R_flush(reg);
-		E("\tinx ");
+		E_tab();
+		E(insn);
+		E_space();
 		E_reg(reg);
 		E_nl();
 	end sub;
 
-	sub E_dcx(reg: RegId)
-		R_flush(reg);
-		E("\tdcx ");
-		E_reg(reg);
-		E_nl();
+	sub E_sra(reg: RegId)
+		E_shift("sra", reg);
 	end sub;
 
-	sub E_xchg()
-		R_flush(REG_HL|REG_DE);
-		E("\txchg\n");
-	end sub;
-
-	sub E_pchl()
-		R_flushall();
-		E("\tpchl\n");
-	end sub;
-
-	sub E_cma()
-		R_flush(REG_A);
-		E("\tcma\n");
-	end sub;
-
-	sub E_ral()
-		R_flush(REG_A);
-		E("\tral\n");
-	end sub;
-
-	sub E_rar()
-		R_flush(REG_A);
-		E("\trar\n");
-	end sub;
-
-	sub E_dad(reg: RegId)
-		R_flush(REG_HL);
-		E("\tdad ");
-		E_reg(reg);
-		E_nl();
+	sub E_srl(reg: RegId)
+		E_shift("srl", reg);
 	end sub;
 
 	# Does not persist the name; only call this with constant strings.
@@ -563,7 +631,6 @@
 		E_u16(sid);
 	end sub;
 
-	# Note that this *destroys* the source register.
 	sub ArchEmitMove(src: RegId, dest: RegId)
 		if src == 0 then
 			E_pop(dest);
@@ -571,7 +638,23 @@
 			E_push(src);
 		elseif ((src == REG_HL) and (dest == REG_DE))
 				or ((src == REG_DE) and (dest == REG_HL)) then
-			E_xchg();
+			E_ex();
+		elseif ((src == REG_HLHL) and (dest == REG_DEDE))
+				or ((src == REG_DEDE) and (dest == REG_HLHL)) then
+			E_ex();
+			E_exx();
+			E_ex();
+			E_exx();
+		elseif ((src|dest) & (REG_HLHL|REG_DEDE|REG_BCBC)) != 0 then
+			E_mov(loreg(dest), loreg(src));
+			E_mov(hireg(dest), hireg(src));
+			E_exx();
+			E_mov(loreg(dest), loreg(src));
+			E_mov(hireg(dest), hireg(src));
+			E_exx();
+		elseif ((src|dest) & (REG_IX|REG_IY)) != 0 then
+			E_push(src);
+			E_pop(dest);
 		else
 			E_mov(dest, src);
 
@@ -587,17 +670,25 @@
 
 width 16;
 
-register a b c d e h l hl de bc;
-register stk4 param;
+register a b c d e h l hl de bc hlhl dede bcbc ix iy;
+register param;
 
-regdata a              compatible a|b|d|h;
-regdata b  uses bc|b|c compatible a|b|d|h;
-regdata d  uses de|d|e compatible a|b|d|h;
-regdata h  uses hl|h|l compatible a|b|d|h;
-regdata bc uses bc|b|c compatible bc|de|hl;
-regdata de uses de|d|e compatible bc|de|hl;
-regdata hl uses hl|h|l compatible bc|de|hl;
-regdata stk4 stacked;
+regclass r8 := a|b|d|h;
+regclass r16 := hl|de|bc|ix|iy;
+regclass r32 := hlhl|dede|bcbc;
+
+regdata a                     compatible r8;
+regdata b    uses bcbc|bc|b|c compatible r8;
+regdata d    uses dede|de|d|e compatible r8;
+regdata h    uses hlhl|hl|h|l compatible r8;
+regdata bc   uses bcbc|bc|b|c compatible r16;
+regdata de   uses dede|de|d|e compatible r16;
+regdata hl   uses hlhl|hl|h|l compatible r16;
+regdata bcbc uses bcbc|bc|b|c compatible r32;
+regdata dede uses dede|de|d|e compatible r32;
+regdata hlhl uses hlhl|hl|h|l compatible r32;
+regdata ix                    compatible r16;
+regdata iy                    compatible r16;
 regdata param stacked;
 
 // --- Core things ----------------------------------------------------------
@@ -612,7 +703,7 @@ gen LABEL():b
 
 gen JUMP():j
 {
-	E_jmp($j.label);
+	E_jp($j.label);
 }
 
 // --- Subroutines ----------------------------------------------------------
@@ -660,14 +751,14 @@ gen STARTSUB():s
 					pop_return_address();
 					E_pop(REG_HL);
 				end if;
-				E_shld(param, 0);
+				E_store16(REG_HL, param, 0);
 
 			when 4:
 				pop_return_address();
 				E_pop(REG_HL);
-				E_shld(param, 0);
+				E_store16(REG_HL, param, 0);
 				E_pop(REG_HL);
-				E_shld(param, 2);
+				E_store16(REG_HL, param, 2);
 		end case;
 	end loop;
 
@@ -707,7 +798,7 @@ gen ENDSUB():s
 				end if;
 
 			when 2:
-				E_lhld(param, 0);
+				E_load16(REG_HL, param, 0);
 				if count != (params-1) then
 					push_return_address();
 					E_push(REG_HL);
@@ -715,9 +806,9 @@ gen ENDSUB():s
 
 			when 4:
 				push_return_address();
-				E_lhld(param, 2);
+				E_load16(REG_HL, param, 2);
 				E_push(REG_HL);
-				E_lhld(param, 0);
+				E_load16(REG_HL, param, 0);
 				E_push(REG_HL);
 		end case;
 
@@ -742,7 +833,7 @@ gen a := CALLE1():s
 gen hl := CALLE2():s
 		{ E_call($s.subr); }
 
-gen stk4 := CALLE4():s
+gen hlhl := CALLE4():s
 		{ E_call($s.subr); }
 
 gen PUSHARG1(a, remaining==0);
@@ -758,29 +849,32 @@ gen PUSHARG2(bc|de|hl:lhs, remaining!=0)
 gen PUSHARG2(CALLE2():s)
 		{ E_call($s.subr); }
 
-gen PUSHARG4(stk4); // already stacked
+gen PUSHARG4(hlhl, remaining==0);
 
-gen PUSHARG4(CALLE4():s)
-		{ E_call($s.subr); }
+gen PUSHARG4(r32:lhs, remaining!=0)
+		{ E_push($lhs); }
 
 gen a := POPARG1(remaining==0);
 
-gen a|b|d|h := POPARG1(remaining!=0)
+gen r8 := POPARG1(remaining!=0)
 		{ E_pop($$); }
 
 gen hl := POPARG2(remaining==0);
 
-gen hl|bc|de := POPARG2()
+gen r16 := POPARG2()
 		{ E_pop($$); }
 
-gen stk4 := POPARG4();
+gen hlhl := POPARG4(remaining==0);
+
+gen r32 := POPARG4()
+		{ E_pop($$); }
 
 gen RETURN()
 {
     if current_subr.num_output_parameters == 0 then
 		E_ret();
 	else
-		E("\tjmp end_");
+		E("\tjp end_");
 		E_subref(current_subr);
 		E("\n");
 	end if;
@@ -788,31 +882,31 @@ gen RETURN()
 
 // --- Constants ------------------------------------------------------------
 
-gen a|b|d|h := CONSTANT():rhs
+gen r8 := CONSTANT():rhs
 {
 	if ($rhs.value == 0) and ($$ == REG_A) then
-		E_xra(REG_A);
+		E_xor(REG_A);
 	else
 		E_mvi($$, $rhs.value as uint8);
 	end if;
 }
 
-gen bc|de|hl := CONSTANT():rhs
+gen r16 := CONSTANT():rhs
 {
 	E_lxi($$, $rhs.value as uint16);
 }
 
-gen stk4 := CONSTANT():rhs uses hl
-{
-	E_lxi(REG_HL, ($rhs.value >> 16) as uint16);
-	E_push(REG_HL);
-	E_lxi(REG_HL, $rhs.value as uint16);
-	E_push(REG_HL);
-}
-
-gen bc|de|hl := ADDRESS():a
+gen r16 := ADDRESS():a
 {
 	E_lxia($$, $a.sym, $a.off);
+}
+
+gen r32 := CONSTANT():c
+{
+	E_lxi($$, $c.value as uint16);
+	E_exx();
+	E_lxi($$, ($c.value>>16) as uint16);
+	E_exx();
 }
 
 // --- 8-bit loads and stores -----------------------------------------------
@@ -822,7 +916,7 @@ gen a := LOAD1(ADDRESS():a)
 	E_lda($a.sym, $a.off);
 }
 
-gen a := LOAD1(bc|de|hl:ptr)
+gen a := LOAD1(hl|bc|de:ptr)
 {
 	if $ptr == REG_HL then
 		E_loadm(REG_A);
@@ -831,12 +925,17 @@ gen a := LOAD1(bc|de|hl:ptr)
 	end if;
 }
 
+//gen r8 := LOAD1(ADD2(ix|iy:ptr, CONSTANT():c))
+//{
+//	E_load8i($$, $ptr, $c.value as int8);
+//}
+
 gen STORE1(a, ADDRESS():a)
 {
 	E_sta($a.sym, $a.off);
 }
 
-gen STORE1(a, bc|de|hl:ptr)
+gen STORE1(a, hl|bc|de:ptr)
 {
 	if $ptr == REG_HL then
 		E_storem(REG_A);
@@ -845,63 +944,97 @@ gen STORE1(a, bc|de|hl:ptr)
 	end if;
 }
 
-// This looks useful, but actually produces slightly worse code.
-//gen STORE1(CONSTANT():c, hl)
+//gen STORE1(r8:r, ADD2(ix|iy:ptr, CONSTANT():c))
 //{
-//	E_storemc($c.value as uint8);
+//	E_store8i($r, $ptr, $c.value as int8);
+//}
+//
+//gen STORE1(CONSTANT():v, ADD2(ix|iy:ptr, CONSTANT():c))
+//{
+//	E_store8ic($v.value as uint8, $ptr, $c.value as int8);
 //}
 
 // --- 16-bit loads and stores ----------------------------------------------
 
-gen hl := LOAD2(ADDRESS():a)
+gen r16 := LOAD2(ADDRESS():a)
 {
-	E_lhld($a.sym, $a.off);
+	E_load16($$, $a.sym, $a.off);
 }
 
 %{
 	sub load2(dest: RegId)
 		if dest == REG_HL then
 			E_loadm(REG_A);
-			E_inx(REG_HL);
+			E_inc(REG_HL);
 			E_loadm(dest);
 			E_mov(loreg(dest), REG_A);
 		else
 			E_loadm(loreg(dest));
-			E_inx(REG_HL);
+			E_inc(REG_HL);
 			E_loadm(dest);
 		end if;
 	end sub;
 %}
 
-gen hl|bc|de := LOAD2(hl) uses a
+gen r16 := LOAD2(hl) uses a
 {
 	load2($$);
 }
 
-gen STORE2(hl, ADDRESS():a)
+gen STORE2(r16:ptr, ADDRESS():a)
 {
-	E_shld($a.sym, $a.off);
+	E_store16($ptr, $a.sym, $a.off);
 }
 
 gen STORE2(bc|de:val, hl) uses a
 {
 	E_storem(loreg($val));
-	E_inx(REG_HL);
+	E_inc(REG_HL);
 	E_storem($val);
 }
 
 // --- 32-bit loads and stores ----------------------------------------------
 
-gen stk4 := LOAD4(hl)
-		{ E_callhelper("_load4"); }
+gen r32 := LOAD4(ix|iy:ptr)
+{
+	E_load8i(loreg($$), $ptr, 0);
+	E_load8i(hireg($$), $ptr, 1);
+	E_exx();
+	E_load8i(loreg($$), $ptr, 2);
+	E_load8i(hireg($$), $ptr, 3);
+	E_exx();
+}
 
-gen STORE4(stk4, hl)
-		{ E_callhelper("_store4"); }
+gen r32 := LOAD4(ADDRESS():a)
+{
+	E_load16($$, $a.sym, $a.off);
+	E_exx();
+	E_load16($$, $a.sym, $a.off+2);
+	E_exx();
+}
+
+gen STORE4(r32:val, ix|iy:ptr)
+{
+	E_store8i(loreg($val), $ptr, 0);
+	E_store8i(hireg($val), $ptr, 1);
+	E_exx();
+	E_store8i(loreg($val), $ptr, 2);
+	E_store8i(hireg($val), $ptr, 3);
+	E_exx();
+}
+
+gen STORE4(r32:val, ADDRESS():a)
+{
+	E_store16($val, $a.sym, $a.off);
+	E_exx();
+	E_store16($val, $a.sym, $a.off+2);
+	E_exx();
+}
 
 // --- 8-bit arithmetic -----------------------------------------------------
 
 gen a := ADD1(b|d|h:lhs, a)
-		{ E_add($lhs); }
+		{ E_add(REG_A, $lhs); }
 
 gen a|b|d|h := ADD1($$, CONSTANT(value==-1))
 		{ E_dec($$); }
@@ -910,7 +1043,7 @@ gen a|b|d|h := ADD1($$, CONSTANT(value==1))
 		{ E_inc($$); }
 
 gen a := ADD1(a, CONSTANT():c)
-		{ E_adi($c.value as uint8); }
+		{ E_addi($c.value as uint8); }
 
 gen a := SUB1(a, b|d|h:rhs)
 		{ E_sub($rhs); }
@@ -919,37 +1052,37 @@ gen a|b|d|h := SUB1($$, CONSTANT(value==1))
 		{ E_dec($$); }
 
 gen a := SUB1(a, CONSTANT():c)
-		{ E_sbi($c.value as uint8); }
+		{ E_subi($c.value as uint8); }
 
-gen a := MUL1(b, d)
+gen a := MUL1(d, h)
 		{ E_callhelper("_mul1"); }
 
 gen a := NOT1(a)
-		{ E_cma(); }
+		{ E_cpl(); }
 
 gen a := NEG1(b|d|h:lhs)
 {
-	E_xra(REG_A);
+	E_xor(REG_A);
 	E_sub($lhs);
 }
 
 gen a := OR1(a, b|d|h:lhs)
-		{ E_ora($lhs); }
+		{ E_or($lhs); }
 
 gen a := OR1(a, CONSTANT():c)
 		{ E_ori($c.value as uint8); }
 
 gen a := AND1(a, b|d|h:lhs)
-		{ E_ana($lhs); }
+		{ E_and($lhs); }
 
 gen a := AND1(a, CONSTANT():c)
-		{ E_ani($c.value as uint8); }
+		{ E_andi($c.value as uint8); }
 
 gen a := EOR1(a, b|d|h:lhs)
-		{ E_xra($lhs); }
+		{ E_xor($lhs); }
 
 gen a := EOR1(a, CONSTANT():c)
-		{ E_xri($c.value as uint8); }
+		{ E_xori($c.value as uint8); }
 
 gen b := DIVU1(b, d) uses a
 		{ E_callhelper("_dvrmu1"); }
@@ -963,7 +1096,7 @@ gen b := DIVS1(b, d) uses a
 gen d := REMS1(b, d)
 		{ E_callhelper("_dvrms1"); }
 
-gen a := RSHIFTS1(a, b) uses bc
+gen a := RSHIFTS1(a, b)
 		{ E_callhelper("_asr1"); }
 
 gen a := RSHIFTU1(a, b) uses bc
@@ -976,17 +1109,25 @@ gen a := LSHIFT1(a, CONSTANT(value<=5):c)
 {
 	var i := $c.value as uint8;
 	while i != 0 loop
-		E_add(REG_A);
+		E_add(REG_A, REG_A);
 		i := i - 1;
 	end loop;
 }
 
-gen a := RSHIFTU1(a, CONSTANT(value<=2):c)
+gen r8 := RSHIFTU1($$, CONSTANT(value<=3):c)
 {
 	var i := $c.value as uint8;
 	while i != 0 loop
-		E_ora(REG_A);
-		E_rar();
+		E_srl($$);
+		i := i - 1;
+	end loop;
+}
+
+gen r8 := RSHIFTS1($$, CONSTANT(value<=3):c)
+{
+	var i := $c.value as uint8;
+	while i != 0 loop
+		E_sra($$);
 		i := i - 1;
 	end loop;
 }
@@ -1011,55 +1152,60 @@ gen a := RSHIFTU1(a, CONSTANT(value<=2):c)
 	end sub;
 %}
 		
-gen hl|bc|de := ADD2($$, CONSTANT(value is small_positive):c)
+gen r16 := ADD2($$, CONSTANT(value is small_positive):c)
 {
 	var i: uint8 := $c.value as uint8;
 	while i != 0 loop
-		E_inx($$);
+		E_inc($$);
 		i := i - 1;
 	end loop;
 }
 
-gen hl|bc|de := ADD2($$, CONSTANT(value is small_negative):c)
+gen r16 := ADD2($$, CONSTANT(value is small_negative):c)
 {
 	var i: uint8 := $c.value as uint8;
 	while i != 0 loop
-		E_dcx($$);
+		E_dec($$);
 		i := i + 1;
 	end loop;
 }
-
+	
 gen hl := ADD2(hl|bc|de:lhs, hl|bc|de:rhs)
 {
 	if ($lhs != REG_HL) and ($rhs != REG_HL) then
 		if $rhs == REG_DE then
-			E_xchg();
+			E_ex();
 			$rhs := REG_HL;
 		else
 			if $lhs == REG_DE then
-				E_xchg();
+				E_ex();
 			else
-				ArchEmitMove($lhs, REG_HL);
+				E_mov(REG_L, loreg($lhs));
+				E_mov(REG_H, hireg($lhs));
 			end if;
 			$lhs := REG_HL;
 		end if;
 	end if;
 
 	if $lhs == REG_HL then
-		E_dad($rhs);
+		E_add(REG_HL, $rhs);
 	else
-		E_dad($lhs);
+		E_add(REG_HL, $lhs);
 	end if;
 }
 
-gen bc|de|hl := NEG2(bc|de|hl:lhs) uses a
+gen hl := NEG2(bc|de:lhs) uses a
 {
-	E_xra(REG_A);
-	E_sub(loreg($lhs));
-	E_mov(loreg($$), REG_A);
-	E_sbb(REG_A);
-	E_sub($lhs);
-	E_mov($$, REG_A);
+	E_xor(REG_A);
+	E_mov(REG_A, REG_L);
+	E_mov(REG_A, REG_H);
+	E_sbc(REG_HL, $lhs);
+}
+
+gen hl := SUB2(hl:lhs, bc|de:rhs)
+{
+	E_and(REG_A);
+	E_sbc(REG_HL, $rhs);
 }
 
 %{
@@ -1081,16 +1227,6 @@ gen bc|de|hl := NEG2(bc|de|hl:lhs) uses a
 		E_mov(dest, REG_A);
 	end sub;
 %}
-
-gen bc|de|hl := SUB2(bc|de|hl:lhs, bc|de|hl:rhs) uses a
-{
-	aluop2($lhs, $rhs, $$, "sub", "sbb");
-}
-
-gen bc|de|hl := SUB2(bc|de|hl:lhs, CONSTANT():c) uses a
-{
-	aluop2i($lhs, $c.value as uint16, $$, "sui", "sbi");
-}
 
 gen de := DIVU2(de, bc) uses a
 		{ E_callhelper("_dvrmu2"); }
@@ -1118,96 +1254,122 @@ gen hl := MUL2(hl, de) uses a|bc
 %}
 
 gen bc|de|hl := OR2(bc|de|hl:lhs, bc|de|hl:rhs) uses a
-		{ logic2($lhs, $rhs, $$, "ora"); }
+		{ logic2($lhs, $rhs, $$, "or"); }
 
 gen bc|de|hl := OR2(bc|de|hl:lhs, CONSTANT():c) uses a
-		{ logic2i($lhs, $c.value as uint16, $$, "ori"); }
+		{ logic2i($lhs, $c.value as uint16, $$, "or"); }
 
 gen bc|de|hl := AND2(bc|de|hl:lhs, bc|de|hl:rhs) uses a
-		{ logic2($lhs, $rhs, $$, "ana"); }
+		{ logic2($lhs, $rhs, $$, "and"); }
 
 gen bc|de|hl := AND2(bc|de|hl:lhs, CONSTANT():c) uses a
-		{ logic2i($lhs, $c.value as uint16, $$, "ani"); }
+		{ logic2i($lhs, $c.value as uint16, $$, "and"); }
 
 gen bc|de|hl := EOR2(bc|de|hl:lhs, bc|de|hl:rhs) uses a
-		{ logic2($lhs, $rhs, $$, "xra"); }
+		{ logic2($lhs, $rhs, $$, "xor"); }
 
 gen bc|de|hl := EOR2(bc|de|hl:lhs, CONSTANT():c) uses a
-		{ logic2i($lhs, $c.value as uint16, $$, "xri"); }
+		{ logic2i($lhs, $c.value as uint16, $$, "xor"); }
 
 gen bc|de|hl := NOT2(bc|de|hl:lhs) uses a
 {
 	E_mov(REG_A, loreg($lhs));
-	E_cma();
+	E_cpl();
 	E_mov(loreg($$), REG_A);
 	E_mov(REG_A, $lhs);
-	E_cma();
+	E_cpl();
 	E_mov($$, REG_A);
 }
 
-gen hl := RSHIFTU2(hl, b) uses a
+gen hl := RSHIFTU2(hl, a)
 		{ E_callhelper("_lsr2"); }
 
-gen hl := RSHIFTS2(hl, b) uses a
+gen hl := RSHIFTS2(hl, a)
 		{ E_callhelper("_asr2"); }
 
-gen hl := LSHIFT2(hl, b) uses a
+gen hl := LSHIFT2(hl, a)
 		{ E_callhelper("_asl2"); }
 
 gen hl := LSHIFT2(hl, CONSTANT(value<=5):c)
 {
 	var i := $c.value as uint8;
 	while i != 0 loop
-		E_dad(REG_HL);
+		E_add(REG_HL, REG_HL);
 		i := i - 1;
 	end loop;
 }
 
 // --- 32-bit arithmetic ----------------------------------------------------
 
-gen stk4 := ADD4(stk4, stk4) uses a|bc|de|hl
-        { E_callhelper("_add4"); }
+gen r32 := ADD4(bcbc|dede:lhs, hlhl)
+{
+	E_add(REG_HL, $lhs);
+	E_exx();
+	E_adc(REG_HL, $lhs);
+	E_exx();
+}
 
-gen stk4 := SUB4(stk4, stk4) uses a|bc|de|hl
-        { E_callhelper("_sub4"); }
+gen r32 := SUB4(hlhl, bcbc|dede:rhs)
+{
+	E_and(REG_A);
+	E_sbc(REG_HL, $rhs);
+	E_exx();
+	E_sbc(REG_HL, $rhs);
+	E_exx();
+}
 
-gen stk4 := NEG4(stk4) uses a|bc|de|hl
-        { E_callhelper("_neg4"); }
+gen hlhl := NEG4(hlhl) uses a|bcbc
+{
+	E_xor(REG_A);
+	E_mov(REG_B, REG_A);
+	E_mov(REG_C, REG_A);
+	E_sbc(REG_HL, REG_BC);
+	E_exx();
+	E_mov(REG_B, REG_A);
+	E_mov(REG_C, REG_A);
+	E_sbc(REG_HL, REG_BC);
+	E_exx();
+}
 
-gen stk4 := MUL4(stk4, stk4) uses a|bc|de|hl
+gen hlhl := MUL4(bcbc, dede)
         { E_callhelper("_mul4"); }
 
-gen stk4 := DIVU4(stk4, stk4) uses a|bc|de|hl
+gen r32 := DIVU4(r32, r32)
         { E_callhelper("_divu4"); }
 
-gen stk4 := REMU4(stk4, stk4) uses a|bc|de|hl
+gen r32 := REMU4(r32, r32)
         { E_callhelper("_remu4"); }
 
-gen stk4 := DIVS4(stk4, stk4) uses a|bc|de|hl
+gen r32 := DIVS4(r32, r32)
         { E_callhelper("_divs4"); }
 
-gen stk4 := REMS4(stk4, stk4) uses a|bc|de|hl
+gen r32 := REMS4(r32, r32)
         { E_callhelper("_rems4"); }
 
-gen stk4 := AND4(stk4, stk4) uses a|bc|de|hl
+gen hlhl := AND4(dede, hlhl)
         { E_callhelper("_and4"); }
 
-gen stk4 := OR4(stk4, stk4) uses a|bc|de|hl
+gen hlhl := OR4(dede, hlhl)
         { E_callhelper("_or4"); }
 
-gen stk4 := EOR4(stk4, stk4) uses a|bc|de|hl
+gen hlhl := EOR4(dede, hlhl)
         { E_callhelper("_eor4"); }
 
-gen stk4 := NOT4(stk4) uses a|bc|de|hl
-        { E_callhelper("_not4"); }
+gen r32 := NOT4($$)
+{
+	E_cpl();
+	E_exx();
+	E_cpl();
+	E_exx();
+}
 
-gen stk4 := LSHIFT4(stk4, b) uses a|de|hl
+gen hlhl := LSHIFT4(hlhl, a)
         { E_callhelper("_asl4"); }
 
-gen stk4 := RSHIFTU4(stk4, b) uses a|de|hl
+gen hlhl := RSHIFTU4(hlhl, a)
         { E_callhelper("_lsr4"); }
 
-gen stk4 := RSHIFTS4(stk4, b) uses a|de|hl
+gen hlhl := RSHIFTS4(hlhl, a)
         { E_callhelper("_asr4"); }
 
 // --- Conditionals ---------------------------------------------------------
@@ -1223,39 +1385,34 @@ gen stk4 := RSHIFTS4(stk4, b) uses a|de|hl
 	end sub;
 
 	sub E_jumps_jz_jnz(node: [Node])
-		E_jumps_with_fallthrough("jz", "jnz", node);
+		E_jumps_with_fallthrough("jp z,", "jp nz,", node);
 	end sub;
 
 	sub E_jumps_jc_jnc(node: [Node])
-		E_jumps_with_fallthrough("jc", "jnc", node);
+		E_jumps_with_fallthrough("jp c,", "jp nc,", node);
 	end sub;
 
 	sub bequ1(node: [Node], nota: RegId)
-		E_cmp(nota);
+		E_cp(nota);
 		E_jumps_jz_jnz(node);
 	end sub;
 
 	sub bequ1c(node: [Node], value: uint8)
 		if value == 0 then
-			E_ora(REG_A);
+			E_or(REG_A);
 		else
 			E_cpi(value);
 		end if;
 		E_jumps_jz_jnz(node);
 	end sub;
 
-	sub bequ2(node: [Node])
-		E_callhelper("_cmpeq2");
-		E_jumps_jz_jnz(node);
-	end sub;
-
 	sub bequ2c(node: [Node], value: uint16)
 		if value != 0 then
 			E_lxi(REG_DE, -value);
-			E_dad(REG_DE);
+			E_add(REG_HL, REG_DE);
 		end if;
 		E_mov(REG_A, REG_H);
-		E_ora(REG_L);
+		E_or(REG_L);
 		E_jumps_jz_jnz(node);
 	end sub;
 
@@ -1270,7 +1427,7 @@ gen stk4 := RSHIFTS4(stk4, b) uses a|de|hl
 			label := node.beqs0.truelabel;
 		end if;
 		if label != node.beqs0.fallthrough then
-			E_jmp(label);
+			E_jp(label);
 		end if;
 	end sub;
 %}
@@ -1295,7 +1452,7 @@ gen BEQS1(a, CONSTANT():c):b
 
 gen BLTU1(a, b|d|h:rhs):b
 {
-	E_cmp($rhs);
+	E_cp($rhs);
 	E_jumps_jc_jnc(self.n[0]);
 }
 
@@ -1303,7 +1460,7 @@ gen BLTU1(a, CONSTANT():c):b
 {
 	var v := $c.value as uint8;
 	if v == 0 then
-		E_ora(REG_A);
+		E_or(REG_A);
 	else
 		E_cpi(v);
 	end if;
@@ -1313,40 +1470,27 @@ gen BLTU1(a, CONSTANT():c):b
 gen BLTS1(a, b):b
 {
 	E_callhelper("_cmps1");
-	E_jumps_with_fallthrough("jm", "jp", self.n[0]);
+	E_jumps_with_fallthrough("jp m,", "jp p,", self.n[0]);
 }
 
-gen BEQU2(de, hl):a
-		{ bequ2(self.n[0]); }
+%{
+	sub bequ2(node: [Node], lhs: RegId)
+		E_and(REG_A);
+		E_sbc(REG_HL, lhs);
+		E_jumps_jz_jnz(node);
+	end sub;
+%}
 
-gen BEQU2(hl, CONSTANT():c) uses a|de
-		{ bequ2c(self.n[0], $c.value as uint16); }
+gen BEQU2(bc|de:lhs, hl):a
+		{ bequ2(self.n[0], $lhs); }
 
-gen BEQS2(de, hl):a
-		{ bequ2(self.n[0]); }
+gen BEQS2(bc|de:lhs, hl):a
+		{ bequ2(self.n[0], $lhs); }
 
-gen BEQS2(hl, CONSTANT():c) uses a|de
-		{ bequ2c(self.n[0], $c.value as uint16); }
-
-gen BLTU2(hl|bc|de:lhs, hl|bc|de:rhs):b uses a
+gen BLTU2(hl, bc|de:rhs):b
 {
-	E_mov(REG_A, loreg($lhs));
-	E_sub(loreg($rhs));
-
-	E_mov(REG_A, $lhs);
-	E_sbb($rhs);
-
-	E_jumps_jc_jnc(self.n[0]);
-}
-
-gen BLTU2(hl|bc|de:lhs, CONSTANT():c):b uses a
-{
-	E_mov(REG_A, loreg($lhs));
-	E_sui($c.value as uint8);
-
-	E_mov(REG_A, $lhs);
-	E_sbi((($c.value as uint16) >> 8) as uint8);
-
+	E_and(REG_A);
+	E_sbc(REG_HL, $rhs);
 	E_jumps_jc_jnc(self.n[0]);
 }
 
@@ -1356,40 +1500,50 @@ gen BLTS2(de, hl):b uses a|bc
 	E_jumps_jc_jnc(self.n[0]);
 }
 
-gen BEQU4(stk4:lhs, stk4:rhs) uses a|hl|bc|de
-		{ bequ4(self.n[0]); }
+gen BEQU4(hlhl, dede):b uses a
+{
+	E_callhelper("_cmpeq4");
+	E_jumps_jz_jnz(self.n[0]);
+}
 
-gen BEQS4(stk4:lhs, stk4:rhs) uses a|hl|bc|de
-		{ bequ4(self.n[0]); }
+gen BEQS4(hlhl, dede):b uses a
+{
+	E_callhelper("_cmpeq4");
+	E_jumps_jz_jnz(self.n[0]);
+}
 
-gen BLTU4(stk4:lhs, stk4:rhs):b uses a|hl|bc|de
+gen BLTU4(hlhl, dede):b
 {
 	E_callhelper("_cmpu4");
 	E_jumps_jc_jnc(self.n[0]);
 }
 
-gen BLTS4(stk4:lhs, stk4:rhs):b uses a|hl|bc|de
+gen BLTS4(hlhl, dede):b
 {
 	E_callhelper("_cmps4");
 	E_jumps_jc_jnc(self.n[0]);
 }
-
+	
 // --- Case -----------------------------------------------------------------
 
 gen STARTCASE1(a);
 
 gen STARTCASE2(de);
 
-gen STARTCASE4(stk4)
+gen STARTCASE4(r32:val)
 {
-	E_pop(REG_BC);
+	E_push($val);
+	E_exx();
+	E_push($val);
+	E_exx();
 	E_pop(REG_DE);
+	E_pop(REG_BC);
 }
 
 gen WHENCASE1():c
 {
 	if $c.value == 0 then
-		E_ora(REG_A);
+		E_or(REG_A);
 	else
 		E_cpi($c.value as uint8);
 	end if;
@@ -1401,14 +1555,14 @@ gen WHENCASE1():c
 		if value < 0x100 then
 			E_mov(REG_A, loreg(reg));
 			if value != 0 then
-				E_sbi(value as uint8);
+				E_subi(value as uint8);
 			end if;
-			E_ora(hireg(reg));
+			E_or(hireg(reg));
 		else
 			E_lxi(REG_HL, -value);
-			E_dad(reg);
+			E_add(REG_HL, reg);
 			E_mov(REG_A, REG_H);
-			E_ora(REG_L);
+			E_or(REG_L);
 		end if;
 		E_jnz(label);
 	end sub;
@@ -1436,29 +1590,50 @@ gen hl|bc|de := CAST12(a, sext==0)
 gen hl|bc|de := CAST12(a, sext!=0)
 {
 	E_mov(loreg($$), REG_A);
-	E_ral();
-	E_sbb(REG_A);
+	E_rra();
+	E_sbc(REG_A, REG_A);
 	E_mov($$, REG_A);
 }
 
-gen stk4 := CAST14(a:rhs, sext==0) uses hl
+gen r32 := CAST14(a:rhs, sext==0)
 {
-	E_lxi(REG_HL, 0);
-	E_push(REG_HL);
-	E_mov(REG_L, REG_A);
-	E_push(REG_HL);
+	E_mov(loreg($$), REG_A);
+	E_xor(REG_A);
+	E_mov(hireg($$), REG_A);
+	E_exx();
+	E_mov(loreg($$), REG_A);
+	E_mov(hireg($$), REG_A);
+	E_exx();
 }
 
-gen stk4 := CAST14(a:rhs, sext!=0) uses hl|b
+gen r32 := CAST14(a:rhs, sext!=0)
 {
-	E_mov(REG_B, REG_A);
-	E_ral();
-	E_sbb(REG_A);
-	E_mov(REG_H, REG_A);
+	E_mov(loreg($$), REG_A);
+	E_rra();
+	E_sbc(REG_A, REG_A);
+	E_mov(hireg($$), REG_A);
+	E_exx();
+	E_mov(loreg($$), REG_A);
+	E_mov(hireg($$), REG_A);
+	E_exx();
+}
+
+gen hlhl := CAST24(hl, sext==0)
+{
+	E_exx();
+	E_lxi(REG_HL, 0);
+	E_exx();
+}
+
+gen hlhl := CAST24(hl, sext==0) uses a
+{
+	E_mov(REG_A, REG_L);
+	E_rra();
+	E_sbc(REG_A, REG_A);
+	E_exx();
 	E_mov(REG_L, REG_A);
-	E_push(REG_HL);
-	E_mov(REG_L, REG_B);
-	E_push(REG_HL);
+	E_mov(REG_H, REG_A);
+	E_exx();
 }
 
 gen a := CAST21(hl|bc|de:rhs)
@@ -1467,55 +1642,17 @@ gen a := CAST21(hl|bc|de:rhs)
 gen a := CAST21(ADDRESS():a)
 		{ E_lda($a.sym, $a.off); }
 
-gen stk4 := CAST24(hl|de:rhs, sext==0) uses bc
-{
-	E_lxi(REG_BC, 0);
-	ArchEmitMove(REG_BC, 0);
-	ArchEmitMove(REG_HL, 0);
-}
+gen a := CAST41(r32:rhs)
+		{ E_mov(REG_A, loreg($rhs)); }
 
-gen stk4 := CAST24(hl|de:rhs, sext!=0) uses a|bc
-{
-	E_mov(REG_A, $rhs);
-	E_ral();
-	E_sbb(REG_A);
-	E_mov(REG_B, REG_A);
-	E_mov(REG_C, REG_A);
-	E_push(REG_BC);
-	E_push($rhs);
-}
+gen hl := CAST42(hlhl);
 
-gen a := CAST41(stk4) uses hl
-{
-	E_pop(REG_HL);
-	E_mov(REG_A, REG_L);
-	E_pop(REG_HL);
-}
-
-gen a := CAST41(LOAD4(ADDRESS():a))
-		{ E_lda($a.sym, $a.off); }
-
-gen a|b|d|h := CAST41(LOAD4(hl))
-		{ E_loadm($$); }
-
-gen hl := CAST42(stk4) uses bc
-{
-	E_pop(REG_HL);
-	E_pop(REG_BC);
-}
-
-gen hl := CAST42(LOAD4(ADDRESS():a))
-		{ E_lhld($a.sym, $a.off); }
-	
-gen hl|bc|de := CAST42(LOAD4(hl))
-		{ load2($$); }
-	
 // --- Strings --------------------------------------------------------------
 
 gen bc|de|hl := STRING():s
 {
 	R_flush($$);
-	E("\tlxi ");
+	E("\tld ");
 	E_reg($$);
 	E_comma();
 	E_string($s.text);
@@ -1594,5 +1731,4 @@ gen ASMEND()
 {
     E_nl();
 }
-
 

--- a/src/cowcom/archz80.cow.ng
+++ b/src/cowcom/archz80.cow.ng
@@ -221,14 +221,6 @@
 	end sub;
 
 	sub E_push(src: RegId)
-		if (src & (REG_HLHL|REG_BCBC|REG_DEDE)) != 0 then
-			E_exx();
-			E("\tpush ");
-			E_stackref(src);
-			E_nl();
-			E_exx();
-		end if;
-
 		E("\tpush ");
 		E_stackref(src);
 		E_nl();
@@ -239,14 +231,6 @@
 		E("\tpop ");
 		E_stackref(dest);
 		E_nl();
-
-		if (dest & (REG_HLHL|REG_BCBC|REG_DEDE)) != 0 then
-			E_exx();
-			E("\tpop ");
-			E_stackref(dest);
-			E_nl();
-			E_exx();
-		end if;
 	end sub;
 
 	sub E_loadm(reg: RegId)
@@ -302,7 +286,7 @@
 	end sub;
 
 	sub E_load8i(dest: RegId, index: RegId, off: int8)
-		RegCacheFlushValues();
+		R_flush(dest);
 		E("\tld ");
 		E_reg(dest);
 		E(", (");
@@ -335,6 +319,20 @@
 		var cache := RegCacheFindValue(sym, off);
 		if (cache & dest) != 0 then
 			# Value already in the right register.
+			E("; cache ");
+			E_reg(dest);
+			E_nl();
+			return;
+		elseif cache != 0 then
+			# Value in a register, but not the right one.
+			cache := FindFirst(cache);
+			if ((cache|dest) & (REG_IX|REG_IY)) != 0 then
+				E_push(cache);
+				E_pop(dest);
+			else
+				E_mov(hireg(dest), hireg(cache));
+				E_mov(loreg(dest), loreg(cache));
+			end if;
 			return;
 		end if;
 
@@ -344,7 +342,7 @@
 		E(", (");
 		E_symref(sym, off);
 		E(")\n");
-		RegCacheLeavesValue(REG_HL, sym, off);
+		RegCacheLeavesValue(dest, sym, off);
 	end sub;
 
 	sub E_store16(src: RegId, sym: [Symbol], off: Size)
@@ -353,7 +351,7 @@
 		E("), ");
 		E_reg(src);
 		E_nl();
-		RegCacheLeavesValue(REG_HL, sym, off);
+		RegCacheLeavesValue(src, sym, off);
 	end sub;
 
 	sub E_mvi(reg: RegId, value: uint8)
@@ -455,6 +453,11 @@
 	sub E_cpl()
 		R_flush(REG_A);
 		E("\tcpl\n");
+	end sub;
+
+	sub E_rcf() # reset carry flag
+		# Don't use E_alu here because we don't want to flush A.
+		E("\tand a\n");
 	end sub;
 
 	sub E_sub(rhs: RegId)
@@ -640,7 +643,17 @@
 	sub ArchEmitMove(src: RegId, dest: RegId)
 		if src == 0 then
 			E_pop(dest);
+			if (dest & (REG_HLHL|REG_DEDE|REG_BCBC)) != 0 then
+				E_exx();
+				E_pop(dest);
+				E_exx();
+			end if;
 		elseif dest == 0 then
+			if (src & (REG_HLHL|REG_DEDE|REG_BCBC)) != 0 then
+				E_exx();
+				E_push(src);
+				E_exx();
+			end if;
 			E_push(src);
 		elseif ((src == REG_HL) and (dest == REG_DE))
 				or ((src == REG_DE) and (dest == REG_HL)) then
@@ -759,11 +772,18 @@ gen STARTSUB():s
 				E_store16(REG_HL, param, 0);
 
 			when 4:
-				pop_return_address();
-				E_pop(REG_HL);
-				E_store16(REG_HL, param, 0);
-				E_pop(REG_HL);
-				E_store16(REG_HL, param, 2);
+				if count != lastparam then
+					pop_return_address();
+					E_pop(REG_HL);
+					E_store16(REG_HL, param, 0);
+					E_pop(REG_HL);
+					E_store16(REG_HL, param, 2);
+				else
+					E_store16(REG_HL, param, 0);
+					E_exx();
+					E_store16(REG_HL, param, 2);
+					E_exx();
+				end if;
 		end case;
 	end loop;
 
@@ -810,11 +830,18 @@ gen ENDSUB():s
 				end if;
 
 			when 4:
-				push_return_address();
-				E_load16(REG_HL, param, 2);
-				E_push(REG_HL);
-				E_load16(REG_HL, param, 0);
-				E_push(REG_HL);
+				if count != (params-1) then
+					push_return_address();
+					E_load16(REG_HL, param, 2);
+					E_push(REG_HL);
+					E_load16(REG_HL, param, 0);
+					E_push(REG_HL);
+				else
+					E_load16(REG_HL, param, 0);
+					E_exx();
+					E_load16(REG_HL, param, 2);
+					E_exx();
+				end if;
 		end case;
 
 		count := count + 1;
@@ -857,7 +884,7 @@ gen PUSHARG2(CALLE2():s)
 gen PUSHARG4(hlhl, remaining==0);
 
 gen PUSHARG4(r32:lhs, remaining!=0)
-		{ E_push($lhs); }
+		{ ArchEmitMove($lhs, 0); }
 
 gen a := POPARG1(remaining==0);
 
@@ -866,13 +893,13 @@ gen r8 := POPARG1(remaining!=0)
 
 gen hl := POPARG2(remaining==0);
 
-gen r16 := POPARG2()
+gen r16 := POPARG2(remaining!=0)
 		{ E_pop($$); }
 
 gen hlhl := POPARG4(remaining==0);
 
-gen r32 := POPARG4()
-		{ E_pop($$); }
+gen r32 := POPARG4(remaining!=0)
+		{ ArchEmitMove(0, $$); }
 
 gen RETURN()
 {
@@ -930,10 +957,10 @@ gen a := LOAD1(hl|bc|de:ptr)
 	end if;
 }
 
-//gen r8 := LOAD1(ADD2(ix|iy:ptr, CONSTANT():c))
-//{
-//	E_load8i($$, $ptr, $c.value as int8);
-//}
+gen r8 := LOAD1(ADD2(ix|iy:ptr, CONSTANT():c))
+{
+	E_load8i($$, $ptr, $c.value as int8);
+}
 
 gen STORE1(a, ADDRESS():a)
 {
@@ -949,15 +976,15 @@ gen STORE1(a, hl|bc|de:ptr)
 	end if;
 }
 
-//gen STORE1(r8:r, ADD2(ix|iy:ptr, CONSTANT():c))
-//{
-//	E_store8i($r, $ptr, $c.value as int8);
-//}
-//
-//gen STORE1(CONSTANT():v, ADD2(ix|iy:ptr, CONSTANT():c))
-//{
-//	E_store8ic($v.value as uint8, $ptr, $c.value as int8);
-//}
+gen STORE1(r8:r, ADD2(ix|iy:ptr, CONSTANT():c))
+{
+	E_store8i($r, $ptr, $c.value as int8);
+}
+
+gen STORE1(CONSTANT():v, ADD2(ix|iy:ptr, CONSTANT():c))
+{
+	E_store8ic($v.value as uint8, $ptr, $c.value as int8);
+}
 
 // --- 16-bit loads and stores ----------------------------------------------
 
@@ -983,6 +1010,12 @@ gen hl|bc|de := LOAD2(hl|ix|iy:rhs) uses a
 	end if;
 }
 
+gen hl|bc|de := LOAD2(ADD2(ix|iy:rhs, CONSTANT():c))
+{
+	E_load8i(loreg($$), $rhs, ($c.value as int8)+0);
+	E_load8i(hireg($$), $rhs, ($c.value as int8)+1);
+}
+
 gen STORE2(r16:ptr, ADDRESS():a)
 {
 	E_store16($ptr, $a.sym, $a.off);
@@ -1000,6 +1033,12 @@ gen STORE2(bc|de:val, hl|ix|iy:rhs) uses a
 	end if;
 }
 
+gen STORE2(hl|bc|de:val, ADD2(ix|iy:rhs, CONSTANT():c)) uses a
+{
+	E_store8i(loreg($val), $rhs, ($c.value as int8)+0);
+	E_store8i(hireg($val), $rhs, ($c.value as int8)+1);
+}
+
 // --- 32-bit loads and stores ----------------------------------------------
 
 gen r32 := LOAD4(ix|iy:ptr)
@@ -1009,6 +1048,16 @@ gen r32 := LOAD4(ix|iy:ptr)
 	E_exx();
 	E_load8i(loreg($$), $ptr, 2);
 	E_load8i(hireg($$), $ptr, 3);
+	E_exx();
+}
+
+gen r32 := LOAD4(ADD2(ix|iy:ptr, CONSTANT():c))
+{
+	E_load8i(loreg($$), $ptr, ($c.value as int8)+0);
+	E_load8i(hireg($$), $ptr, ($c.value as int8)+1);
+	E_exx();
+	E_load8i(loreg($$), $ptr, ($c.value as int8)+2);
+	E_load8i(hireg($$), $ptr, ($c.value as int8)+3);
 	E_exx();
 }
 
@@ -1027,6 +1076,16 @@ gen STORE4(r32:val, ix|iy:ptr)
 	E_exx();
 	E_store8i(loreg($val), $ptr, 2);
 	E_store8i(hireg($val), $ptr, 3);
+	E_exx();
+}
+
+gen STORE4(r32:val, ADD2(ix|iy:ptr, CONSTANT():c))
+{
+	E_store8i(loreg($val), $ptr, ($c.value as int8)+0);
+	E_store8i(hireg($val), $ptr, ($c.value as int8)+1);
+	E_exx();
+	E_store8i(loreg($val), $ptr, ($c.value as int8)+2);
+	E_store8i(hireg($val), $ptr, ($c.value as int8)+3);
 	E_exx();
 }
 
@@ -1061,7 +1120,7 @@ gen a|b|d|h := SUB1($$, CONSTANT(value==1))
 gen a := SUB1(a, CONSTANT():c)
 		{ E_subi($c.value as uint8); }
 
-gen a := MUL1(d, h)
+gen a := MUL1(d, h) uses b
 		{ E_callhelper("_mul1"); }
 
 gen a := NOT1(a)
@@ -1097,10 +1156,10 @@ gen h := DIVU1(h, d) uses a
 gen a := REMU1(h, d)
 		{ E_callhelper("_dvrmu1"); }
 
-gen b := DIVS1(b, d) uses a
+gen h := DIVS1(h, d) uses a
 		{ E_callhelper("_dvrms1"); }
 
-gen d := REMS1(b, d) // note, result not in A
+gen d := REMS1(h, d) // note, result not in A
 		{ E_callhelper("_dvrms1"); }
 
 gen a := RSHIFTS1(a, b)
@@ -1204,14 +1263,14 @@ gen hl := ADD2(hl|bc|de:lhs, hl|bc|de:rhs)
 gen hl := NEG2(bc|de:lhs) uses a
 {
 	E_xor(REG_A);
-	E_mov(REG_A, REG_L);
-	E_mov(REG_A, REG_H);
+	E_mov(REG_L, REG_A);
+	E_mov(REG_H, REG_A);
 	E_sbc(REG_HL, $lhs);
 }
 
 gen hl := SUB2(hl:lhs, bc|de:rhs)
 {
-	E_and(REG_A);
+	E_rcf();
 	E_sbc(REG_HL, $rhs);
 }
 
@@ -1235,16 +1294,16 @@ gen hl := SUB2(hl:lhs, bc|de:rhs)
 	end sub;
 %}
 
-gen de := DIVU2(de, bc) uses a
+gen bc := DIVU2(bc, de) uses a
 		{ E_callhelper("_dvrmu2"); }
 
-gen hl := REMU2(de, bc) uses a
+gen hl := REMU2(bc, de) uses a
 		{ E_callhelper("_dvrmu2"); }
 
-gen de := DIVS2(de, bc) uses a
+gen bc := DIVS2(bc, de) uses a
 		{ E_callhelper("_dvrms2"); }
 
-gen bc := REMS2(de, bc) uses a|hl // note, remainder not in hl
+gen de := REMS2(bc, de) uses a
 		{ E_callhelper("_dvrms2"); }
 
 gen hl := MUL2(de, bc) uses a
@@ -1308,7 +1367,7 @@ gen hl := LSHIFT2(hl, CONSTANT(value<=5):c)
 
 // --- 32-bit arithmetic ----------------------------------------------------
 
-gen r32 := ADD4(bcbc|dede:lhs, hlhl)
+gen hlhl := ADD4(bcbc|dede:lhs, hlhl)
 {
 	E_add(REG_HL, $lhs);
 	E_exx();
@@ -1316,41 +1375,41 @@ gen r32 := ADD4(bcbc|dede:lhs, hlhl)
 	E_exx();
 }
 
-gen r32 := SUB4(hlhl, bcbc|dede:rhs)
+gen hlhl := SUB4(hlhl, bcbc|dede:rhs)
 {
-	E_and(REG_A);
+	E_rcf();
 	E_sbc(REG_HL, $rhs);
 	E_exx();
 	E_sbc(REG_HL, $rhs);
 	E_exx();
 }
 
-gen hlhl := NEG4(hlhl) uses a|bcbc
+gen hlhl := NEG4(dede|bcbc:rhs) uses a
 {
 	E_xor(REG_A);
-	E_mov(REG_B, REG_A);
-	E_mov(REG_C, REG_A);
-	E_sbc(REG_HL, REG_BC);
+	E_mov(REG_H, REG_A);
+	E_mov(REG_L, REG_A);
+	E_sbc(REG_HL, $rhs);
 	E_exx();
-	E_mov(REG_B, REG_A);
-	E_mov(REG_C, REG_A);
-	E_sbc(REG_HL, REG_BC);
+	E_mov(REG_H, REG_A);
+	E_mov(REG_L, REG_A);
+	E_sbc(REG_HL, $rhs);
 	E_exx();
 }
 
 gen hlhl := MUL4(bcbc, dede) uses a
         { E_callhelper("_mul4"); }
 
-gen dede := DIVU4(dede, bcbc) uses a|hlhl
+gen bcbc := DIVU4(bcbc, dede) uses a|hlhl
         { E_callhelper("_dvrmu4"); }
 
-gen hlhl := REMU4(dede, bcbc) uses a
+gen hlhl := REMU4(bcbc, dede) uses a
         { E_callhelper("_dvrmu4"); }
 
-gen dede := DIVS4(dede, bcbc) uses a|hlhl
+gen bcbc := DIVS4(bcbc, dede) uses a|hlhl
         { E_callhelper("_dvrms4"); }
 
-gen bcbc := REMS4(dede, bcbc) uses a|hlhl // note, remainder in bcbc
+gen dede := REMS4(bcbc, dede) uses a
         { E_callhelper("_dvrms4"); }
 
 gen hlhl := AND4(dede, hlhl) uses a
@@ -1362,13 +1421,8 @@ gen hlhl := OR4(dede, hlhl) uses a
 gen hlhl := EOR4(dede, hlhl) uses a
         { E_callhelper("_eor4"); }
 
-gen r32 := NOT4($$)
-{
-	E_cpl();
-	E_exx();
-	E_cpl();
-	E_exx();
-}
+gen hlhl := NOT4(hlhl) uses a
+		{ E_callhelper("_not4"); }
 
 gen hlhl := LSHIFT4(hlhl, b)
         { E_callhelper("_asl4"); }
@@ -1478,17 +1532,17 @@ gen BLTU1(a, CONSTANT():c):b
 	E_jumps_jc_jnc(self.n[0]);
 }
 
-gen BLTS1(a, b):b
+gen BLTS1(a, b|d|h:rhs):b
 {
-	E_sub(REG_B);
-	E("\tjp p, $+5\n");
+	E_sub($rhs);
+	E("\tjp po, $+5\n");
 	E_xori(0x80);
 	E_jumps_jm_jp(self.n[0]);
 }
 
 %{
 	sub bequ2(node: [Node], lhs: RegId)
-		E_and(REG_A);
+		E_rcf();
 		E_sbc(REG_HL, lhs);
 		E_jumps_jz_jnz(node);
 	end sub;
@@ -1502,7 +1556,7 @@ gen BEQS2(bc|de:lhs, hl):a
 
 gen BLTU2(hl, bc|de:rhs):b
 {
-	E_and(REG_A);
+	E_rcf();
 	E_sbc(REG_HL, $rhs);
 	E_jumps_jc_jnc(self.n[0]);
 }
@@ -1545,11 +1599,15 @@ gen STARTCASE2(de);
 
 gen STARTCASE4(r32:val)
 {
-	E_push($val);
 	E_exx();
 	E_push($val);
 	E_exx();
-	E_pop(REG_DE);
+	if $val == REG_HLHL then
+		E_ex(); # quickly move to DE
+	elseif $val == REG_BCBC then
+		E_mov(REG_D, REG_B);
+		E_mov(REG_E, REG_C);
+	end if;
 	E_pop(REG_BC);
 }
 
@@ -1588,8 +1646,8 @@ gen WHENCASE2():c uses a
 
 gen WHENCASE4():c uses a
 {
-	case2($c.value as uint16, REG_BC, $c.falselabel);
-	case2(($c.value >> 16) as uint16, REG_DE, $c.falselabel);
+	case2($c.value as uint16, REG_DE, $c.falselabel);
+	case2(($c.value >> 16) as uint16, REG_BC, $c.falselabel);
 }
 
 // --- Casts ----------------------------------------------------------------
@@ -1603,9 +1661,9 @@ gen hl|bc|de := CAST12(a, sext==0)
 gen hl|bc|de := CAST12(a, sext!=0)
 {
 	E_mov(loreg($$), REG_A);
-	E_rra();
+	E_add(REG_A, REG_A);
 	E_sbc(REG_A, REG_A);
-	E_mov($$, REG_A);
+	E_mov(hireg($$), REG_A);
 }
 
 gen r32 := CAST14(a:rhs, sext==0)
@@ -1622,7 +1680,7 @@ gen r32 := CAST14(a:rhs, sext==0)
 gen r32 := CAST14(a:rhs, sext!=0)
 {
 	E_mov(loreg($$), REG_A);
-	E_rra();
+	E_add(REG_A, REG_A);
 	E_sbc(REG_A, REG_A);
 	E_mov(hireg($$), REG_A);
 	E_exx();
@@ -1641,7 +1699,7 @@ gen hlhl := CAST24(hl, sext==0)
 gen hlhl := CAST24(hl, sext!=0) uses a
 {
 	E_mov(REG_A, REG_L);
-	E_rra();
+	E_add(REG_A, REG_A);
 	E_sbc(REG_A, REG_A);
 	E_exx();
 	E_mov(REG_L, REG_A);

--- a/src/cowcom/build.lua
+++ b/src/cowcom/build.lua
@@ -1,4 +1,4 @@
-local ARCHS = { "8080" }
+local ARCHS = { "8080", "z80" }
 
 lemoncowgol {
 	ins = { "src/cowcom/parser.y" },

--- a/src/cowcom/codegen.coh
+++ b/src/cowcom/codegen.coh
@@ -62,7 +62,7 @@ sub FindFirst(inreg: RegId): (outreg: RegId)
 		end if;
 		outreg := outreg << 1;
 	end loop;
-	SimpleError("failed to allocate register");
+	outreg := 0;
 end sub;
 
 include "inssel.coh";
@@ -400,12 +400,12 @@ sub Generate(rootnode: [Node])
 				var blocked := CalculateBlockedRegisters(@next consumer, @prev producer);
 				var candidate := node.desired_reg & producer.producable_regs;
 
-				var mask := candidate & ~(blocked | producer.output_regs | consumer.input_regs);
-				if mask != 0 then
+				var mask1 := candidate & ~(blocked | producer.output_regs | consumer.input_regs);
+				if mask1 != 0 then
 					# Good news --- we can allocate the ideal register for
 					# both producer and consumer.
 
-					candidate := FindFirst(mask);
+					candidate := FindFirst(mask1);
 					node.produced_reg := candidate;
 					producer.produced_reg := candidate;
 
@@ -414,13 +414,14 @@ sub Generate(rootnode: [Node])
 					BlockRegisters(@next consumer, @prev producer, blocked);
 					producer.output_regs := producer.output_regs | blocked;
 				else
-					mask := producer.producable_regs & ~(blocked | producer.output_regs);
-					if mask != 0 then
+					mask1 := producer.producable_regs & ~(blocked | producer.output_regs);
+					var mask2 := node.desired_reg & ~consumer.input_regs;
+					if (mask1 != 0) and (mask2 != 0) then
 						# The producer and consumer want different registers, but the
 						# producers register works up until the consumer.
 
-						producer.produced_reg := FindFirst(mask);
-						node.produced_reg := FindFirst(node.desired_reg & ~consumer.input_regs);
+						producer.produced_reg := FindFirst(mask1);
+						node.produced_reg := FindFirst(mask2);
 						consumer.input_regs := consumer.input_regs
 							| FindConflictingRegisters(node.produced_reg);
 						blocked := FindConflictingRegisters(producer.produced_reg);
@@ -428,14 +429,14 @@ sub Generate(rootnode: [Node])
 						producer.output_regs := producer.output_regs | blocked;
 						CreateReload(consumer, producer.produced_reg, node.produced_reg);
 					else
-						mask := node.desired_reg & ~(blocked | consumer.input_regs);
-						if mask != 0 then
+						mask1 := node.desired_reg & ~(blocked | consumer.input_regs);
+						mask2 := producer.producable_regs & ~producer.output_regs;
+						if (mask1 != 0) and (mask2 != 0) then
 							# The producer and consumer want different registers, but the
 							# consumer's register works after the producer.
 
-							producer.produced_reg := FindFirst(
-									producer.producable_regs & ~producer.output_regs);
-							node.produced_reg := FindFirst(mask);
+							producer.produced_reg := FindFirst(mask2);
+							node.produced_reg := FindFirst(mask1);
 							blocked := FindConflictingRegisters(node.produced_reg);
 							consumer.input_regs := consumer.input_regs | blocked;
 							BlockRegisters(@next consumer, @prev producer, blocked);
@@ -447,6 +448,21 @@ sub Generate(rootnode: [Node])
 							# spill to the stack via a push and pop.
 
 							sub deadlock()
+								print("node.op=");
+								print_i8(node.op);
+								print_nl();
+								print("producer.producable_regs=");
+								print_hex_i32(producer.producable_regs as uint32);
+								print_nl();
+								print("producer.output_regs=");
+								print_hex_i32(producer.output_regs as uint32);
+								print_nl();
+								print("node.desired_reg=");
+								print_hex_i32(node.desired_reg as uint32);
+								print_nl();
+								print("consumer.input_regs=");
+								print_hex_i32(consumer.input_regs as uint32);
+								print_nl();
 								SimpleError("register allocation deadlock");
 							end sub;
 

--- a/src/cowcom/emitter.coh
+++ b/src/cowcom/emitter.coh
@@ -66,6 +66,16 @@ sub E_u8(value: uint8)
 	E_u32(value as uint32);
 end sub;
 
+sub E_i8(value: int8)
+	if value < 0 then
+		EmitByte('-');
+		value := -value;
+	else
+		EmitByte('+');
+	end if;
+	E_u8(value as uint8);
+end sub;
+
 sub E_h(value: uint32, width: uint8)
 	var buffer: uint8[5];
 	var pe := UIToA(value as uint32, 16, &buffer[0]);

--- a/src/cowcom/regcache.coh
+++ b/src/cowcom/regcache.coh
@@ -5,7 +5,7 @@ const CACHE_SLOT_CONSTANT := 1;
 const CACHE_SLOT_ADDRESS  := 2;
 const CACHE_SLOT_VALUE    := 3;
 
-typedef CacheValue := int(0, (1<<MACHINE_WIDTH)-1);
+typedef CacheValue := uint32;
 
 record CacheSlot
 	symbol: [Symbol];

--- a/toolchains.lua
+++ b/toolchains.lua
@@ -45,7 +45,7 @@ toolchain_ocgen = {
 toolchain_ncpm = {
 	name = "ncpm",
 	compiler = "bin/cowcom.8080.ocgen.exe",
-	linker = cowlink,
+	linker = cowlink_cpm,
 	assembler = buildzmac,
 	runtime = "rt/cpm",
 	asmext = ".asm",
@@ -53,11 +53,23 @@ toolchain_ncpm = {
 	tester = cpmtest,
 }
 
+toolchain_ncpmz = {
+	name = "ncpmz",
+	compiler = "bin/cowcom.z80.ocgen.exe",
+	linker = cowlink_cpmz,
+	assembler = buildzmac,
+	runtime = "rt/cpmz",
+	asmext = ".z80",
+	binext = ".z80.com",
+	tester = cpmtest,
+}
+
 ALL_TOOLCHAINS = {
-	toolchain_ocpm,
+	--toolchain_ocpm,
 	toolchain_olx386,
 	toolchain_olxthumb2,
 	toolchain_ocgen,
 	toolchain_ncpm,
+	toolchain_ncpmz,
 }
 

--- a/tools/cpmemu/emulator.c
+++ b/tools/cpmemu/emulator.c
@@ -74,6 +74,10 @@ void showregs(void)
 		z80ex_get_reg(z80, regHL),
 		z80ex_get_reg(z80, regIX),
 		z80ex_get_reg(z80, regIY));
+	printf("                 shadow  bc=%04x de=%04x hl=%04x\n",
+		z80ex_get_reg(z80, regBC_),
+		z80ex_get_reg(z80, regDE_),
+		z80ex_get_reg(z80, regHL_));
 
 	char buffer[80];
 	int tstates;
@@ -102,6 +106,12 @@ static void cmd_register(void)
 			reg = regDE;
 		else if (strcmp(w1, "hl") == 0)
 			reg = regHL;
+		else if (strcmp(w1, "bc'") == 0)
+			reg = regBC_;
+		else if (strcmp(w1, "de'") == 0)
+			reg = regDE_;
+		else if (strcmp(w1, "hl'") == 0)
+			reg = regHL_;
 		else if (strcmp(w1, "ix") == 0)
 			reg = regIX;
 		else if (strcmp(w1, "iy") == 0)

--- a/tools/newgen/globals.h
+++ b/tools/newgen/globals.h
@@ -123,7 +123,7 @@ extern void warning(const char* msg, ...);
 extern void yyerror(const char* msg, ...);
 extern int yydebug;
 
-extern int machine_width;
+extern int machine_word;
 
 extern void* open_file(FILE* fp);
 extern void include_file(void* buffer);

--- a/tools/newgen/lexer.l
+++ b/tools/newgen/lexer.l
@@ -48,7 +48,7 @@ ID [A-Za-z][A-Za-z0-9_$]*
 "rewrite"                 { return REWRITE; }
 "stacked"                 { return STACKED; }
 "uses"                    { return USES; }
-"width"                   { return WIDTH; }
+"wordsize"                { return WORDSIZE; }
 
 \"                        { BEGIN(STRINGSTATE); return BEGINSTRING; }
 <STRINGSTATE>([^\"\\$]|\\.)* { string = strdup(yytext); return CSTRING; }

--- a/tools/newgen/main.c
+++ b/tools/newgen/main.c
@@ -24,7 +24,7 @@ static const char* infilename;
 FILE* outfp;
 FILE* outhfp;
 
-int machine_width = 0;
+int machine_word = 0;
 
 #if defined COWGOL
 	#define DEREF "."
@@ -844,8 +844,8 @@ int main(int argc, const char* argv[])
 	sort_rules();
 
 	#if defined COWGOL
-		if (machine_width != 0)
-			fprintf(outhfp, "const MACHINE_WIDTH := %d;\n", machine_width);
+		if (machine_word != 0)
+			fprintf(outhfp, "const MACHINE_WORD := 0x%x;\n", machine_word);
 
 		fprintf(outhfp, "const INSTRUCTION_TEMPLATE_DEPTH := %d;\n", maxdepth);
 		fprintf(outhfp, "const INSTRUCTION_TEMPLATE_COUNT := %d;\n", rulescount);

--- a/tools/newgen/parser.y
+++ b/tools/newgen/parser.y
@@ -76,9 +76,9 @@ regdata(R) ::= regdata(R1) STACKED.
 
 /* --- Width ------------------------------------------------------------- */
 
-rules ::= rules WIDTH int(R) SEMICOLON.
+rules ::= rules WORDSIZE int(R) SEMICOLON.
 {
-    machine_width = R;
+    machine_word = R;
 }
 
 /* --- Rewrite rules ----------------------------------------------------- */


### PR DESCRIPTION
This adds a working Z80 backend, complete with index register support; although lack of aliasing analysis makes it less useful than you might think because every time you write through ix or iy you need to discard all values in case they've changed. Also, the register allocator is rather reluctant to use them for some reason.

The code size is pretty bad --- very slightly smaller than the 8080. This appears mostly to be the fault of 32-bit arithmetic, which uses the shadow registers on the Z80 but was done through helper routines on the 8080. So the 8080 can add two numbers on the stack in three bytes for the call to the helper, but the Z80 takes four. Routines that use 32-bit maths typically have every other instruction being exx.