### PR TITLE
Even more optimisations.

### DIFF
--- a/src/cowcom/arch8080.cow.ng
+++ b/src/cowcom/arch8080.cow.ng
@@ -131,49 +131,89 @@
 		E_nl();
 	end sub;
 
+	sub getreg(reg: RegId, regtable: [RegId], name: string): (result: RegId)
+		result := 0;
+		while reg != 0 loop
+			if (reg & 1) != 0 then
+				result := [regtable];
+				return;
+			end if;
+			reg := reg >> 1;
+			regtable := @next regtable;
+		end loop;
+
+		if result == 0 then
+			StartError();
+			print("bad ");
+			print(name);
+			print_char(' ');
+			print_hex_i16(reg);
+			EndError();
+		end if;
+	end sub;
+
 	sub loreg(reg: RegId): (result: RegId)
-		case reg is
-			when REG_A:  result := REG_A;
-			when REG_BC: result := REG_C;
-			when REG_DE: result := REG_E;
-			when REG_HL: result := REG_L;
-			when else:
-				StartError();
-				print("bad loreg ");
-				print_hex_i16(reg);
-				EndError();
-		end case;
+		var regs: RegId[] := {
+			REG_A,  # a
+			REG_C,  # b
+			REG_C,  # c
+			REG_E,  # d
+			REG_E,  # e
+			REG_L,  # h
+			REG_L,  # l
+			REG_L,  # hl
+			REG_E,  # de
+			REG_C,  # bc
+		};
+
+		result := getreg(reg, &regs[0], "loreg");
 	end sub;
 
 	sub hireg(reg: RegId): (result: RegId)
-		case reg is
-			when REG_A:  result := REG_A;
-			when REG_BC: result := REG_B;
-			when REG_DE: result := REG_D;
-			when REG_HL: result := REG_H;
-			when else:
-				SimpleError("bad hireg");
-		end case;
+		var regs: RegId[] := {
+			REG_A,  # a
+			REG_B,  # b
+			REG_B,  # c
+			REG_D,  # d
+			REG_D,  # e
+			REG_H,  # h
+			REG_H,  # l
+			REG_H,  # hl
+			REG_D,  # de
+			REG_B,  # bc
+		};
+
+		result := getreg(reg, &regs[0], "loreg");
 	end sub;
 
 	sub E_reg(reg: RegId)
-		case reg is
-			when REG_A: EmitByte('a');
-			when REG_B: EmitByte('b');
-			when REG_C: EmitByte('c');
-			when REG_D: EmitByte('d');
-			when REG_E: EmitByte('e');
-			when REG_H: EmitByte('h');
-			when REG_L: EmitByte('l');
-			when REG_BC: EmitByte('b');
-			when REG_DE: EmitByte('d');
-			when REG_HL: EmitByte('h');
-			when else:
-				StartError();
-				print("invalid register 0x");
-				print_hex_i16(reg);
-				EndError();
-		end case;
+		var names: string[] := {
+			"a",
+			"b",
+			"c",
+			"d",
+			"e",
+			"h",
+			"l",
+			"h",
+			"d",
+			"b",
+		};
+
+		var p := &names[0];
+		while reg != 0 loop
+			if (reg & 1) != 0 then
+				E([p]);
+				return;
+			end if;
+			reg := reg >> 1;
+			p := @next p;
+		end loop;
+
+		StartError();
+		print("bad reg ");
+		print_hex_i16(reg);
+		EndError();
 	end sub;
 
 	sub E_stackreg(reg: RegId)

--- a/src/cowcom/arch8080.cow.ng
+++ b/src/cowcom/arch8080.cow.ng
@@ -1079,6 +1079,14 @@ gen bc|de|hl := NEG2(bc|de|hl:lhs) uses a
 		E_alui(hiinsn, (value >> 8) as uint8);
 		E_mov(dest, REG_A);
 	end sub;
+
+	sub dvrmu2()
+		E_callhelper("_dvrmu2");
+	end sub;
+
+	sub dvrms2()
+		E_callhelper("_dvrms2");
+	end sub;
 %}
 
 gen bc|de|hl := SUB2(bc|de|hl:lhs, bc|de|hl:rhs) uses a
@@ -1092,16 +1100,16 @@ gen bc|de|hl := SUB2(bc|de|hl:lhs, CONSTANT():c) uses a
 }
 
 gen de := DIVU2(de, bc) uses a
-		{ E_callhelper("_dvrmu2"); }
+		{ dvrmu2(); }
 
 gen hl := REMU2(de, bc) uses a
-		{ E_callhelper("_dvrmu2"); }
+		{ dvrmu2(); }
 
 gen de := DIVS2(de, bc) uses a
-		{ E_callhelper("_dvrms2"); }
+		{ dvrms2(); }
 
 gen hl := REMS2(de, bc) uses a
-		{ E_callhelper("_dvrms2"); }
+		{ dvrms2(); }
 
 gen hl := MUL2(hl, de) uses a|bc
 		{ E_callhelper("_mul2"); }
@@ -1229,6 +1237,10 @@ gen stk4 := RSHIFTS4(stk4, b) uses a|de|hl
 		E_jumps_with_fallthrough("jc", "jnc", node);
 	end sub;
 
+	sub E_jumps_jm_jp(node: [Node])
+		E_jumps_with_fallthrough("jm", "jp", node);
+	end sub;
+
 	sub bequ1(node: [Node], nota: RegId)
 		E_cmp(nota);
 		E_jumps_jz_jnz(node);
@@ -1260,6 +1272,16 @@ gen stk4 := RSHIFTS4(stk4, b) uses a|de|hl
 
 	sub bequ4(node: [Node])
 		E_callhelper("_cmpu4");
+		E_jumps_jz_jnz(node);
+	end sub;
+
+	sub bequ40(node: [Node])
+		E_pop(REG_HL);
+		E_mov(REG_A, REG_H);
+		E_ora(REG_L);
+		E_pop(REG_HL);
+		E_ora(REG_H);
+		E_ora(REG_L);
 		E_jumps_jz_jnz(node);
 	end sub;
 
@@ -1312,7 +1334,13 @@ gen BLTU1(a, CONSTANT():c):b
 gen BLTS1(a, b):b
 {
 	E_callhelper("_cmps1");
-	E_jumps_with_fallthrough("jm", "jp", self.n[0]);
+	E_jumps_jm_jp(self.n[0]);
+}
+
+gen BLTS1(a, CONSTANT(value==0))
+{
+	E_ora(REG_A);
+	E_jumps_jm_jp(self.n[0]);
 }
 
 gen BEQU2(de, hl):a
@@ -1355,11 +1383,24 @@ gen BLTS2(de, hl):b uses a|bc
 	E_jumps_jc_jnc(self.n[0]);
 }
 
+gen BLTS2(hl|bc|de:lhs, CONSTANT(value==0)) uses a
+{
+	E_mov(REG_A, hireg($lhs));
+	E_ora(REG_A);
+	E_jumps_jm_jp(self.n[0]);
+}
+
 gen BEQU4(stk4:lhs, stk4:rhs) uses a|hl|bc|de
 		{ bequ4(self.n[0]); }
 
 gen BEQS4(stk4:lhs, stk4:rhs) uses a|hl|bc|de
 		{ bequ4(self.n[0]); }
+
+gen BEQU4(stk4:lhs, CONSTANT(value==0)) uses a|hl
+		{ bequ40(self.n[0]); }
+
+gen BEQS4(stk4:lhs, CONSTANT(value==0)) uses a|hl
+		{ bequ40(self.n[0]); }
 
 gen BLTU4(stk4:lhs, stk4:rhs):b uses a|hl|bc|de
 {
@@ -1371,6 +1412,14 @@ gen BLTS4(stk4:lhs, stk4:rhs):b uses a|hl|bc|de
 {
 	E_callhelper("_cmps4");
 	E_jumps_jc_jnc(self.n[0]);
+}
+
+gen BLTS4(stk4:lhs, CONSTANT(value==0)) uses a
+{
+	E_pop(REG_A);
+	E_pop(REG_A); # high byte of 4-byte word ends up in A -- conveniently!
+	E_ora(REG_A);
+	E_jumps_jm_jp(self.n[0]);
 }
 
 // --- Case -----------------------------------------------------------------

--- a/src/cowcom/archz80.cow.ng
+++ b/src/cowcom/archz80.cow.ng
@@ -135,70 +135,126 @@
 		E_nl();
 	end sub;
 
+	sub getreg(reg: RegId, regtable: [RegId], name: string): (result: RegId)
+		result := 0;
+		while reg != 0 loop
+			if (reg & 1) != 0 then
+				result := [regtable];
+				return;
+			end if;
+			reg := reg >> 1;
+			regtable := @next regtable;
+		end loop;
+
+		if result == 0 then
+			StartError();
+			print("bad ");
+			print(name);
+			print_char(' ');
+			print_hex_i16(reg);
+			EndError();
+		end if;
+	end sub;
+
 	sub loreg(reg: RegId): (result: RegId)
-		case reg is
-			when REG_A:    result := REG_A;
-			when REG_BC:   result := REG_C;
-			when REG_DE:   result := REG_E;
-			when REG_HL:   result := REG_L;
-			when REG_BCBC: result := REG_C;
-			when REG_DEDE: result := REG_E;
-			when REG_HLHL: result := REG_L;
-			when else:
-				StartError();
-				print("bad loreg ");
-				print_hex_i16(reg);
-				EndError();
-		end case;
+		var regs: RegId[] := {
+			REG_A,  # a
+			REG_C,  # b
+			REG_C,  # c
+			REG_E,  # d
+			REG_E,  # e
+			REG_L,  # h
+			REG_L,  # l
+			REG_L,  # hl
+			REG_E,  # de
+			REG_C,  # bc
+			REG_L,  # hlhl
+			REG_E,  # dede
+			REG_C,  # bcbc
+			0,      # ix
+			0,      # iy
+		};
+
+		result := getreg(reg, &regs[0], "loreg");
 	end sub;
 
 	sub hireg(reg: RegId): (result: RegId)
-		case reg is
-			when REG_A:    result := REG_A;
-			when REG_BC:   result := REG_B;
-			when REG_DE:   result := REG_D;
-			when REG_HL:   result := REG_H;
-			when REG_BCBC: result := REG_B;
-			when REG_DEDE: result := REG_D;
-			when REG_HLHL: result := REG_H;
-			when else:
-				StartError();
-				print("bad hireg ");
-				print_hex_i16(reg);
-				EndError();
-		end case;
+		var regs: RegId[] := {
+			REG_A,  # a
+			REG_B,  # b
+			REG_B,  # c
+			REG_D,  # d
+			REG_D,  # e
+			REG_H,  # h
+			REG_H,  # l
+			REG_H,  # hl
+			REG_D,  # de
+			REG_B,  # bc
+			REG_H,  # hlhl
+			REG_D,  # dede
+			REG_B,  # bcbc
+			0,      # ix
+			0,      # iy
+		};
+
+		result := getreg(reg, &regs[0], "hireg");
 	end sub;
 
 	sub wordreg(reg: RegId): (result: RegId)
-		case reg is
-			when REG_BCBC: result := REG_BC;
-			when REG_DEDE: result := REG_DE;
-			when REG_HLHL: result := REG_HL;
-			when else:
-				SimpleError("bad wordreg");
-		end case;
+		var regs: RegId[] := {
+			REG_A,  # a
+			REG_BC, # b
+			REG_BC, # c
+			REG_DE, # d
+			REG_DE, # e
+			REG_HL, # h
+			REG_HL, # l
+			REG_HL, # hl
+			REG_DE, # de
+			REG_BC, # bc
+			REG_HL, # hlhl
+			REG_DE, # dede
+			REG_BC, # bcbc
+			REG_IX, # ix
+			REG_IY, # iy
+		};
+
+		result := getreg(reg, &regs[0], "wordreg");
 	end sub;
 
 	sub E_reg(reg: RegId)
-		case reg is
-			when REG_A:    E("a");
-			when REG_B:    E("b");
-			when REG_C:    E("c");
-			when REG_D:    E("d");
-			when REG_E:    E("e");
-			when REG_H:    E("h");
-			when REG_L:    E("l");
-			when REG_BC:   E("bc");
-			when REG_DE:   E("de");
-			when REG_HL:   E("hl");
-			when REG_IX:   E("ix");
-			when REG_IY:   E("iy");
-			when REG_BCBC: E("bc");
-			when REG_DEDE: E("de");
-			when REG_HLHL: E("hl");
-			when else:
-				SimpleError("bad reg");
-		end case;
+		var names: string[] := {
+			"a",
+			"b",
+			"c",
+			"d",
+			"e",
+			"h",
+			"l",
+			"hl",
+			"de",
+			"bc",
+			"hl",
+			"de",
+			"bc",
+			"ix",
+			"iy"
+		};
+
+		var p := &names[0];
+		while reg != 0 loop
+			if (reg & 1) != 0 then
+				E([p]);
+				return;
+			end if;
+			reg := reg >> 1;
+			p := @next p;
+		end loop;
+
+		StartError();
+		print("bad reg ");
+		print_hex_i16(reg);
+		EndError();
 	end sub;
 
 	sub E_stackref(reg: RegId)
@@ -539,6 +595,10 @@
 
 	sub E_srl(reg: RegId)
 		E_shift("srl", reg);
+	end sub;
+
+	sub E_rr(reg: RegId)
+		E_shift("rr", reg);
 	end sub;
 
 	sub E_bit(bit: uint8, reg: RegId)
@@ -1496,6 +1556,18 @@ gen hl := LSHIFT2(hl, CONSTANT(value<=5):c)
 		E_add(REG_HL, REG_HL);
 		i := i - 1;
 	end loop;
+}
+
+gen r16 := RSHIFTU2($$, CONSTANT(value==1):c)
+{
+	E_srl(hireg($$));
+	E_rr(loreg($$));
+}
+
+gen r16 := RSHIFTS2($$, CONSTANT(value==1):c)
+{
+	E_sra(hireg($$));
+	E_rr(loreg($$));
 }
 
 // --- 32-bit arithmetic ----------------------------------------------------

--- a/src/cowcom/archz80.cow.ng
+++ b/src/cowcom/archz80.cow.ng
@@ -976,7 +976,7 @@ gen r32 := CONSTANT():c
 %{
 	sub is_indexable_8bit(value: Arith): (result: uint8)
 		result := 1;
-		if (value < -128) or (value > 127) then
+		if (value < -128) or (value > 127) or ((value >= -4) and (value <= 4)) then
 			result := 0;
 		end if;
 	end sub;
@@ -1024,7 +1024,7 @@ gen STORE1(CONSTANT():v, ADD2(ix|iy:ptr, CONSTANT(value is indexable_8bit):c))
 %{
 	sub is_indexable_16bit(value: Arith): (result: uint8)
 		result := 1;
-		if (value < -128) or (value > 126) then
+		if (value < -128) or (value > 126) or ((value >= -3) and (value <= 3)) then
 			result := 0;
 		end if;
 	end sub;
@@ -1092,13 +1092,38 @@ gen STORE2(CONSTANT():v, ADD2(ix|iy:rhs, CONSTANT(value is indexable_16bit):c)) 
 %{
 	sub is_indexable_32bit(value: Arith): (result: uint8)
 		result := 1;
-		if (value < -128) or (value > 124) then
+		if (value < -128) or (value > 124) or ((value >= -3) and (value <= 3)) then
 			result := 0;
 		end if;
 	end sub;
 %}
 
-gen r32 := LOAD4(ix|iy:ptr)
+gen bcbc|dede := LOAD4(hl|ix|iy:ptr)
+{
+	if $ptr == REG_HL then
+		E_loadm(loreg($$));           #  7
+		E_inc(REG_HL);                #  6
+		E_loadm(hireg($$));           #  7
+		E_inc(REG_HL);                #  6
+		E_push(REG_HL);               # 11
+		E_exx();                      #  4
+		E_pop(REG_HL);                # 10
+		E_loadm(loreg($$));           #  7
+		E_inc(REG_HL);                #  6
+		E_loadm(hireg($$));           #  7
+		E_exx();                      # 71 t-states
+	else
+		E_load8i(loreg($$), $ptr, 0); # 19
+		E_load8i(hireg($$), $ptr, 1); # 19
+		E_exx();                      #  4
+		E_load8i(loreg($$), $ptr, 2); # 19
+		E_load8i(hireg($$), $ptr, 3); # 19
+		E_exx();                      #  4
+		                              # 85 t-states
+	end if;
+}
+
+gen hlhl := LOAD4(ix|iy:ptr)
 {
 	E_load8i(loreg($$), $ptr, 0);
 	E_load8i(hireg($$), $ptr, 1);
@@ -1133,14 +1158,29 @@ gen r32 := LOAD4(ADDRESS():a)
 	RegCacheLeavesValue($$, $a.sym, $a.off);
 }
 
-gen STORE4(r32:val, ix|iy:ptr)
+gen STORE4(r32:val, hl|ix|iy:ptr)
 {
-	E_store8i(loreg($val), $ptr, 0);
-	E_store8i(hireg($val), $ptr, 1);
-	E_exx();
-	E_store8i(loreg($val), $ptr, 2);
-	E_store8i(hireg($val), $ptr, 3);
-	E_exx();
+	if $ptr == REG_HL then
+		E_storem(loreg($val));           #  7
+		E_inc(REG_HL);                   #  6
+		E_storem(hireg($val));           #  7
+		E_inc(REG_HL);                   #  6
+		E_push(REG_HL);                  # 11
+		E_exx();                         #  4
+		E_pop(REG_HL);                   # 10
+		E_storem(loreg($val));           #  7
+		E_inc(REG_HL);                   #  6
+		E_storem(hireg($val));           #  7
+		E_exx();                         # 71 t-states
+	else
+		E_store8i(loreg($val), $ptr, 0); # 19
+		E_store8i(hireg($val), $ptr, 1); # 19
+		E_exx();                         #  4
+		E_store8i(loreg($val), $ptr, 2); # 19
+		E_store8i(hireg($val), $ptr, 3); # 19
+		E_exx();                         #  4
+		                                 # 84 t-states
+	end if;
 }
 
 gen STORE4(r32:val, ADD2(ix|iy:ptr, CONSTANT(value is indexable_32bit):c))
@@ -1332,6 +1372,9 @@ gen hl := ADD2(hl|bc|de:lhs, hl|bc|de:rhs)
 		E_add(REG_HL, $lhs);
 	end if;
 }
+
+gen ix|iy := ADD2($$, bc|de:rhs)
+		{ E_add($$, $rhs); }
 
 gen hl := NEG2(bc|de:lhs) uses a
 {

--- a/src/cowcom/archz80.cow.ng
+++ b/src/cowcom/archz80.cow.ng
@@ -541,6 +541,14 @@
 		E_shift("srl", reg);
 	end sub;
 
+	sub E_bit(bit: uint8, reg: RegId)
+		E("\tbit ");
+		E_u8(bit);
+		E_comma();
+		E_reg(reg);
+		E_nl();
+	end sub;
+
 	# Does not persist the name; only call this with constant strings.
 	sub E_callhelper(name: string)
 		var e := externs;
@@ -1408,19 +1416,28 @@ gen hl := SUB2(hl:lhs, bc|de:rhs)
 		E_alui(hiinsn, (value >> 8) as uint8);
 		E_mov(hireg(dest), REG_A);
 	end sub;
+
+	sub E_dvrmu2()
+		E_callhelper("_dvrmu2");
+	end sub;
+
+	sub E_dvrms2()
+		E_callhelper("_dvrms2");
+	end sub;
+
 %}
 
 gen bc := DIVU2(bc, de) uses a
-		{ E_callhelper("_dvrmu2"); }
+		{ E_dvrmu2(); }
 
 gen hl := REMU2(bc, de) uses a
-		{ E_callhelper("_dvrmu2"); }
+		{ E_dvrmu2(); }
 
 gen bc := DIVS2(bc, de) uses a
-		{ E_callhelper("_dvrms2"); }
+		{ E_dvrms2(); }
 
 gen de := REMS2(bc, de) uses a
-		{ E_callhelper("_dvrms2"); }
+		{ E_dvrms2(); }
 
 gen hl := MUL2(de, bc) uses a
 		{ E_callhelper("_mul2"); }
@@ -1563,6 +1580,10 @@ gen hlhl := RSHIFTS4(hlhl, b)
 
 	sub E_jumps_jz_jnz(node: [Node])
 		E_jumps_with_fallthrough("jp z,", "jp nz,", node);
+	end sub;
+
+	sub E_jumps_jnz_jz(node: [Node])
+		E_jumps_with_fallthrough("jp nz,", "jp z,", node);
 	end sub;
 
 	sub E_jumps_jc_jnc(node: [Node])
@@ -1717,6 +1738,12 @@ gen BLTS2(hl, de):b uses a|bc
 	E_jumps_jm_jp(self.n[0]);
 }
 
+gen BLTS2(hl|bc|de:lhs, CONSTANT(value==0)):b
+{
+	E_bit(7, hireg($lhs));
+	E_jumps_jnz_jz(self.n[0]);
+}
+
 gen BEQU4(dede, hlhl):b uses a
 		{ bequ4(self.n[0]); }
 
@@ -1740,7 +1767,15 @@ gen BLTS4(hlhl, dede):b
 	E_callhelper("_cmps4");
 	E_jumps_jm_jp(self.n[0]);
 }
-	
+
+gen BLTS4(r32:lhs, CONSTANT(value==0)):b
+{
+	E_exx();
+	E_bit(7, hireg($lhs));
+	E_exx();
+	E_jumps_jnz_jz(self.n[0]);
+}
+
 // --- Case -----------------------------------------------------------------
 
 gen STARTCASE1(a);

--- a/src/cowcom/expressions.coh
+++ b/src/cowcom/expressions.coh
@@ -68,6 +68,15 @@ sub UndoLValue(lvalue: [Node]): (address: [Node])
 	Discard(lvalue);
 end sub;
 
+sub expr_i_cant_do_that(lhs: [Node], rhs: [Node])
+	StartError();
+	print(lhs.type.name);
+	print(" and ");
+	print(rhs.type.name);
+	print(" are not compatible in this context");
+	EndError();
+end sub;
+
 sub CheckExpressionType(node: [Node], type: [Symbol])
 	if node.type == (0 as [Symbol]) then
 		node.type := type;
@@ -116,12 +125,7 @@ sub ResolveUntypedConstantsSimply(lhs: [Node], rhs: [Node])
 	elseif (lhs.type == (0 as [Symbol])) and (rhs.type != (0 as [Symbol])) then
 		lhs.type := rhs.type;
 	elseif lhs.type != rhs.type then
-		StartError();
-		print("type mismatch between ");
-		print(lhs.type.name);
-		print(" and ");
-		print(rhs.type.name);
-		EndError();
+		expr_i_cant_do_that(lhs, rhs);
 	end if;
 end sub;
 
@@ -140,12 +144,7 @@ end sub;
 sub CondSimple(lhs: [Node], rhs: [Node])
 	ResolveUntypedConstantsSimply(lhs, rhs);
 	if lhs.type != rhs.type then
-		StartError();
-		print("you tried to compare a ");
-		print(lhs.type.name);
-		print(" and a ");
-		print(rhs.type.name);
-		EndError();
+		expr_i_cant_do_that(lhs, rhs);
 	end if;
 end sub;
 
@@ -158,12 +157,7 @@ sub ExprAdd(lhs: [Node], rhs: [Node]): (result: [Node])
 	ResolveUntypedConstantsForAddOrSub(lhs, rhs);
 
 	sub cant_add_that()
-		StartError();
-		print("you can't add a ");
-		print(lhs.type.name);
-		print(" to a ");
-		print(rhs.type.name);
-		EndError();
+		expr_i_cant_do_that(lhs, rhs);
 	end sub;
 
 	if (IsPtr(lhs.type) != 0) then
@@ -171,7 +165,7 @@ sub ExprAdd(lhs: [Node], rhs: [Node]): (result: [Node])
 			cant_add_that();
 		end if;
 	elseif IsPtr(rhs.type) != 0 then
-		SimpleError("add numbers to pointers, not vice versa");
+		cant_add_that();
 	elseif (IsPtr(lhs.type) == 0) and (lhs.type != rhs.type) then
 		cant_add_that();
 	end if;
@@ -184,12 +178,7 @@ sub ExprSub(lhs: [Node], rhs: [Node]): (result: [Node])
 	ResolveUntypedConstantsForAddOrSub(lhs, rhs);
 
 	sub cant_sub_that()
-		StartError();
-		print("you can't subtract a ");
-		print(lhs.type.name);
-		print(" from a ");
-		print(rhs.type.name);
-		EndError();
+		expr_i_cant_do_that(lhs, rhs);
 	end sub;
 
 	if (IsPtr(lhs.type) != 0) and (IsPtr(rhs.type) == 0) and (rhs.type != intptr_type) then
@@ -231,37 +220,22 @@ sub expr_i_checkshift(lhs: [Node], rhs: [Node])
 	CheckExpressionType(rhs, uint8_type);
 end sub;
 
-sub ExprRShift(lhs: [Node], rhs: [Node]): (result: [Node])
-	if lhs.op == MIDCODE_CONSTANT then
-		expr_i_checkrhsconst(rhs);
-		lhs.constant.value := lhs.constant.value >> (rhs.constant.value as uint8);
-		result := lhs;
-		Discard(rhs);
-		return;
-	end if;
-
-	expr_i_checkshift(lhs, rhs);
-
-	result := MidRshiftu(NodeWidth(lhs), lhs, rhs);
-	result.type := lhs.type;
-
+sub ExprShift(sop: uint8, uop: uint8, lhs: [Node], rhs: [Node]): (result: [Node])
+	var op := uop;
 	if IsSNum(lhs.type) != 0 then
-		result.op := result.op + (MIDCODE_RSHIFTS0-MIDCODE_RSHIFTU0);
+		op := sop;
 	end if;
-end sub;
 
-sub ExprLShift(lhs: [Node], rhs: [Node]): (result: [Node])
 	if lhs.op == MIDCODE_CONSTANT then
 		expr_i_checkrhsconst(rhs);
-		lhs.constant.value := lhs.constant.value << (rhs.constant.value as uint8);
+		lhs.constant.value := FoldConstant2(op, lhs, rhs);
 		result := lhs;
 		Discard(rhs);
 		return;
 	end if;
-
 	expr_i_checkshift(lhs, rhs);
 
-	result := MidLshift(NodeWidth(lhs), lhs, rhs);
+	result := MidC2Op(op, NodeWidth(lhs), lhs, rhs);
 	result.type := lhs.type;
 end sub;
 

--- a/src/cowcom/lempar.coh
+++ b/src/cowcom/lempar.coh
@@ -68,18 +68,6 @@ var yyRuleInfoNRhs: uint8[] := {
 %%
 };
 
-# reduce actions
-sub yy_find_reduce_action(stateno: YYACTIONTYPE, lookahead: YYCODETYPE): (action: YYACTIONTYPE)
-	action := yy_default[stateno as @indexof yy_default];
-	if stateno <= YY_REDUCE_COUNT then
-		var i := (yy_reduce_ofst[stateno as @indexof yy_reduce_ofst] as @indexof yy_action)
-				+ (lookahead as @indexof yy_action);
-		if (i>=0) and (i<YY_ACTTAB_COUNT) and (yy_lookahead[i] == lookahead) then
-			action := yy_action[i];
-		end if;
-	end if;
-end sub;
-
 sub yy_trace_shift(stateno: YYACTIONTYPE, msg: string)
 	print(msg);
 	print(" '");
@@ -118,7 +106,16 @@ sub yy_reduce(yyruleno: YYACTIONTYPE, yylookahead: YYCODETYPE, yylookaheadtoken:
 	[@next yytos].minor.yyall := yylhs.yyall;
 
 	var yygoto := yyRuleInfoLhs[yyruleno as @indexof yyRuleInfoLhs];
-	yyact := yy_find_reduce_action(yytos.stateno, yygoto);
+	var stateno := yytos.stateno;
+	yyact := yy_default[stateno as @indexof yy_default];
+	if stateno <= YY_REDUCE_COUNT then
+		var i := (yy_reduce_ofst[stateno as @indexof yy_reduce_ofst] as @indexof yy_action)
+				+ (yygoto as @indexof yy_action);
+		if (i>=0) and (i<YY_ACTTAB_COUNT) and (yy_lookahead[i] == yygoto) then
+			yyact := yy_action[i];
+		end if;
+	end if;
+
 	yytos := @next yytos;
 	yytos.stateno := yyact;
 	yytos.major := yygoto;

--- a/src/cowcom/midcodec.coh
+++ b/src/cowcom/midcodec.coh
@@ -88,16 +88,19 @@ sub FoldConstant2(op: uint8, lhsp: [Node], rhsp: [Node]): (result: Arith)
 	var lhs := lhsp.constant.value;
 	var rhs := rhsp.constant.value;
 	case op is
-		when MIDCODE_ADD0: result := lhs + rhs;
-		when MIDCODE_SUB0: result := lhs - rhs;
-		when MIDCODE_MUL0: result := lhs * rhs;
-		when MIDCODE_DIVU0: result := ((lhs as uint32) / (rhs as uint32)) as Arith;
-		when MIDCODE_DIVS0: result := (lhs as int32) / (rhs as int32);
-		when MIDCODE_REMU0: result := ((lhs as uint32) % (rhs as uint32)) as Arith;
-		when MIDCODE_REMS0: result := (lhs as int32) % (rhs as int32);
-		when MIDCODE_AND0: result := lhs & rhs;
-		when MIDCODE_OR0:  result := lhs | rhs;
-		when MIDCODE_EOR0: result := lhs ^ rhs;
+		when MIDCODE_ADD0:      result := lhs + rhs;
+		when MIDCODE_SUB0:      result := lhs - rhs;
+		when MIDCODE_MUL0:      result := lhs * rhs;
+		when MIDCODE_DIVU0:     result := ((lhs as uint32) / (rhs as uint32)) as Arith;
+		when MIDCODE_DIVS0:     result := (lhs as int32) / (rhs as int32);
+		when MIDCODE_REMU0:     result := ((lhs as uint32) % (rhs as uint32)) as Arith;
+		when MIDCODE_REMS0:     result := (lhs as int32) % (rhs as int32);
+		when MIDCODE_AND0:      result := lhs & rhs;
+		when MIDCODE_OR0:       result := lhs | rhs;
+		when MIDCODE_EOR0:      result := lhs ^ rhs;
+		when MIDCODE_LSHIFT0:   result := lhs << (rhs as uint8);
+		when MIDCODE_RSHIFTU0:  result := ((lhs as uint32) >> (rhs as uint8)) as Arith;
+		when MIDCODE_RSHIFTS0:  result := (lhs as int32) >> (rhs as uint8);
 		when else:
 			midcodec_i_bad_fold();
 	end case;

--- a/src/cowcom/parser.y
+++ b/src/cowcom/parser.y
@@ -393,8 +393,8 @@ expression(E) ::= expression(E1) PERCENT expression(E2).   { E := Expr2Simple(MI
 expression(E) ::= expression(E1) CARET expression(E2).     { E := Expr2Simple(MIDCODE_EOR0, MIDCODE_EOR0, E1, E2); }
 expression(E) ::= expression(E1) AMPERSAND expression(E2). { E := Expr2Simple(MIDCODE_AND0, MIDCODE_AND0, E1, E2); }
 expression(E) ::= expression(E1) PIPE expression(E2).      { E := Expr2Simple(MIDCODE_OR0, MIDCODE_OR0, E1, E2); }
-expression(E) ::= expression(E1) LSHIFT expression(E2).    { E := ExprLShift(E1, E2); }
-expression(E) ::= expression(E1) RSHIFT expression(E2).    { E := ExprRShift(E1, E2); }
+expression(E) ::= expression(E1) LSHIFT expression(E2).    { E := ExprShift(MIDCODE_LSHIFT0, MIDCODE_LSHIFT0, E1, E2); }
+expression(E) ::= expression(E1) RSHIFT expression(E2).    { E := ExprShift(MIDCODE_RSHIFTS0, MIDCODE_RSHIFTU0, E1, E2); }
 
 expression(E) ::= expression(E1) AS typeref(T).
 {

--- a/tools/newgen/main.c
+++ b/tools/newgen/main.c
@@ -722,37 +722,24 @@ static void emit_replacement(Rule* rule, Node* pattern, Node* replacement)
 
 static void create_rewriters(void)
 {
-	#if defined COWGOL
-		fprintf(outfp, "sub RewriteNode(rule: uint8, n: [[Node]]): (result: [Node])\n");
-		fprintf(outfp, "case rule is\n");
-	#else
+	#if !defined COWGOL
 		fprintf(outfp, "Node* rewrite_node(uint8_t rule, Node** n) {\n");
 		fprintf(outfp, "switch (rule) {\n");
-	#endif
 
-	for (int i=0; i<rulescount; i++)
-	{
-		Rule* r = rules[i];
-		if (r->replacement)
+		for (int i=0; i<rulescount; i++)
 		{
-			#if defined COWGOL
-				fprintf(outfp, "when %d:\n", i);
-				fprintf(outfp, "result :=\n");
-			#else
+			Rule* r = rules[i];
+			if (r->replacement)
+			{
 				fprintf(outfp, "case %d:\n", i);
 				fprintf(outfp, "\treturn\n");
-			#endif
 
-			print_line(r->lineno);
-			emit_replacement(r, r->pattern, r->replacement);
-			fprintf(outfp, ";\n");
+				print_line(r->lineno);
+				emit_replacement(r, r->pattern, r->replacement);
+				fprintf(outfp, ";\n");
+			}
 		}
-	}
 
-	#if defined COWGOL
-		fprintf(outfp, "end case;\n");
-		fprintf(outfp, "end sub;\n");
-	#else
 		fprintf(outfp, "}\n");
 		fprintf(outfp, "return NULL;\n");
 		fprintf(outfp, "}\n");


### PR DESCRIPTION
Continue picking away at the 8080 and Z80 backends. This actually knocks quite a lot off the compiler size while also improving the code quality. The Z80 self compiler is down from 57179 to 54938 bytes, and the 8080 self compiler 51442 to 49629 bytes. Still too big, still better.