### PR TITLE
Add a cowcom ncgen target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export CFLAGS = -g -O3
 export LDFLAGS = -g
 
 all: $(OBJ)/build.ninja
-	@ninja -f $(OBJ)/build.ninja
+	@ninja -f $(OBJ)/build.ninja -k0
 
 clean:
 	@echo CLEAN

--- a/mkninja.lua
+++ b/mkninja.lua
@@ -101,5 +101,6 @@ include "src/cowcom/build.lua"
 include "src/cowwrap/build.lua"
 include "rt/cpm/build.lua"
 include "rt/cpmz/build.lua"
+include "rt/cgen/build.lua"
 include "tests/build.lua"
 

--- a/rt/cgen/build.lua
+++ b/rt/cgen/build.lua
@@ -1,0 +1,5 @@
+cowwrap {
+	ins = { "rt/cgen/cowgol.cos" },
+	outs = { "$OBJ/rt/cgen/cowgol.coo" }
+}
+

--- a/rt/cgen/cowgol.h
+++ b/rt/cgen/cowgol.h
@@ -32,6 +32,8 @@ union data
 {
 	i8 i8;
 	i4 i4[2];
+	i2 i2[4];
+	i1 i1[8];
 	void* ptr;
 };
 

--- a/src/build.lua
+++ b/src/build.lua
@@ -177,7 +177,7 @@ function cowlink(e)
 	rule {
 		ins = concat {
 			"scripts/quiet",
-			"bin/cowlink.8080.ocgen.exe",
+			e.linker,
 			e.runtime,
 			e.ins
 		},
@@ -190,6 +190,7 @@ function cowlink_cpm(e)
 	cowlink {
 		ins = e.ins,
 		outs = e.outs,
+		linker = "bin/cowlink.8080.ocgen.exe",
 		runtime = "$OBJ/rt/cpm/cowgol.coo",
 	}
 end
@@ -198,7 +199,17 @@ function cowlink_cpmz(e)
 	cowlink {
 		ins = e.ins,
 		outs = e.outs,
+		linker = "bin/cowlink.8080.ocgen.exe",
 		runtime = "$OBJ/rt/cpmz/cowgol.coo",
+	}
+end
+
+function cowlink_cgen(e)
+	cowlink {
+		ins = e.ins,
+		outs = e.outs,
+		linker = "bin/cowlink.cgen.ocgen.exe",
+		runtime = "$OBJ/rt/cgen/cowgol.coo",
 	}
 end
 

--- a/src/cowcom/arch8080.cow.ng
+++ b/src/cowcom/arch8080.cow.ng
@@ -19,6 +19,18 @@
 		newvalue := value;
 	end sub;
 
+	sub ArchInitTypes()
+		uint32_type := MakeNumberType(4, 1, 0, "uint32");
+		int32_type := MakeNumberType(4, 1, 1, "int32");
+		uint16_type := MakeNumberType(2, 1, 0, "uint16");
+		int16_type := MakeNumberType(2, 1, 1, "int16");
+		uint8_type := MakeNumberType(1, 1, 0, "uint8");
+		int8_type := MakeNumberType(1, 1, 1, "int8");
+
+		intptr_type := uint16_type;
+		AddAliasString("intptr", intptr_type);
+	end sub;
+
 	sub ArchGuessIntType(min: Arith, max: Arith): (symbol: [Symbol])
 		if (min >= 0) and (max <= 255) then
 			symbol := uint8_type;
@@ -50,20 +62,6 @@
 		end if;
 	end sub;
 
-	sub E_labelref(labelid: uint16)
-		EmitByte(COO_ESCAPE_THISCOO);
-		E_h16(labelid);
-	end sub;
-
-	sub E_subref(subr: [Subroutine])
-		if subr == current_subr then
-			EmitByte(COO_ESCAPE_THISSUB);
-		else
-			EmitByte(COO_ESCAPE_SUBREF);
-			E_h16(subr.id);
-		end if;
-	end sub;
-
 	sub E_symref(sym: [Symbol], off: Size)
 		if sym.vardata.externname != (0 as string) then
 			E(sym.vardata.externname);
@@ -74,22 +72,6 @@
 			E_h8(0);
 			E_h16(sym.vardata.offset + off);
 		end if;
-	end sub;
-
-	sub E_space()
-		EmitByte(' ');
-	end sub;
-
-	sub E_comma()
-		EmitByte(',');
-	end sub;
-
-	sub E_tab()
-		EmitByte('\t');
-	end sub;
-
-	sub E_nl();
-		EmitByte('\n');
 	end sub;
 
 	sub R_flushall()
@@ -630,7 +612,7 @@
 wordsize uint16;
 
 register a b c d e h l hl de bc;
-register stk4 param;
+register stk4;
 
 regdata a              compatible a|b|d|h;
 regdata b  uses bc|b|c compatible a|b|d|h;
@@ -640,7 +622,6 @@ regdata bc uses bc|b|c compatible bc|de|hl;
 regdata de uses de|d|e compatible bc|de|hl;
 regdata hl uses hl|h|l compatible bc|de|hl;
 regdata stk4 stacked;
-regdata param stacked;
 
 // --- Core things ----------------------------------------------------------
 
@@ -1512,6 +1493,8 @@ gen WHENCASE4():c uses a
 	case2($c.value as uint16, REG_BC, $c.falselabel);
 	case2(($c.value >> 16) as uint16, REG_DE, $c.falselabel);
 }
+
+gen ENDCASE();
 
 // --- Casts ----------------------------------------------------------------
 

--- a/src/cowcom/archcgen.cow.ng
+++ b/src/cowcom/archcgen.cow.ng
@@ -77,8 +77,10 @@
 
 	sub E_symref(sym: [Symbol], off: Size)
 		if sym.vardata.externname != (0 as string) then
+			E("((i1*)");
 			E(sym.vardata.externname);
 			E_i16(off as int16);
+			E(")");
 		else
 			EmitByte(COO_ESCAPE_WSREF);
 			E_h16(sym.vardata.subr.id);

--- a/src/cowcom/archcgen.cow.ng
+++ b/src/cowcom/archcgen.cow.ng
@@ -61,6 +61,7 @@
 	sub ArchInitVariable(symbol: [Symbol])
 		var subr := symbol.vardata.subr;
 		var offset := subr.workspace[0];
+		offset := ArchAlignUp(offset, symbol.vardata.type.typedata.alignment);
 		symbol.vardata.offset := offset;
 		subr.workspace[0] := offset + symbol.vardata.type.typedata.width;
 	end sub;
@@ -156,7 +157,13 @@ gen STARTSUB():s
 	EmitterPushChunk();
 	E_h16($s.subr.id);
 
-	E("\n\nvoid ");
+	E("\n// ");
+	E($s.subr.name);
+	E_space();
+	EmitByte(COO_ESCAPE_WSREF);
+	E_h16($s.subr.id);
+	E("000000");
+	E("\nvoid ");
 	E_subref($s.subr);
 	E("(");
 
@@ -168,6 +175,8 @@ gen STARTSUB():s
 		first := 0;
 	end sub;
 
+	# Output parameters, left to right (the rightmost gets pushed last)
+
 	var count: uint8 := 0;
 	while count != $s.subr.num_output_parameters loop
 		var param := GetOutputParameter($s.subr, count);
@@ -178,11 +187,18 @@ gen STARTSUB():s
 		E("* p");
 		E_u16(Push());
 
+		E(" /* ");
+		E(param.name);
+		E(" */");
 		count := count + 1;
 	end loop;
 
-	count := 0;
-	while count != $s.subr.num_input_parameters loop
+	# Input parameters, right to left (the rightmost was pushed last
+	# and so is the first C parameter)
+
+	count := $s.subr.num_input_parameters;
+	while count != 0 loop
+		count := count - 1;
 		param := GetInputParameter($s.subr, count);
 
 		comma();
@@ -191,7 +207,9 @@ gen STARTSUB():s
 		E(" p");
 		E_u16(Push());
 
-		count := count + 1;
+		E(" /* ");
+		E(param.name);
+		E(" */");
 	end loop;
 
 	if ($s.subr.num_input_parameters + $s.subr.num_output_parameters) == 0 then
@@ -209,7 +227,9 @@ gen STARTSUB():s
 		E_symref(param, 0);
 		E(") = p");
 		E_u16(Pop());
-		E(";\n");
+		E("; /*");
+		E(param.name);
+		E(" */\n");
 
 		count := count + 1;
 	end loop;
@@ -296,7 +316,7 @@ gen v8 := POPARG8();
 			count := count + 1;
 		end loop;
 
-		# Input parameters (right to left; the last one was pushed last).
+		# Input parameters (right to left; the rightmost gets pushed last)
 
 		count := 0;
 		while count != subr.num_input_parameters loop
@@ -657,6 +677,7 @@ gen v8 := RSHIFTS8(v8, v1) { Shift(8, "s8", ">>"); }
 		else
 			E_labelref(node.beqs0.falselabel);
 		end if;
+		E(";\n");
 	end sub;
 %}
 
@@ -702,9 +723,9 @@ gen STARTCASE2(v2);
 gen STARTCASE4(v4);
 gen STARTCASE8(v8);
 
-gen WHENCASE1():c { Whencase($c.value, $c.falselabel); }
-gen WHENCASE2():c { Whencase($c.value, $c.falselabel); }
-gen WHENCASE4():c { Whencase($c.value, $c.falselabel); }
+gen WHENCASE1():c { Whencase($c.value & 0xff, $c.falselabel); }
+gen WHENCASE2():c { Whencase($c.value & 0xffff, $c.falselabel); }
+gen WHENCASE4():c { Whencase($c.value & 0xffffffff, $c.falselabel); }
 gen WHENCASE8():c { Whencase($c.value, $c.falselabel); }
 
 gen ENDCASE()

--- a/src/cowcom/archcgen.cow.ng
+++ b/src/cowcom/archcgen.cow.ng
@@ -1,0 +1,929 @@
+%{
+	var uint64_type: [Symbol];
+	var int64_type: [Symbol];
+	var uint32_type: [Symbol];
+	var int32_type: [Symbol];
+	var uint16_type: [Symbol];
+	var int16_type: [Symbol];
+	var uint8_type: [Symbol];
+	var int8_type: [Symbol];
+	var intptr_type: [Symbol];
+
+	const VARSTACK_SIZE := 64;
+	typedef Slot := uint16;
+	var varstack: Slot[VARSTACK_SIZE];
+	var varsp: uint8;
+	var varid: Slot := 1;
+
+	record Extern
+		name: string;
+		id: uint16;
+		next: [Extern];
+	end record;
+
+	var externs: [Extern] := (0 as [Extern]);
+
+	sub ArchAlignUp(value: Size, alignment: uint8): (newvalue: Size)
+		var a := (alignment-1) as Size;
+		newvalue := (value+a) & ~a;
+	end sub;
+
+	sub ArchInitTypes()
+		uint64_type := MakeNumberType(8, 8, 0, "uint64");
+		int64_type := MakeNumberType(8, 8, 1, "int64");
+		uint32_type := MakeNumberType(4, 4, 0, "uint32");
+		int32_type := MakeNumberType(4, 4, 1, "int32");
+		uint16_type := MakeNumberType(2, 2, 0, "uint16");
+		int16_type := MakeNumberType(2, 2, 1, "int16");
+		uint8_type := MakeNumberType(1, 1, 0, "uint8");
+		int8_type := MakeNumberType(1, 1, 1, "int8");
+
+		intptr_type := uint64_type;
+		AddAliasString("intptr", intptr_type);
+	end sub;
+
+	sub ArchGuessIntType(min: Arith, max: Arith): (symbol: [Symbol])
+		if (min >= 0) and (max <= 255) then
+			symbol := uint8_type;
+		elseif (min >= -128) and (max <= 127) then
+			symbol := int8_type;
+		elseif (min >= 0) and (max <= 65535) then
+			symbol := uint16_type;
+		elseif (min >= -32768) and (max <= 32767) then
+			symbol := int16_type;
+		elseif (min >= 0) then
+			symbol := uint32_type;
+		else
+			symbol := int32_type;
+		end if;
+	end sub;
+
+	sub ArchInitVariable(symbol: [Symbol])
+		var subr := symbol.vardata.subr;
+		var offset := subr.workspace[0];
+		symbol.vardata.offset := offset;
+		subr.workspace[0] := offset + symbol.vardata.type.typedata.width;
+	end sub;
+
+	sub ArchInitMember(containing: [Symbol], member: [Symbol], position: Size)
+		position := ArchAlignUp(position, member.vardata.type.typedata.alignment);
+		member.vardata.offset := position;
+		position := position + member.vardata.type.typedata.width;
+		if position > containing.typedata.width then
+			containing.typedata.width := position;
+		end if;
+	end sub;
+
+	sub E_symref(sym: [Symbol], off: Size)
+		if sym.vardata.externname != (0 as string) then
+			E(sym.vardata.externname);
+			E_i16(off as int16);
+		else
+			EmitByte(COO_ESCAPE_WSREF);
+			E_h16(sym.vardata.subr.id);
+			E_h8(0);
+			E_h16(sym.vardata.offset + off);
+		end if;
+	end sub;
+
+	# Note that this *destroys* the source register.
+	sub ArchEmitMove(src: RegId, dest: RegId)
+		SimpleError("move");
+	end sub;
+
+	sub ArchEndInstruction()
+	end sub;
+
+	sub PushVid(vid: Slot)
+		if varsp == VARSTACK_SIZE then
+			SimpleError("varstack overflow");
+		end if;
+		varstack[varsp] := vid;
+		varsp := varsp + 1;
+	end sub;
+
+	sub Push(): (vid: Slot)
+		vid := varid;
+		varid := varid + 1;
+		PushVid(vid);
+	end sub;
+
+	sub Pop(): (vid: Slot)
+		if varsp == 0 then
+			SimpleError("varstack underflow");
+		end if;
+		varsp := varsp - 1;
+		vid := varstack[varsp];
+	end sub;
+%}
+
+wordsize uint32;
+
+register v1 v2 v4 v8;
+
+regdata v1 stacked;
+regdata v2 stacked;
+regdata v4 stacked;
+regdata v8 stacked;
+
+// --- Core things ----------------------------------------------------------
+
+gen STARTFILE();
+gen ENDFILE();
+
+gen LABEL():b
+{
+	E_labelref($b.label);
+	E(":;\n");
+}
+
+gen JUMP():j
+{
+	E("\tgoto ");
+	E_labelref($j.label);
+	E(";\n");
+}
+
+gen RETURN()
+{
+	E("\tgoto endsub;\n");
+}
+
+// --- Subroutines ----------------------------------------------------------
+
+gen STARTSUB():s
+{
+	EmitterPushChunk();
+	E_h16($s.subr.id);
+
+	E("\n\nvoid ");
+	E_subref($s.subr);
+	E("(");
+
+	var first: uint8 := 1;
+	sub comma()
+		if first == 0 then
+			E(", ");
+		end if;
+		first := 0;
+	end sub;
+
+	var count: uint8 := 0;
+	while count != $s.subr.num_output_parameters loop
+		var param := GetOutputParameter($s.subr, count);
+
+		comma();
+		E("i");
+		E_u8(param.vardata.type.typedata.width as uint8);
+		E("* p");
+		E_u16(Push());
+
+		count := count + 1;
+	end loop;
+
+	count := 0;
+	while count != $s.subr.num_input_parameters loop
+		param := GetInputParameter($s.subr, count);
+
+		comma();
+		E("i");
+		E_u8(param.vardata.type.typedata.width as uint8);
+		E(" p");
+		E_u16(Push());
+
+		count := count + 1;
+	end loop;
+
+	if ($s.subr.num_input_parameters + $s.subr.num_output_parameters) == 0 then
+		E("void");
+	end if;
+	E(") {\n");
+
+	count := 0;
+	while count != $s.subr.num_input_parameters loop
+		param := GetInputParameter($s.subr, count);
+
+		E("\t*(i");
+		E_u8(param.vardata.type.typedata.width as uint8);
+		E("*)(intptr_t)(");
+		E_symref(param, 0);
+		E(") = p");
+		E_u16(Pop());
+		E(";\n");
+
+		count := count + 1;
+	end loop;
+}
+
+gen ENDSUB():s
+{
+	E("endsub:;\n");
+
+	var count: uint8 := $s.subr.num_output_parameters;
+	while count != 0 loop
+		count := count - 1;
+		var param := GetOutputParameter($s.subr, count);
+
+		E("\t*p");
+		E_u16(Pop());
+		E(" = *(i");
+		E_u8(param.vardata.type.typedata.width as uint8);
+		E("*)(intptr_t)(");
+		E_symref(param, 0);
+		E(");\n");
+	end loop;
+	E("}\n");
+	EmitterDeclareWorkspace($s.subr, 0, $s.subr.workspace[0]);
+	EmitterPopChunk('S');
+}
+
+gen PUSHARG1(v1);
+gen PUSHARG2(v2);
+gen PUSHARG4(v4);
+gen PUSHARG8(v8);
+
+gen v1 := POPARG1();
+gen v2 := POPARG2();
+gen v4 := POPARG4();
+gen v8 := POPARG8();
+
+%{
+	sub Call(subr: [Subroutine])
+		# Allocate vids for the return parameters.
+
+		var outputvid := varid;
+		varid := varid + (subr.num_output_parameters as Slot);
+
+		# Declare variables for the output parameters.
+
+		var count: uint8 := 0;
+		while count != subr.num_output_parameters loop
+			var param := GetOutputParameter(subr, count);
+
+			E("\ti");
+			E_u8(param.vardata.type.typedata.width as uint8);
+			E(" v");
+			E_u16(outputvid + (count as Slot));
+			E(";\n");
+
+			count := count + 1;
+		end loop;
+
+		# Emit the function call.
+
+		E("\t");
+		E_subref(subr);
+		E("(");
+
+		var first: uint8 := 1;
+		sub comma()
+			if first == 0 then
+				E(", ");
+			end if;
+			first := 0;
+		end sub;
+
+		# Output parameters (left to right).
+
+		count := 0;
+		while count != subr.num_output_parameters loop
+			param := GetOutputParameter(subr, count);
+
+			comma();
+			E("&v");
+			E_u16(outputvid + (count as Slot));
+
+			count := count + 1;
+		end loop;
+
+		# Input parameters (right to left; the last one was pushed last).
+
+		count := 0;
+		while count != subr.num_input_parameters loop
+			var vid := Pop();
+			comma();
+			E("v");
+			E_u16(vid);
+
+			count := count + 1;
+		end loop;
+
+		E(");\n");
+
+		# Now push the output parameters (left to right; the last one will be
+		# popped first).
+
+		count := 0;
+		while count != subr.num_output_parameters loop
+			vid := outputvid + (count as Slot);
+			PushVid(vid);
+			count := count + 1;
+		end loop;
+	end sub;
+%}
+
+gen CALL():s         { Call($s.subr); }
+gen v1 := CALLE1():s { Call($s.subr); }
+gen v2 := CALLE2():s { Call($s.subr); }
+gen v4 := CALLE4():s { Call($s.subr); }
+gen v8 := CALLE8():s { Call($s.subr); }
+
+// --- Core conversions --------------------------------------------------
+
+%{
+	sub LoadConstant(width: uint8, value: Arith)
+		E("\ti");
+		E_u8(width);
+		E(" v");
+		E_u16(Push());
+		E(" = (i");
+		E_u8(width);
+		E(")");
+		E_i32(value as int32);
+		E(";\n");
+	end sub;
+%}
+
+gen v1 := CONSTANT():c { LoadConstant(1, $c.value); }
+gen v2 := CONSTANT():c { LoadConstant(2, $c.value); }
+gen v4 := CONSTANT():c { LoadConstant(4, $c.value); }
+gen v8 := CONSTANT():c { LoadConstant(8, $c.value); }
+
+gen v8 := ADDRESS():a
+{
+	E("\ti8 v");
+	E_u16(Push());
+	E(" = (i8)(intptr_t)(");
+	E_symref($a.sym, $a.off);
+	E(");\n");
+}
+
+// --- Loads and stores -----------------------------------------------------
+
+%{
+	sub StoreVV(width: uint8)
+		var addrid := Pop();
+		var valid := Pop();
+		E("\t*(i");
+		E_u8(width);
+		E("*)(intptr_t)v");
+		E_u16(addrid);
+		E(" = v");
+		E_u16(valid);
+		E(";\n");
+	end sub;
+
+	sub LoadVV(width: uint8)
+		var addrid := Pop();
+		var valid := Push();
+		E("\ti");
+		E_u8(width);
+		E(" v");
+		E_u16(valid);
+		E(" = *(i");
+		E_u8(width);
+		E("*)(intptr_t)v");
+		E_u16(addrid);
+		E(";\n");
+	end sub;
+%}
+
+gen STORE1(v1:val, v8:addr) { StoreVV(1); }
+gen STORE2(v2:val, v8:addr) { StoreVV(2); }
+gen STORE4(v4:val, v8:addr) { StoreVV(4); }
+gen STORE8(v8:val, v8:addr) { StoreVV(8); }
+
+gen v1 := LOAD1(v8:addr) { LoadVV(1); }
+gen v2 := LOAD2(v8:addr) { LoadVV(2); }
+gen v4 := LOAD4(v8:addr) { LoadVV(4); }
+gen v8 := LOAD8(v8:addr) { LoadVV(8); }
+
+// --- Maths ----------------------------------------------------------------
+
+%{
+	sub Op2VV(width: uint8, op: string)
+		var rhsid := Pop();
+		var lhsid := Pop();
+		E("\ti");
+		E_u8(width);
+		E(" v");
+		E_u16(Push());
+		E(" = v");
+		E_u16(lhsid);
+		E(op);
+		E("v");
+		E_u16(rhsid);
+		E(";\n");
+	end sub;
+
+	sub Op2VC(width: uint8, op: string, rhs: Arith)
+		var lhsid := Pop();
+		E("\ti");
+		E_u8(width);
+		E(" v");
+		E_u16(Push());
+		E(" = v");
+		E_u16(lhsid);
+		E(op);
+		E("(");
+		E_i32(rhs);
+		E(");\n");
+	end sub;
+
+	sub Op2VVSigned(width: uint8, op: string)
+		var rhsid := Pop();
+		var lhsid := Pop();
+		E("\ti");
+		E_u8(width);
+		E(" v");
+		E_u16(Push());
+		E(" = (s");
+		E_u8(width);
+		E(")v");
+		E_u16(lhsid);
+		E(op);
+		E("(s");
+		E_u8(width);
+		E(")v");
+		E_u16(rhsid);
+		E(";\n");
+	end sub;
+
+	sub Op2VCSigned(width: uint8, op: string, rhs: Arith)
+		var lhsid := Pop();
+		E("\ti");
+		E_u8(width);
+		E(" v");
+		E_u16(Push());
+		E(" = v");
+		E_u16(lhsid);
+		E(op);
+		E("(");
+		E_i32(rhs);
+		E(");\n");
+	end sub;
+%}
+
+gen v1 := ADD1(v1:lhs, v1:rhs)          { Op2VV(1, "+"); }
+gen v2 := ADD2(v2:lhs, v2:rhs)          { Op2VV(2, "+"); }
+gen v4 := ADD4(v4:lhs, v4:rhs)          { Op2VV(4, "+"); }
+gen v8 := ADD8(v8:lhs, v8:rhs)          { Op2VV(8, "+"); }
+gen v1 := ADD1(v1:lhs, CONSTANT():rhs)  { Op2VC(1, "+", $rhs.value); }
+gen v2 := ADD2(v2:lhs, CONSTANT():rhs)  { Op2VC(2, "+", $rhs.value); }
+gen v4 := ADD4(v4:lhs, CONSTANT():rhs)  { Op2VC(4, "+", $rhs.value); }
+gen v8 := ADD8(v8:lhs, CONSTANT():rhs)  { Op2VC(8, "+", $rhs.value); }
+
+gen v1 := SUB1(v1:lhs, v1:rhs)          { Op2VV(1, "-"); }
+gen v2 := SUB2(v2:lhs, v2:rhs)          { Op2VV(2, "-"); }
+gen v4 := SUB4(v4:lhs, v4:rhs)          { Op2VV(4, "-"); }
+gen v8 := SUB8(v8:lhs, v8:rhs)          { Op2VV(8, "-"); }
+gen v1 := SUB1(v1:lhs, CONSTANT():rhs)  { Op2VC(1, "-", $rhs.value); }
+gen v2 := SUB2(v2:lhs, CONSTANT():rhs)  { Op2VC(2, "-", $rhs.value); }
+gen v4 := SUB4(v4:lhs, CONSTANT():rhs)  { Op2VC(4, "-", $rhs.value); }
+gen v8 := SUB8(v8:lhs, CONSTANT():rhs)  { Op2VC(8, "-", $rhs.value); }
+
+gen v1 := MUL1(v1:lhs, v1:rhs)          { Op2VV(1, "*"); }
+gen v2 := MUL2(v2:lhs, v2:rhs)          { Op2VV(2, "*"); }
+gen v4 := MUL4(v4:lhs, v4:rhs)          { Op2VV(4, "*"); }
+gen v8 := MUL8(v8:lhs, v8:rhs)          { Op2VV(8, "*"); }
+gen v1 := MUL1(v1:lhs, CONSTANT():rhs)  { Op2VC(1, "*", $rhs.value); }
+gen v2 := MUL2(v2:lhs, CONSTANT():rhs)  { Op2VC(2, "*", $rhs.value); }
+gen v4 := MUL4(v4:lhs, CONSTANT():rhs)  { Op2VC(4, "*", $rhs.value); }
+gen v8 := MUL8(v8:lhs, CONSTANT():rhs)  { Op2VC(8, "*", $rhs.value); }
+
+gen v1 := DIVU1(v1:lhs, v1:rhs)         { Op2VV(1, "/"); }
+gen v2 := DIVU2(v2:lhs, v2:rhs)         { Op2VV(2, "/"); }
+gen v4 := DIVU4(v4:lhs, v4:rhs)         { Op2VV(4, "/"); }
+gen v8 := DIVU8(v8:lhs, v8:rhs)         { Op2VV(8, "/"); }
+gen v1 := DIVU1(v1:lhs, CONSTANT():rhs) { Op2VC(1, "/", $rhs.value); }
+gen v2 := DIVU2(v2:lhs, CONSTANT():rhs) { Op2VC(2, "/", $rhs.value); }
+gen v4 := DIVU4(v4:lhs, CONSTANT():rhs) { Op2VC(4, "/", $rhs.value); }
+gen v8 := DIVU8(v8:lhs, CONSTANT():rhs) { Op2VC(8, "/", $rhs.value); }
+
+gen v1 := REMU1(v1:lhs, v1:rhs)         { Op2VV(1, "%"); }
+gen v2 := REMU2(v2:lhs, v2:rhs)         { Op2VV(2, "%"); }
+gen v4 := REMU4(v4:lhs, v4:rhs)         { Op2VV(4, "%"); }
+gen v8 := REMU8(v8:lhs, v8:rhs)         { Op2VV(8, "%"); }
+gen v1 := REMU1(v1:lhs, CONSTANT():rhs) { Op2VC(1, "%", $rhs.value); }
+gen v2 := REMU2(v2:lhs, CONSTANT():rhs) { Op2VC(2, "%", $rhs.value); }
+gen v4 := REMU4(v4:lhs, CONSTANT():rhs) { Op2VC(4, "%", $rhs.value); }
+gen v8 := REMU8(v8:lhs, CONSTANT():rhs) { Op2VC(8, "%", $rhs.value); }
+
+gen v1 := DIVS1(v1:lhs, v1:rhs)         { Op2VVSigned(1, "/"); }
+gen v2 := DIVS2(v2:lhs, v2:rhs)         { Op2VVSigned(2, "/"); }
+gen v4 := DIVS4(v4:lhs, v4:rhs)         { Op2VVSigned(4, "/"); }
+gen v8 := DIVS8(v8:lhs, v8:rhs)         { Op2VVSigned(8, "/"); }
+gen v1 := DIVS1(v1:lhs, CONSTANT():rhs) { Op2VCSigned(1, "/", $rhs.value); }
+gen v2 := DIVS2(v2:lhs, CONSTANT():rhs) { Op2VCSigned(2, "/", $rhs.value); }
+gen v4 := DIVS4(v4:lhs, CONSTANT():rhs) { Op2VCSigned(4, "/", $rhs.value); }
+gen v8 := DIVS8(v8:lhs, CONSTANT():rhs) { Op2VCSigned(8, "/", $rhs.value); }
+
+gen v1 := REMS1(v1:lhs, v1:rhs)         { Op2VVSigned(1, "%"); }
+gen v2 := REMS2(v2:lhs, v2:rhs)         { Op2VVSigned(2, "%"); }
+gen v4 := REMS4(v4:lhs, v4:rhs)         { Op2VVSigned(4, "%"); }
+gen v8 := REMS8(v8:lhs, v8:rhs)         { Op2VVSigned(8, "%"); }
+gen v1 := REMS1(v1:lhs, CONSTANT():rhs) { Op2VCSigned(1, "%", $rhs.value); }
+gen v2 := REMS2(v2:lhs, CONSTANT():rhs) { Op2VCSigned(2, "%", $rhs.value); }
+gen v4 := REMS4(v4:lhs, CONSTANT():rhs) { Op2VCSigned(4, "%", $rhs.value); }
+gen v8 := REMS8(v8:lhs, CONSTANT():rhs) { Op2VCSigned(8, "%", $rhs.value); }
+
+gen v1 := AND1(v1:lhs, v1:rhs)          { Op2VV(1, "&"); }
+gen v2 := AND2(v2:lhs, v2:rhs)          { Op2VV(2, "&"); }
+gen v4 := AND4(v4:lhs, v4:rhs)          { Op2VV(4, "&"); }
+gen v8 := AND8(v8:lhs, v8:rhs)          { Op2VV(8, "&"); }
+gen v1 := AND1(v1:lhs, CONSTANT():rhs)  { Op2VC(1, "&", $rhs.value); }
+gen v2 := AND2(v2:lhs, CONSTANT():rhs)  { Op2VC(2, "&", $rhs.value); }
+gen v4 := AND4(v4:lhs, CONSTANT():rhs)  { Op2VC(4, "&", $rhs.value); }
+gen v8 := AND8(v8:lhs, CONSTANT():rhs)  { Op2VC(8, "&", $rhs.value); }
+
+gen v1 := OR1(v1:lhs, v1:rhs)           { Op2VV(1, "|"); }
+gen v2 := OR2(v2:lhs, v2:rhs)           { Op2VV(2, "|"); }
+gen v4 := OR4(v4:lhs, v4:rhs)           { Op2VV(4, "|"); }
+gen v8 := OR8(v8:lhs, v8:rhs)           { Op2VV(8, "|"); }
+gen v1 := OR1(v1:lhs, CONSTANT():rhs)   { Op2VC(1, "|", $rhs.value); }
+gen v2 := OR2(v2:lhs, CONSTANT():rhs)   { Op2VC(2, "|", $rhs.value); }
+gen v4 := OR4(v4:lhs, CONSTANT():rhs)   { Op2VC(4, "|", $rhs.value); }
+gen v8 := OR8(v8:lhs, CONSTANT():rhs)   { Op2VC(8, "|", $rhs.value); }
+
+gen v1 := EOR1(v1:lhs, v1:rhs)          { Op2VV(1, "^"); }
+gen v2 := EOR2(v2:lhs, v2:rhs)          { Op2VV(2, "^"); }
+gen v4 := EOR4(v4:lhs, v4:rhs)          { Op2VV(4, "^"); }
+gen v8 := EOR8(v8:lhs, v8:rhs)          { Op2VV(8, "^"); }
+gen v1 := EOR1(v1:lhs, CONSTANT():rhs)  { Op2VC(1, "^", $rhs.value); }
+gen v2 := EOR2(v2:lhs, CONSTANT():rhs)  { Op2VC(2, "^", $rhs.value); }
+gen v4 := EOR4(v4:lhs, CONSTANT():rhs)  { Op2VC(4, "^", $rhs.value); }
+gen v8 := EOR8(v8:lhs, CONSTANT():rhs)  { Op2VC(8, "^", $rhs.value); }
+
+%{
+	sub Op1V(width: uint8, op: string)
+		var valid := Pop();
+		E("\ti");
+		E_u8(width);
+		E(" v");
+		E_u16(Push());
+		E(" = ");
+		E(op);
+		E("v");
+		E_u16(valid);
+		E(";\n");
+	end sub;
+%}
+
+gen v1 := NEG1(v1) { Op1V(1, "-"); }
+gen v2 := NEG2(v2) { Op1V(2, "-"); }
+gen v4 := NEG4(v4) { Op1V(4, "-"); }
+gen v8 := NEG8(v8) { Op1V(8, "-"); }
+gen v1 := NOT1(v1) { Op1V(1, "~"); }
+gen v2 := NOT2(v2) { Op1V(2, "~"); }
+gen v4 := NOT4(v4) { Op1V(4, "~"); }
+gen v8 := NOT8(v8) { Op1V(8, "~"); }
+
+// --- Shifts ---------------------------------------------------------------
+
+%{
+	sub Shift(width: uint8, type: string, op: string)
+		var rhsid := Pop();
+		var lhsid := Pop();
+		E("\ti");
+		E_u8(width);
+		E(" v");
+		E_u16(Push());
+		E(" = ((");
+		E(type);
+		E(")v");
+		E_u16(lhsid);
+		E(")");
+		E(op);
+		E("v");
+		E_u16(rhsid);
+		E(";\n");
+	end sub;
+%}
+
+gen v1 := LSHIFT1(v1, v1)  { Shift(1, "i1", "<<"); }
+gen v2 := LSHIFT2(v2, v1)  { Shift(2, "i2", "<<"); }
+gen v4 := LSHIFT4(v4, v1)  { Shift(4, "i4", "<<"); }
+gen v8 := LSHIFT8(v8, v1)  { Shift(8, "i8", "<<"); }
+gen v1 := RSHIFTU1(v1, v1) { Shift(1, "i1", ">>"); }
+gen v2 := RSHIFTU2(v2, v1) { Shift(2, "i2", ">>"); }
+gen v4 := RSHIFTU4(v4, v1) { Shift(4, "i4", ">>"); }
+gen v8 := RSHIFTU8(v8, v1) { Shift(8, "i8", ">>"); }
+gen v1 := RSHIFTS1(v1, v1) { Shift(1, "s1", ">>"); }
+gen v2 := RSHIFTS2(v2, v1) { Shift(2, "s2", ">>"); }
+gen v4 := RSHIFTS4(v4, v1) { Shift(4, "s4", ">>"); }
+gen v8 := RSHIFTS8(v8, v1) { Shift(8, "s8", ">>"); }
+
+// --- Branches -------------------------------------------------------------
+
+%{
+	sub Branch(node: [Node], op: string)
+		var rhsid := Pop();
+		var lhsid := Pop();
+		E("\tif (v");
+		E_u16(lhsid);
+		E(op);
+		E("v");
+		E_u16(rhsid);
+		E(") goto ");
+		E_labelref(node.beqs0.truelabel);
+		E("; else goto ");
+		E_labelref(node.beqs0.falselabel);
+		E(";\n");
+	end sub;
+
+	sub BranchSigned(node: [Node], width: uint8, op: string)
+		var rhsid := Pop();
+		var lhsid := Pop();
+		E("\tif ((s");
+		E_u8(width);
+		E(")v");
+		E_u16(lhsid);
+		E(op);
+		E("(s");
+		E_u8(width);
+		E(")v");
+		E_u16(rhsid);
+		E(") goto ");
+		E_labelref(node.beqs0.truelabel);
+		E("; else goto ");
+		E_labelref(node.beqs0.falselabel);
+		E(";\n");
+	end sub;
+
+	sub BranchConstant(node: [Node], lhs: Arith, rhs: Arith)
+		E("\tgoto ");
+		if lhs == rhs then
+			E_labelref(node.beqs0.truelabel);
+		else
+			E_labelref(node.beqs0.falselabel);
+		end if;
+	end sub;
+%}
+
+gen BEQU0(CONSTANT():c1, CONSTANT():c2):b { BranchConstant(self.n[0], $c1.value, $c2.value); }
+gen BEQS0(CONSTANT():c1, CONSTANT():c2):b { BranchConstant(self.n[0], $c1.value, $c2.value); }
+
+gen BEQU1(v1:lhs, v1:rhs):b { Branch(self.n[0], "=="); }
+gen BEQS1(v1:lhs, v1:rhs):b { Branch(self.n[0], "=="); }
+gen BEQU2(v2:lhs, v2:rhs):b { Branch(self.n[0], "=="); }
+gen BEQS2(v2:lhs, v2:rhs):b { Branch(self.n[0], "=="); }
+gen BEQU4(v4:lhs, v4:rhs):b { Branch(self.n[0], "=="); }
+gen BEQS4(v4:lhs, v4:rhs):b { Branch(self.n[0], "=="); }
+gen BEQU8(v8:lhs, v8:rhs):b { Branch(self.n[0], "=="); }
+gen BEQS8(v8:lhs, v8:rhs):b { Branch(self.n[0], "=="); }
+
+gen BLTU1(v1:lhs, v1:rhs):b { Branch(self.n[0], "<"); }
+gen BLTU2(v2:lhs, v2:rhs):b { Branch(self.n[0], "<"); }
+gen BLTU4(v4:lhs, v4:rhs):b { Branch(self.n[0], "<"); }
+gen BLTU8(v8:lhs, v8:rhs):b { Branch(self.n[0], "<"); }
+
+gen BLTS1(v1:lhs, v1:rhs):b { BranchSigned(self.n[0], 1, "<"); }
+gen BLTS2(v2:lhs, v2:rhs):b { BranchSigned(self.n[0], 2, "<"); }
+gen BLTS4(v4:lhs, v4:rhs):b { BranchSigned(self.n[0], 4, "<"); }
+gen BLTS8(v8:lhs, v8:rhs):b { BranchSigned(self.n[0], 8, "<"); }
+
+// --- Case -----------------------------------------------------------------
+
+%{
+	sub Whencase(value: Arith, falselabel: LabelRef)
+		var vid := varstack[varsp-1];
+		E("\tif (v");
+		E_u16(vid);
+		E(" != ");
+		E_i32(value);
+		E(") goto ");
+		E_labelref(falselabel);
+		E(";\n");
+	end sub;
+%}
+
+gen STARTCASE1(v1);
+gen STARTCASE2(v2);
+gen STARTCASE4(v4);
+gen STARTCASE8(v8);
+
+gen WHENCASE1():c { Whencase($c.value, $c.falselabel); }
+gen WHENCASE2():c { Whencase($c.value, $c.falselabel); }
+gen WHENCASE4():c { Whencase($c.value, $c.falselabel); }
+gen WHENCASE8():c { Whencase($c.value, $c.falselabel); }
+
+gen ENDCASE()
+{
+	varsp := varsp - 1;
+}
+
+// --- Casts ----------------------------------------------------------------
+
+%{
+	sub Cast(src: uint8, dest: uint8, sext: uint8)
+		var vid := Pop();
+		E("\ti");
+		E_u8(dest);
+		E(" v");
+		E_u16(Push());
+		E(" = ");
+		if sext != 0 then
+			E("(s");
+			E_u8(dest);
+			E(")(s");
+			E_u8(src);
+			E(")");
+		end if;
+		E("v");
+		E_u16(vid);
+		E(";\n");
+	end sub;
+%}
+
+gen v2 := CAST12(v1):c { Cast(1, 2, $c.sext); }
+gen v4 := CAST14(v1):c { Cast(1, 4, $c.sext); }
+gen v8 := CAST18(v1):c { Cast(1, 8, $c.sext); }
+gen v1 := CAST21(v2):c { Cast(2, 1, $c.sext); }
+gen v4 := CAST24(v2):c { Cast(2, 4, $c.sext); }
+gen v8 := CAST28(v2):c { Cast(2, 8, $c.sext); }
+gen v1 := CAST41(v4):c { Cast(4, 1, $c.sext); }
+gen v2 := CAST42(v4):c { Cast(4, 2, $c.sext); }
+gen v8 := CAST48(v4):c { Cast(4, 8, $c.sext); }
+gen v1 := CAST81(v8):c { Cast(8, 1, $c.sext); }
+gen v2 := CAST82(v8):c { Cast(8, 2, $c.sext); }
+gen v4 := CAST84(v8):c { Cast(8, 4, $c.sext); }
+
+// --- Strings --------------------------------------------------------------
+
+%{
+	var current_string_id: uint16 := 0;
+
+	sub E_string(text: string): (sid: uint16)
+		sid := current_string_id;
+		current_string_id := current_string_id + 1;
+
+		EmitterPushChunk();
+		E_h16(current_subr.id);
+
+		E("const i1 ");
+		EmitByte(COO_ESCAPE_THISCOO);
+		EmitByte('s');
+		E_h16(sid);
+		E("[] = { ");
+
+		var first: uint8 := 1;
+		loop
+			var c := [text];
+			text := text + 1;
+			if c == 0 then
+				break;
+			end if;
+			if first == 0 then
+				E_comma();
+			end if;
+			first := 0;
+			E("0x");
+			E_h8(c);
+		end loop;
+
+		if first == 0 then
+			E_comma();
+		end if;
+		E("0 };\n");
+		EmitterPopChunk('S');
+	end sub;
+%}
+
+gen v8 := STRING():s
+{
+	E("\ti8 v");
+	E_u16(Push());
+	E(" = (i8)(intptr_t)");
+	EmitByte(COO_ESCAPE_THISCOO);
+	EmitByte('s');
+	E_h16(E_string($s.text));
+	E(";\n");
+}
+
+// --- Array initialisers ------------------------------------------------
+
+%{
+	# This is *vile*. We need to emit differentiated bytes... but also,
+	# occasionally, pointers. We don't have any type information. So,
+	# we can't just emit a byte array because we might need to embed
+	# 8-byte pointers into it, which C doesn't allow. Instead, all
+	# static initialisers end up as arrays of i8, and we buffer up bytes
+	# to emit them in chunks of eight.
+
+	var initialiser_buffer: uint8[8];
+	var initialiser_buffer_fill_bytes: uint8 := 0;
+
+	sub FlushInitialiserBuffer()
+		if initialiser_buffer_fill_bytes != 0 then
+			E("\t{ .i1 = { ");
+			var i: uint8 := 0;
+			while i != initialiser_buffer_fill_bytes loop
+				if i != 0 then
+					E_comma();
+				end if;
+				E("0x");
+				E_h8(initialiser_buffer[i]);
+				i := i + 1;
+			end loop;
+			E("}},\n");
+			initialiser_buffer_fill_bytes := 0;
+		end if;
+	end sub;
+
+	sub E_bytes(ptr: [uint8], width: uint8)
+		while width != 0 loop
+			initialiser_buffer[initialiser_buffer_fill_bytes] := [ptr];
+			ptr := ptr + 1;
+			initialiser_buffer_fill_bytes := initialiser_buffer_fill_bytes + 1;
+
+			if initialiser_buffer_fill_bytes == @sizeof initialiser_buffer then
+				FlushInitialiserBuffer();
+			end if;
+			width := width - 1;
+		end loop;
+	end sub;
+%}
+
+gen STARTINIT():s
+{
+	EmitterPushChunk();
+	E_h16(current_subr.id);
+
+	E("static data ");
+	E($s.sym.vardata.externname);
+	E("[] = { // ");
+	E($s.sym.name);
+	E_nl();
+
+	initialiser_buffer_fill_bytes := 0;
+}
+	
+gen INIT1():c { E_bytes(&$c.value as [uint8], 1); }
+gen INIT2():c { E_bytes(&$c.value as [uint8], 2); }
+gen INIT4():c { E_bytes(&$c.value as [uint8], 4); }
+gen INIT8():c { E_bytes(&$c.value as [uint8], 8); }
+
+gen INITS():s
+{
+	if initialiser_buffer_fill_bytes != 0 then
+		StartError();
+		print("bad initialiser alignment: ");
+		print_i8(initialiser_buffer_fill_bytes);
+		EndError();
+	end if;
+
+	E("\t{ .ptr = (void*)");
+	EmitByte(COO_ESCAPE_THISCOO);
+	EmitByte('s');
+	E_h16(E_string($s.text));
+	E(" },\n");
+}
+
+gen ENDINIT()
+{
+	FlushInitialiserBuffer();
+	E("};\n");
+	EmitterPopChunk('S');
+}
+
+// --- Inline assembly ------------------------------------------------------
+
+gen ASMSTART()
+{
+	E_tab();
+}
+
+gen ASMTEXT():t
+{
+	E($t.text);
+	E_space();
+}
+
+gen ASMSYMBOL():s
+{
+	if $s.sym.kind == VAR then
+		E("*(i");
+		E_u8($s.sym.vardata.type.typedata.width as uint8);
+		E("*)(intptr_t)(");
+		E_symref($s.sym, 0);
+		E(")");
+	else
+		E_subref($s.sym.subr);
+	end if;
+	E_space();
+}
+
+gen ASMVALUE():c
+{
+	EmitByte('(');
+	E_i32($c.value);
+	EmitByte(')');
+}
+
+gen ASMEND()
+{
+    E_nl();
+}
+
+
+

--- a/src/cowcom/archz80.cow.ng
+++ b/src/cowcom/archz80.cow.ng
@@ -19,6 +19,18 @@
 		newvalue := value;
 	end sub;
 
+	sub ArchInitTypes()
+		uint32_type := MakeNumberType(4, 1, 0, "uint32");
+		int32_type := MakeNumberType(4, 1, 1, "int32");
+		uint16_type := MakeNumberType(2, 1, 0, "uint16");
+		int16_type := MakeNumberType(2, 1, 1, "int16");
+		uint8_type := MakeNumberType(1, 1, 0, "uint8");
+		int8_type := MakeNumberType(1, 1, 1, "int8");
+
+		intptr_type := uint16_type;
+		AddAliasString("intptr", intptr_type);
+	end sub;
+
 	sub ArchGuessIntType(min: Arith, max: Arith): (symbol: [Symbol])
 		if (min >= 0) and (max <= 255) then
 			symbol := uint8_type;
@@ -50,20 +62,6 @@
 		end if;
 	end sub;
 
-	sub E_labelref(labelid: uint16)
-		EmitByte(COO_ESCAPE_THISCOO);
-		E_h16(labelid);
-	end sub;
-
-	sub E_subref(subr: [Subroutine])
-		if subr == current_subr then
-			EmitByte(COO_ESCAPE_THISSUB);
-		else
-			EmitByte(COO_ESCAPE_SUBREF);
-			E_h16(subr.id);
-		end if;
-	end sub;
-
 	sub E_symref(sym: [Symbol], off: Size)
 		if sym.vardata.externname != (0 as string) then
 			E(sym.vardata.externname);
@@ -74,22 +72,6 @@
 			E_h8(0);
 			E_h16(sym.vardata.offset + off);
 		end if;
-	end sub;
-
-	sub E_space()
-		EmitByte(' ');
-	end sub;
-
-	sub E_comma()
-		EmitByte(',');
-	end sub;
-
-	sub E_tab()
-		EmitByte('\t');
-	end sub;
-
-	sub E_nl();
-		EmitByte('\n');
 	end sub;
 
 	sub R_flushall()
@@ -771,7 +753,6 @@
 wordsize uint32;
 
 register a b c d e h l hl de bc hlhl dede bcbc ix iy;
-register param;
 
 regclass r8 := a|b|d|h;
 regclass r16 := hl|de|bc|ix|iy;
@@ -789,7 +770,6 @@ regdata dede uses dede|de|d|e compatible r32;
 regdata hlhl uses hlhl|hl|h|l compatible r32;
 regdata ix                    compatible r16;
 regdata iy                    compatible r16;
-regdata param stacked;
 
 // --- Core things ----------------------------------------------------------
 
@@ -1906,6 +1886,8 @@ gen WHENCASE4():c uses a
 	case2($c.value as uint16, REG_DE, $c.falselabel);
 	case2(($c.value >> 16) as uint16, REG_BC, $c.falselabel);
 }
+
+gen ENDCASE();
 
 // --- Casts ----------------------------------------------------------------
 

--- a/src/cowcom/build.lua
+++ b/src/cowcom/build.lua
@@ -1,4 +1,4 @@
-local ARCHS = { "8080", "z80" }
+local ARCHS = { "8080", "z80", "cgen" }
 
 lemoncowgol {
 	ins = { "src/cowcom/parser.y" },
@@ -30,6 +30,7 @@ for _, toolchain in ipairs(ALL_TOOLCHAINS) do
 				"src/cowcom/expressions.coh",
 				"src/cowcom/lexer.coh",
 				"src/cowcom/midcodec.coh",
+				"src/cowcom/namespace.coh",
 				"src/cowcom/regcache.coh",
 				"src/cowcom/symbols.coh",
 				"src/cowcom/types.coh",

--- a/src/cowcom/emitter.coh
+++ b/src/cowcom/emitter.coh
@@ -32,6 +32,22 @@ sub EmitByte(byte: uint8)
 	end if;
 end sub;
 
+sub E_space()
+	EmitByte(' ');
+end sub;
+
+sub E_comma()
+	EmitByte(',');
+end sub;
+
+sub E_tab()
+	EmitByte('\t');
+end sub;
+
+sub E_nl();
+	EmitByte('\n');
+end sub;
+
 sub E(text: string)
 	loop
 		var c := [text];
@@ -86,6 +102,16 @@ sub E_i16(value: int16)
 	E_u16(value as uint16);
 end sub;
 
+sub E_i32(value: int32)
+	if value < 0 then
+		EmitByte('-');
+		value := -value;
+	else
+		EmitByte('+');
+	end if;
+	E_u32(value as uint32);
+end sub;
+
 sub E_h(value: uint32, width: uint8)
 	var buffer: uint8[5];
 	var pe := UIToA(value as uint32, 16, &buffer[0]);
@@ -107,6 +133,20 @@ end sub;
 
 sub E_h32(value: uint32)
 	E_h(value as uint32, 8);
+end sub;
+
+sub E_labelref(labelid: uint16)
+	EmitByte(COO_ESCAPE_THISCOO);
+	E_h16(labelid);
+end sub;
+
+sub E_subref(subr: [Subroutine])
+	if subr == current_subr then
+		EmitByte(COO_ESCAPE_THISSUB);
+	else
+		EmitByte(COO_ESCAPE_SUBREF);
+		E_h16(subr.id);
+	end if;
 end sub;
 
 sub EmitterPushChunk()

--- a/src/cowcom/main.cow
+++ b/src/cowcom/main.cow
@@ -18,6 +18,7 @@ include "src/cowcom/lexer.coh";
 include "src/cowcom/midcodec.coh";
 include "src/cowcom/emitter.coh";
 include "src/cowcom/regcache.coh";
+include "src/cowcom/namespace.coh";
 include "src/cowcom/codegen.coh";
 include "src/cowcom/symbols.coh";
 include "src/cowcom/expressions.coh";
@@ -65,20 +66,6 @@ sub ParseArguments()
 		SyntaxError();
 	end if;
 end sub;
-
-# This routine is a hack and shouldn't be here.
-
-	sub ArchInitTypes()
-		uint32_type := MakeNumberType(4, 0, "uint32");
-		int32_type := MakeNumberType(4, 1, "int32");
-		uint16_type := MakeNumberType(2, 0, "uint16");
-		int16_type := MakeNumberType(2, 1, "int16");
-		uint8_type := MakeNumberType(1, 0, "uint8");
-		int8_type := MakeNumberType(1, 1, "int8");
-
-		intptr_type := uint16_type;
-		AddAliasString("intptr", intptr_type);
-	end sub;
 
 print("COWCOM: ");
 PrintFreeMemory();

--- a/src/cowcom/namespace.coh
+++ b/src/cowcom/namespace.coh
@@ -1,0 +1,98 @@
+sub LookupSymbolInNamespace(namespace: [Namespace], name: string): (symbol: [Symbol])
+	symbol := namespace.first;
+	while symbol != (0 as [Symbol]) loop
+		if StrCmp(symbol.name, name) == 0 then
+			while symbol.kind == TYPEDEF loop
+				symbol := symbol.alias;
+			end loop;
+			return;
+		end if;
+		symbol := symbol.next;
+	end loop;
+	symbol := (0 as [Symbol]);
+end sub;
+
+sub LookupSymbol(namespace: [Namespace], name: string): (symbol: [Symbol])
+	if namespace == (0 as [Namespace]) then
+		namespace := &current_subr.namespace;
+	end if;
+	
+	while namespace != (0 as [Namespace]) loop
+		symbol := LookupSymbolInNamespace(namespace, name);
+		if symbol != (0 as [Symbol]) then
+			return;
+		end if;
+		namespace := namespace.parent;
+	end loop;
+
+	symbol := (0 as [Symbol]);
+end sub;
+
+sub AddToNamespace(namespace: [Namespace], symbol: [Symbol])
+	if namespace.last == (0 as [Symbol]) then
+		namespace.first := symbol;
+		namespace.last := symbol;
+	else
+		namespace.last.next := symbol;
+		namespace.last := symbol;
+	end if;
+end sub;
+
+# Consumes the string in Token
+sub AddSymbol(namespace: [Namespace], token: [Token]): (symbol: [Symbol])
+	if namespace == (0 as [Namespace]) then
+		namespace := &current_subr.namespace;
+	end if;
+
+	symbol := Alloc(@bytesof Symbol) as [Symbol];
+	if token != (0 as [Token]) then
+		if LookupSymbolInNamespace(namespace, token.string) != (0 as [Symbol]) then
+			StartError();
+			print("symbol '");
+			print(token.string);
+			print("' is already defined");
+			EndError();
+		end if;
+
+		symbol.name := token.string;
+		token.string := (0 as string);
+	end if;
+
+	AddToNamespace(namespace, symbol);
+end sub;
+
+# Consumes the string in Token
+sub AddAlias(namespace: [Namespace], token: [Token], real: [Symbol]): (symbol: [Symbol])
+	symbol := AddSymbol(namespace, token);
+	symbol.kind := TYPEDEF;
+	symbol.alias := real;
+end sub;
+
+sub AddAliasString(name: string, real: [Symbol])
+	var token: Token;
+	token.string := name;
+	var symbol := AddAlias(0 as [Namespace], &token, real);
+end sub;
+
+sub CheckNotPartialType(type: [Symbol])
+	if type.typedata.kind == TYPE_PARTIAL then
+		StartError();
+		print("'");
+		print(type.name);
+		print("' is a partial type");
+		EndError();
+	end if;
+end sub;
+
+sub MakeNumberType(width: uint8, alignment: uint8, is_signed: uint8, name: string): (symbol: [Symbol])
+	symbol := Alloc(@bytesof Symbol) as [Symbol];
+	symbol.kind := TYPE;
+	symbol.typedata.kind := TYPE_NUMBER;
+	symbol.typedata.width := width as uint16;
+	symbol.typedata.stride := width as uint16;
+	symbol.typedata.alignment := alignment;
+	symbol.typedata.numbertype.is_signed := is_signed;
+	symbol.name := name;
+	AddToNamespace(&current_subr.namespace, symbol);
+end sub;
+

--- a/src/cowcom/symbols.coh
+++ b/src/cowcom/symbols.coh
@@ -1,89 +1,3 @@
-sub LookupSymbolInNamespace(namespace: [Namespace], name: string): (symbol: [Symbol])
-	symbol := namespace.first;
-	while symbol != (0 as [Symbol]) loop
-		if StrCmp(symbol.name, name) == 0 then
-			while symbol.kind == TYPEDEF loop
-				symbol := symbol.alias;
-			end loop;
-			return;
-		end if;
-		symbol := symbol.next;
-	end loop;
-	symbol := (0 as [Symbol]);
-end sub;
-
-sub LookupSymbol(namespace: [Namespace], name: string): (symbol: [Symbol])
-	if namespace == (0 as [Namespace]) then
-		namespace := &current_subr.namespace;
-	end if;
-	
-	while namespace != (0 as [Namespace]) loop
-		symbol := LookupSymbolInNamespace(namespace, name);
-		if symbol != (0 as [Symbol]) then
-			return;
-		end if;
-		namespace := namespace.parent;
-	end loop;
-
-	symbol := (0 as [Symbol]);
-end sub;
-
-sub AddToNamespace(namespace: [Namespace], symbol: [Symbol])
-	if namespace.last == (0 as [Symbol]) then
-		namespace.first := symbol;
-		namespace.last := symbol;
-	else
-		namespace.last.next := symbol;
-		namespace.last := symbol;
-	end if;
-end sub;
-
-# Consumes the string in Token
-sub AddSymbol(namespace: [Namespace], token: [Token]): (symbol: [Symbol])
-	if namespace == (0 as [Namespace]) then
-		namespace := &current_subr.namespace;
-	end if;
-
-	symbol := Alloc(@bytesof Symbol) as [Symbol];
-	if token != (0 as [Token]) then
-		if LookupSymbolInNamespace(namespace, token.string) != (0 as [Symbol]) then
-			StartError();
-			print("symbol '");
-			print(token.string);
-			print("' is already defined");
-			EndError();
-		end if;
-
-		symbol.name := token.string;
-		token.string := (0 as string);
-	end if;
-
-	AddToNamespace(namespace, symbol);
-end sub;
-
-# Consumes the string in Token
-sub AddAlias(namespace: [Namespace], token: [Token], real: [Symbol]): (symbol: [Symbol])
-	symbol := AddSymbol(namespace, token);
-	symbol.kind := TYPEDEF;
-	symbol.alias := real;
-end sub;
-
-sub AddAliasString(name: string, real: [Symbol])
-	var token: Token;
-	token.string := name;
-	var symbol := AddAlias(0 as [Namespace], &token, real);
-end sub;
-
-sub CheckNotPartialType(type: [Symbol])
-	if type.typedata.kind == TYPE_PARTIAL then
-		StartError();
-		print("'");
-		print(type.name);
-		print("' is a partial type");
-		EndError();
-	end if;
-end sub;
-
 sub InitVariable(symbol: [Symbol], type: [Symbol])
 	CheckNotPartialType(type);
 	symbol.vardata.type := type;
@@ -98,18 +12,6 @@ sub InitVariable(symbol: [Symbol], type: [Symbol])
 	#print("+");
 	#print_hex_i16(symbol.vardata.type.typedata.width as uint16);
 	#print_nl();
-end sub;
-
-sub MakeNumberType(width: uint8, is_signed: uint8, name: string): (symbol: [Symbol])
-	symbol := Alloc(@bytesof Symbol) as [Symbol];
-	symbol.kind := TYPE;
-	symbol.typedata.kind := TYPE_NUMBER;
-	symbol.typedata.width := width as uint16;
-	symbol.typedata.stride := width as uint16;
-	symbol.typedata.alignment := ArchAlignUp(1, width) as uint8;
-	symbol.typedata.numbertype.is_signed := is_signed;
-	symbol.name := name;
-	AddToNamespace(&current_subr.namespace, symbol);
 end sub;
 
 sub MakePointerType(type: [Symbol]): (ptrtype: [Symbol])
@@ -134,9 +36,9 @@ sub MakeArrayType(type: [Symbol], size: Size): (arraytype: [Symbol])
 	arraytype.name := StrDupArrayed(type.name, size);
 	arraytype.kind := TYPE;
 	arraytype.typedata.kind := TYPE_ARRAY;
-	var w := type.typedata.stride * (size - 1) + type.typedata.width;
-	if w < 0 then
-		w := 0;
+	var w: Size := 0;
+	if size > 0 then
+		w := type.typedata.stride * (size - 1) + type.typedata.width;
 	end if;
 	arraytype.typedata.width := w;
 	arraytype.typedata.alignment := type.typedata.alignment;
@@ -145,4 +47,5 @@ sub MakeArrayType(type: [Symbol], size: Size): (arraytype: [Symbol])
 	arraytype.typedata.arraytype.size := size;
 	arraytype.typedata.arraytype.indextype := ArchGuessIntType(0, (size-1) as Arith);
 end sub;
+
 

--- a/src/cowlink/arch8080.coh
+++ b/src/cowlink/arch8080.coh
@@ -6,6 +6,10 @@ sub E_nl()
 	EmitByte('\n');
 end sub;
 
+sub ArchAlignUp(value: Size, alignment: uint8): (newvalue: Size)
+	newvalue := value;
+end sub;
+
 sub ArchEmitSubRef(subid: uint16)
 	E("f");
 	E_u16(subid);
@@ -38,7 +42,7 @@ sub ArchEmitHeader(coo: [Coo])
 	E("\trst 0\n");
 end sub;
 
-sub ArchEmitFooter()
+sub ArchEmitFooter(coo: [Coo])
 	E("\tdseg\n");
 	E("TOP:\n");
 

--- a/src/cowlink/archcgen.coh
+++ b/src/cowlink/archcgen.coh
@@ -1,0 +1,57 @@
+
+const STACK_SIZE := 128;
+
+var workspaceSize: Size[NUM_WORKSPACES];
+
+sub ArchAlignUp(value: Size, alignment: uint8): (newvalue: Size)
+	var a := (alignment-1) as Size;
+	newvalue := (value+a) & ~a;
+end sub;
+
+sub E_nl()
+	EmitByte('\n');
+end sub;
+
+sub ArchEmitSubRef(subid: uint16)
+	E("f");
+	E_u16(subid);
+end sub;
+
+sub ArchEmitWSRef(wid: uint8, address: Size)
+	E("ws+");
+	E_u16(address);
+end sub;
+
+sub ArchEmitHeader(coo: [Coo])
+	E("#include \"cowgol.h\"\n");
+	E("static i8 workspace[0x");
+	E_h16((workspaceSize[0]+7) / 8);
+	E("];\n");
+	E("static i1* ws = (i1*)workspace;\n");
+end sub;
+
+sub ArchEmitFooter(coo: [Coo])
+	E("void cmain(void) {\n");
+
+	while coo != (0 as [Coo]) loop
+		var main := coo.index.subroutines[0];
+		if main != (0 as [Subroutine]) then
+			EmitByte('\t');
+			ArchEmitSubRef(main.id);
+			E("();\n");
+		end if;
+		coo := coo.next;
+	end loop;
+
+	E("}\n");
+
+	# This is ridiculous, but can't be helped: write spaces to pad the end
+	# of the file. Unix C compilers don't like trailing nuls.
+
+	var padding := FCBExt(&outfcb) - FCBPos(&outfcb);
+	while padding != 0 loop
+		EmitByte(' ');
+		padding := padding - 1;
+	end loop;
+end sub;
+

--- a/src/cowlink/build.lua
+++ b/src/cowlink/build.lua
@@ -1,4 +1,12 @@
-local ARCHS = { "8080" }
+local ARCHS = { "8080", "cgen" }
+
+for _, arch in ipairs(ARCHS) do
+	rule {
+		ins = { "src/cowlink/arch"..arch..".coh" },
+		outs = { "$OBJ/cowlink-"..arch.."/archlink.coh" },
+		cmd = "cp @1 &1",
+	}
+end
 
 for _, toolchain in ipairs(ALL_TOOLCHAINS) do
 	for _, arch in ipairs(ARCHS) do
@@ -7,7 +15,7 @@ for _, toolchain in ipairs(ALL_TOOLCHAINS) do
 			ins = {
 				"src/cowlink/main.cow",
 				"include/coodecls.coh",
-				"src/cowlink/arch8080.coh",
+				"$OBJ/cowlink-"..arch.."/archlink.coh",
 				"src/cowlink/asmwrite.coh",
 				"src/cowlink/cooread.coh",
 				"src/cowlink/emitter.coh",

--- a/src/cowlink/graph.coh
+++ b/src/cowlink/graph.coh
@@ -81,8 +81,9 @@ sub PlaceSubroutines(subroutine: [Subroutine])
 		var watermark: Size[NUM_WORKSPACES];
 		i := 0;
 		while i != NUM_WORKSPACES loop
-			var w := subroutine.workspaceAddress[i] 
-				+ subroutine.workspaceSize[i];
+			var w := ArchAlignUp(
+				subroutine.workspaceAddress[i] + subroutine.workspaceSize[i],
+				8);
 			watermark[i] := w;
 			if w > workspaceSize[i] then
 				workspaceSize[i] := w;

--- a/src/cowlink/main.cow
+++ b/src/cowlink/main.cow
@@ -11,7 +11,7 @@ include "include/coodecls.coh";
 include "src/cowlink/types.coh";
 include "src/cowlink/utils.coh";
 include "src/cowlink/emitter.coh";
-include "src/cowlink/arch8080.coh";
+include "archlink.coh";
 include "src/cowlink/cooread.coh";
 include "src/cowlink/asmwrite.coh";
 include "src/cowlink/graph.coh";
@@ -88,7 +88,7 @@ EmitterOpenfile(outputFilename);
 print("Writing output file...\n");
 ArchEmitHeader(firstCoo);
 WriteAllSubroutinesToOutputFile(firstCoo);
-ArchEmitFooter();
+ArchEmitFooter(firstCoo);
 
 EmitterClosefile();
 

--- a/src/midcodes.coh.tab
+++ b/src/midcodes.coh.tab
@@ -43,6 +43,7 @@ y 2 1 BLTU(truelabel: LabelRef, falselabel: LabelRef, fallthrough: LabelRef, neg
 
 y 1 0 STARTCASE()
 y 0 0 WHENCASE(value: int32, falselabel: uint16) = ("%s %d => %d", $$.isdefault ? "default" : "", $$.value, $$.label)
+- 0 0 ENDCASE()
 
 # These produce all combinations of source and destination widths.
 y 1 1 CAST1(sext: uint8)

--- a/toolchains.lua
+++ b/toolchains.lua
@@ -53,11 +53,23 @@ toolchain_ncpmz = {
 	tester = cpmtest,
 }
 
+toolchain_ncgen = {
+	name = "ncgen",
+	compiler = "bin/cowcom.cgen.ocgen.exe",
+	linker = cowlink_cgen,
+	assembler = buildcgen,
+	runtime = "rt/cgen",
+	asmext = ".c",
+	binext = ".exe",
+	tester = nativetest
+}
+
 ALL_TOOLCHAINS = {
 	toolchain_olx386,
 	toolchain_olxthumb2,
 	toolchain_ocgen,
 	toolchain_ncpm,
 	toolchain_ncpmz,
+	toolchain_ncgen,
 }
 


### PR DESCRIPTION
This adds a ncgen target for cowcom, which is the last big step before bootstrapping and removal of oldcom completely. (Or at least it will be once ncgen compiles cowcom correctly, rather than just passing the tests.)