### PR TITLE
Compress the rules tables

### DIFF
--- a/src/cowcom/codegen.coh
+++ b/src/cowcom/codegen.coh
@@ -6,7 +6,6 @@ record Rule
 	compatible_producable_regs: RegId;
 	producable_regs: RegId;
 	uses_regs: RegId;
-	consumable_regs: RegId[INSTRUCTION_TEMPLATE_DEPTH];
 	significant_nodes: uint8;
 	copyable_nodes: uint8;
 	register_nodes: uint8;
@@ -290,6 +289,7 @@ sub Generate(rootnode: [Node])
 
 		var ruleid: uint8 := 0xff;
 		var midcodeptr := &codegen_midcodes[0];
+		var regsptr := &codegen_registers[0];
 		var rule := @prev &codegen_rules[0];
 
 		sub TestRule(): (result: uint8)
@@ -313,10 +313,10 @@ sub Generate(rootnode: [Node])
 			var significant := rule.significant_nodes;
 			while significant != 0 loop
 				var d := [data];
-				data := data + 1;
+				data := @next data;
 				if (significant & 1) != 0 then
 					var t := [template];
-					template := template + 1;
+					template := @next template;
 					if d != t then
 						return;
 					end if;
@@ -359,12 +359,21 @@ sub Generate(rootnode: [Node])
 			end if;
 
 			# Advance the midcode pointer.
-			var significant := rule.significant_nodes;
-			while significant != 0 loop
-				if (significant & 1) != 0 then
-					midcodeptr := midcodeptr + 1;
+			i := rule.significant_nodes;
+			while i != 0 loop
+				if (i & 1) != 0 then
+					midcodeptr := @next midcodeptr;
 				end if;
-				significant := significant >> 1;
+				i := i >> 1;
+			end loop;
+
+			# Advance the registers pointer.
+			i := rule.register_nodes;
+			while i != 0 loop
+				if (i & 1) != 0 then
+					regsptr := @next regsptr;
+				end if;
+				i := i >> 1;
 			end loop;
 		end loop;
 
@@ -394,7 +403,8 @@ sub Generate(rootnode: [Node])
 				producer.n[i] := n;
 				if (regmask & 1) != 0 then
 					PushNode(n);
-					n.desired_reg := rule.consumable_regs[i];
+					n.desired_reg := [regsptr];
+					regsptr := @next regsptr;
 					n.consumer := producer;
 				end if;
 			end if;

--- a/src/cowcom/codegen.coh
+++ b/src/cowcom/codegen.coh
@@ -7,7 +7,7 @@ record Rule
 	producable_regs: RegId;
 	uses_regs: RegId;
 	consumable_regs: RegId[INSTRUCTION_TEMPLATE_DEPTH];
-	matchbytes: uint8[INSTRUCTION_TEMPLATE_DEPTH];
+	significant_nodes: uint8;
 	copyable_nodes: uint8;
 	register_nodes: uint8;
 end record;
@@ -239,25 +239,6 @@ sub ShuffleRegisters(moves: [RegMove])
 	end loop;
 end sub;
 
-sub TemplateComparator(data: [uint8], template: [uint8]): (result: uint8)
-	result := 0;
-
-	var i: uint8 := INSTRUCTION_TEMPLATE_DEPTH;
-	while i != 0 loop
-		var d := [data];
-		data := data + 1;
-		var t := [template];
-		template := template + 1;
-		if (t != 0) and (d != t) then
-			return;
-		end if;
-
-		i := i - 1;
-	end loop;
-
-	result := 1;
-end sub;
-
 sub PrintNodes(rootnode: [Node])
 	var old_next_node := next_node;
 	PushNode(rootnode);
@@ -308,7 +289,52 @@ sub Generate(rootnode: [Node])
 		PopulateMatchBuffer(producer, &matchnodes[0], &matchbytes[0]);
 
 		var ruleid: uint8 := 0xff;
+		var midcodeptr := &codegen_midcodes[0];
 		var rule := @prev &codegen_rules[0];
+
+		sub TestRule(): (result: uint8)
+			result := 0;
+
+			if rule.compatible_producable_regs != 0 then
+				# This rule produces a result, so fail if the result register
+				# isn't compatible.
+				if (node.desired_reg & rule.compatible_producable_regs) == 0 then
+					return;
+				end if;
+			else
+				# This rule produces no result, so fail if we need one.
+				if node.desired_reg != 0 then
+					return;
+				end if;
+			end if;
+
+			var data := &matchbytes[0];
+			var template := midcodeptr;
+			var significant := rule.significant_nodes;
+			while significant != 0 loop
+				var d := [data];
+				data := data + 1;
+				if (significant & 1) != 0 then
+					var t := [template];
+					template := template + 1;
+					if d != t then
+						return;
+					end if;
+				end if;
+
+				significant := significant >> 1;
+			end loop;
+
+			if ((rule.flags & RULE_HAS_PREDICATES) != 0) 
+					and (MatchPredicate(ruleid, &matchnodes[0]) == 0) then
+				# This rule has a manual predicate and the manual predicate said no.
+				return;
+			end if;
+
+			# We have a matching rule!
+			result := 1;
+		end sub;
+
 		loop
 			rule := @next rule;
 			ruleid := ruleid + 1;
@@ -328,32 +354,18 @@ sub Generate(rootnode: [Node])
 				EndError();
 			end if;
 
-			if rule.compatible_producable_regs != 0 then
-				# This rule produces a result, so fail if the result register
-				# isn't compatible.
-				if (node.desired_reg & rule.compatible_producable_regs) == 0 then
-					continue;
+			if TestRule() != 0 then
+				break;
+			end if;
+
+			# Advance the midcode pointer.
+			var significant := rule.significant_nodes;
+			while significant != 0 loop
+				if (significant & 1) != 0 then
+					midcodeptr := midcodeptr + 1;
 				end if;
-			else
-				# This rule produces no result, so fail if we need one.
-				if node.desired_reg != 0 then
-					continue;
-				end if;
-			end if;
-
-			if TemplateComparator(&matchbytes[0], &rule.matchbytes[0]) == 0 then
-				# Fail if the tree doesn't match.
-				continue;
-			end if;
-
-			if ((rule.flags & RULE_HAS_PREDICATES) != 0) 
-					and (MatchPredicate(ruleid, &matchnodes[0]) == 0) then
-				# This rule has a manual predicate and the manual predicate said no.
-				continue;
-			end if;
-
-			# We have a matching rule!
-			break;
+				significant := significant >> 1;
+			end loop;
 		end loop;
 
 		# We have found a rule for this instruction.

--- a/tools/newgen/main.c
+++ b/tools/newgen/main.c
@@ -518,6 +518,19 @@ static void create_rules(void)
 			fprintf(outfp, "# %d\n", i);
 		}
 		fprintf(outfp, "};\n");
+		fprintf(outfp, "var codegen_registers: RegId[] := {\n");
+		for (int i=0; i<rulescount; i++)
+		{
+			Rule* r = rules[i];
+			for (int j=0; j<maxdepth; j++)
+			{
+				Node* n = r->nodes[j];
+				if (n && n->isregister)
+					fprintf(outfp, "0x%x, ", n->reg);
+			}
+			fprintf(outfp, "# %d\n", i);
+		}
+		fprintf(outfp, "};\n");
 	#endif
 
 	#if defined COWGOL
@@ -542,20 +555,20 @@ static void create_rules(void)
 		fprintf(outfp, "0x%x, ", r->result_reg);
 		fprintf(outfp, "0x%x, ", find_conflicting_registers(r->uses_regs));
 
-		fprintf(outfp, "{ ");
-		for (int j=0; j<maxdepth; j++)
-		{
-			Node* n = r->nodes[j];
-			if (j)
-				fprintf(outfp, ", ");
-			if (n && n->isregister)
-				fprintf(outfp, "%d", n->reg);
-			else
-				fprintf(outfp, "0");
-		}
-		fprintf(outfp, " }, ");
-
 		#if !defined COWGOL
+			fprintf(outfp, "{ ");
+			for (int j=0; j<maxdepth; j++)
+			{
+				Node* n = r->nodes[j];
+				if (j)
+					fprintf(outfp, ", ");
+				if (n && n->isregister)
+					fprintf(outfp, "%d", n->reg);
+				else
+					fprintf(outfp, "0");
+			}
+			fprintf(outfp, " }, ");
+
 			fprintf(outfp, "{ ");
 			for (int j=0; j<maxdepth; j++)
 			{

--- a/tools/newgen/main.c
+++ b/tools/newgen/main.c
@@ -505,7 +505,7 @@ static void create_match_predicates(void)
 static void create_rules(void)
 {
 	#if defined COWGOL
-		fprintf(outfp, "var codegen_midcodes: uint8[] := {");
+		fprintf(outfp, "var codegen_midcodes: uint8[] := {\n");
 		for (int i=0; i<rulescount; i++)
 		{
 			Rule* r = rules[i];
@@ -513,14 +513,11 @@ static void create_rules(void)
 			{
 				Node* n = r->nodes[j];
 				if (n && n->midcode)
-				{
-					if ((i & 15) == 0)
-						fprintf(outfp, "\n\t");
 					fprintf(outfp, "% 3d, ", n->midcode);
-				}
 			}
+			fprintf(outfp, "# %d\n", i);
 		}
-		fprintf(outfp, "\n};\n");
+		fprintf(outfp, "};\n");
 	#endif
 
 	#if defined COWGOL


### PR DESCRIPTION
The consumable registers and template byte tables in the codegen rules contained a lot of zero bytes. We can omit these from the code by being cleverer about how we encode the tables. For the 8080, this saves 1073 bytes; for the Z80, which has more complex rules, this saves a very satisfactory 2689 bytes, making the Z80 self compiler now 52512 bytes, which is slowly approaching adequate.