### PR TITLE
ncgen can now build a working compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 export OBJ = .obj
 export LUA = lua
-export CFLAGS = -g -O3
+export CFLAGS = -g -O0
 export LDFLAGS = -g
 
 all: $(OBJ)/build.ninja
-	@ninja -f $(OBJ)/build.ninja -k0
+	@ninja -f $(OBJ)/build.ninja
 
 clean:
 	@echo CLEAN

--- a/include/coodecls.coh
+++ b/include/coodecls.coh
@@ -6,4 +6,5 @@ const COO_ESCAPE_SUBREF  := 1; # <01><hex4>
 const COO_ESCAPE_WSREF   := 2; # <02><hex4:sub><hex2:wsid><hex4:offset>
 const COO_ESCAPE_THISCOO := 3; # <03>
 const COO_ESCAPE_THISSUB := 4; # <04>
+const COO_ESCAPE_WSSIZE  := 5; # <05><hex4:sub><hex2:wsid>
 

--- a/rt/cgen/argv.coh
+++ b/rt/cgen/argv.coh
@@ -2,7 +2,7 @@ var argv_pointer: [[uint8]];
 
 sub ArgvInit()
 	@asm argv_pointer, " = (i8)(intptr_t)global_argv;";
-	argv_pointer := argv_pointer + 8;
+	argv_pointer := @next argv_pointer;
 end sub;
 
 # Returns null is there's no next argument.
@@ -19,7 +19,7 @@ sub ArgvNext(): (arg: [uint8])
 		# No more arguments.
 		argv_pointer := (0 as [[uint8]]);
 	else
-		argv_pointer := argv_pointer + 8;
+		argv_pointer := @next argv_pointer;
 	end if;
 end sub;
 

--- a/rt/cgen/cowgol.h
+++ b/rt/cgen/cowgol.h
@@ -52,7 +52,7 @@ int main(int argc, const char* argv[])
 	/* Remember that Cowgol is built for 64-bit systems, so we need
 	 * to copy the argv array as we could be running on a 32-bit system. */
 
-	global_argv = calloc(argc+1, 8);
+	global_argv = calloc(argc+1, sizeof(i8));
 	for (int i=0; i<argc; i++)
 		global_argv[i] = (i8)(intptr_t)argv[i];
 

--- a/rt/common.coh
+++ b/rt/common.coh
@@ -115,6 +115,7 @@ sub AToI(buffer: [uint8]): (result: int32, ptr: [uint8])
 			when 'o':  base := 8;
 			when 'b':  base := 2;
 			when 'd':  base := 10;
+
 			when else: ptr := ptr - 2;
 		end case;
 		ptr := ptr + 2;

--- a/scripts/mkmidcodescoh.lua
+++ b/scripts/mkmidcodescoh.lua
@@ -56,6 +56,8 @@ hfp:write("sub AllocateNewNode(code: uint8): (m: [Node])\n")
 hfp:write("\tm := Alloc(@bytesof Node) as [Node];\n")
 hfp:write("\t#print(\"alloc \");\n");
 hfp:write("\t#print_hex_i32(m as intptr as uint32);\n");
+hfp:write("\t#print(\" op \");\n");
+hfp:write("\t#print_i8(code);\n");
 hfp:write("\t#print_nl();\n");
 hfp:write("\tm.op := code;\n")
 hfp:write("end sub;\n")

--- a/src/cowcom/arch8080.cow.ng
+++ b/src/cowcom/arch8080.cow.ng
@@ -616,6 +616,7 @@ wordsize uint16;
 
 register a b c d e h l hl de bc;
 register stk4;
+register param;
 
 regdata a              compatible a|b|d|h;
 regdata b  uses bc|b|c compatible a|b|d|h;
@@ -625,6 +626,7 @@ regdata bc uses bc|b|c compatible bc|de|hl;
 regdata de uses de|d|e compatible bc|de|hl;
 regdata hl uses hl|h|l compatible bc|de|hl;
 regdata stk4 stacked;
+regdata param stacked;
 
 // --- Core things ----------------------------------------------------------
 
@@ -759,34 +761,36 @@ gen ENDSUB():s
 	EmitterPopChunk('S');
 }
 
-gen CALL():s
+gen CALL(param):s
 		{ E_call($s.subr); }
 	
-gen a := CALLE1():s
+gen a := CALLE1(param):s
 		{ E_call($s.subr); }
 
-gen hl := CALLE2():s
+gen hl := CALLE2(param):s
 		{ E_call($s.subr); }
 
-gen stk4 := CALLE4():s
+gen stk4 := CALLE4(param):s
 		{ E_call($s.subr); }
 
-gen PUSHARG1(a, remaining==0);
+gen param := END();
 
-gen PUSHARG1(a|b|d|h:lhs, remaining!=0)
+gen param := ARG1(param, a, remaining==0);
+
+gen param := ARG1(param, a|b|d|h:lhs, remaining!=0)
 		{ E_push($lhs); }
 	
-gen PUSHARG2(hl, remaining==0);
+gen param := ARG2(param, hl, remaining==0);
 
-gen PUSHARG2(bc|de|hl:lhs, remaining!=0)
+gen param := ARG2(param, bc|de|hl:lhs, remaining!=0)
 		{ E_push($lhs); }
 
-gen PUSHARG2(CALLE2():s)
+gen param := ARG2(END(), CALLE2(param):s)
 		{ E_call($s.subr); }
 
-gen PUSHARG4(stk4); // already stacked
+gen param := ARG4(param, stk4); // already stacked
 
-gen PUSHARG4(CALLE4():s)
+gen param := ARG4(END(), CALLE4(param):s)
 		{ E_call($s.subr); }
 
 gen a := POPARG1(remaining==0);

--- a/src/cowcom/arch8080.cow.ng
+++ b/src/cowcom/arch8080.cow.ng
@@ -607,6 +607,9 @@
 
 	sub ArchEndInstruction()
 	end sub;
+
+	sub ArchEndGroup()
+	end sub;
 %}
 
 wordsize uint16;

--- a/src/cowcom/archcgen.cow.ng
+++ b/src/cowcom/archcgen.cow.ng
@@ -15,10 +15,6 @@
 	var varsp: uint8;
 	var varid: Slot := 1;
 
-	const ARGSTACK_SIZE := VARSTACK_SIZE;
-	var argstack: Slot[ARGSTACK_SIZE];
-	var argsp: uint8;
-
 	record Extern
 		name: string;
 		id: uint16;
@@ -93,11 +89,6 @@
 		end if;
 	end sub;
 
-	# Note that this *destroys* the source register.
-	sub ArchEmitMove(src: RegId, dest: RegId)
-		SimpleError("move");
-	end sub;
-
 	sub ArchEndInstruction()
 	end sub;
 
@@ -146,31 +137,20 @@
 		vid := varstack[varsp-1];
 	end sub;
 
-	sub PushArg(vid: Slot)
-		if argsp == ARGSTACK_SIZE then
-			SimpleError("argstack overflow");
-		end if;
-		argstack[argsp] := vid;
-		argsp := argsp + 1;
-	end sub;
-
-	sub PopArg(): (vid: Slot)
-		if argsp == 0 then
-			SimpleError("argstack underflow");
-		end if;
-		argsp := argsp - 1;
-		vid := argstack[argsp];
+	# Note that this *destroys* the source register.
+	sub ArchEmitMove(src: RegId, dest: RegId)
 	end sub;
 %}
 
 wordsize uint32;
 
-register v1 v2 v4 v8;
+register v1 v2 v4 v8 param;
 
 regdata v1 stacked;
 regdata v2 stacked;
 regdata v4 stacked;
 regdata v8 stacked;
+regdata param;
 
 // --- Core things ----------------------------------------------------------
 
@@ -310,15 +290,16 @@ gen ENDSUB():s
 	EmitterPopChunk('S');
 }
 
-gen PUSHARG1(v1) { PushArg(Pop()); }
-gen PUSHARG2(v2) { PushArg(Pop()); }
-gen PUSHARG4(v4) { PushArg(Pop()); }
-gen PUSHARG8(v8) { PushArg(Pop()); }
+gen param := END();
+gen param := ARG1(param, v1);
+gen param := ARG2(param, v2);
+gen param := ARG4(param, v4);
+gen param := ARG8(param, v8);
 
-gen v1 := POPARG1() { PushVid(PopArg()); }
-gen v2 := POPARG2() { PushVid(PopArg()); }
-gen v4 := POPARG4() { PushVid(PopArg()); }
-gen v8 := POPARG8() { PushVid(PopArg()); }
+gen v1 := POPARG1();
+gen v2 := POPARG2();
+gen v4 := POPARG4();
+gen v8 := POPARG8();
 
 %{
 	sub Call(subr: [Subroutine])
@@ -373,7 +354,7 @@ gen v8 := POPARG8() { PushVid(PopArg()); }
 
 		count := 0;
 		while count != subr.num_input_parameters loop
-			var vid := PopArg();
+			var vid := Pop();
 			comma();
 			E("v");
 			E_u16(vid);
@@ -389,17 +370,17 @@ gen v8 := POPARG8() { PushVid(PopArg()); }
 		count := 0;
 		while count != subr.num_output_parameters loop
 			vid := outputvid + (count as Slot);
-			PushArg(vid);
+			PushVid(vid);
 			count := count + 1;
 		end loop;
 	end sub;
 %}
 
-gen CALL():s         { Call($s.subr); }
-gen v1 := CALLE1():s { Call($s.subr); PushVid(PopArg()); }
-gen v2 := CALLE2():s { Call($s.subr); PushVid(PopArg()); }
-gen v4 := CALLE4():s { Call($s.subr); PushVid(PopArg()); }
-gen v8 := CALLE8():s { Call($s.subr); PushVid(PopArg()); }
+gen CALL(param):s         { Call($s.subr); }
+gen v1 := CALLE1(param):s { Call($s.subr); }
+gen v2 := CALLE2(param):s { Call($s.subr); }
+gen v4 := CALLE4(param):s { Call($s.subr); }
+gen v8 := CALLE8(param):s { Call($s.subr); }
 
 // --- Core conversions --------------------------------------------------
 

--- a/src/cowcom/archcgen.cow.ng
+++ b/src/cowcom/archcgen.cow.ng
@@ -15,6 +15,10 @@
 	var varsp: uint8;
 	var varid: Slot := 1;
 
+	const ARGSTACK_SIZE := VARSTACK_SIZE;
+	var argstack: Slot[ARGSTACK_SIZE];
+	var argsp: uint8;
+
 	record Extern
 		name: string;
 		id: uint16;
@@ -97,6 +101,10 @@
 	sub ArchEndInstruction()
 	end sub;
 
+	sub ArchEndGroup()
+		E_nl();
+	end sub;
+
 	sub PushVid(vid: Slot)
 		if varsp == VARSTACK_SIZE then
 			SimpleError("varstack overflow");
@@ -109,14 +117,49 @@
 		vid := varid;
 		varid := varid + 1;
 		PushVid(vid);
+		#E("/* push v");
+		#E_u16(vid);
+		#E(" at ");
+		#E_u8(varsp);
+		#E(" */");
 	end sub;
 
-	sub Pop(): (vid: Slot)
+	sub CheckVarstackUnderflow()
 		if varsp == 0 then
 			SimpleError("varstack underflow");
 		end if;
+	end sub;
+
+	sub Pop(): (vid: Slot)
+		CheckVarstackUnderflow();
 		varsp := varsp - 1;
 		vid := varstack[varsp];
+		#E("/* pop v");
+		#E_u16(vid);
+		#E(" at ");
+		#E_u8(varsp);
+		#E(" */");
+	end sub;
+
+	sub Peek(): (vid: Slot)
+		CheckVarstackUnderflow();
+		vid := varstack[varsp-1];
+	end sub;
+
+	sub PushArg(vid: Slot)
+		if argsp == ARGSTACK_SIZE then
+			SimpleError("argstack overflow");
+		end if;
+		argstack[argsp] := vid;
+		argsp := argsp + 1;
+	end sub;
+
+	sub PopArg(): (vid: Slot)
+		if argsp == 0 then
+			SimpleError("argstack underflow");
+		end if;
+		argsp := argsp - 1;
+		vid := argstack[argsp];
 	end sub;
 %}
 
@@ -161,10 +204,14 @@ gen STARTSUB():s
 
 	E("\n// ");
 	E($s.subr.name);
-	E_space();
+	E(" workspace at ");
 	EmitByte(COO_ESCAPE_WSREF);
 	E_h16($s.subr.id);
 	E("000000");
+	E(" length ");
+	EmitByte(COO_ESCAPE_WSSIZE);
+	E_h16($s.subr.id);
+	E("00");
 	E("\nvoid ");
 	E_subref($s.subr);
 	E("(");
@@ -182,12 +229,13 @@ gen STARTSUB():s
 	var count: uint8 := 0;
 	while count != $s.subr.num_output_parameters loop
 		var param := GetOutputParameter($s.subr, count);
+		var pid := Push();
 
 		comma();
 		E("i");
 		E_u8(param.vardata.type.typedata.width as uint8);
 		E("* p");
-		E_u16(Push());
+		E_u16(pid);
 
 		E(" /* ");
 		E(param.name);
@@ -202,12 +250,13 @@ gen STARTSUB():s
 	while count != 0 loop
 		count := count - 1;
 		param := GetInputParameter($s.subr, count);
+		pid := Push();
 
 		comma();
 		E("i");
 		E_u8(param.vardata.type.typedata.width as uint8);
 		E(" p");
-		E_u16(Push());
+		E_u16(pid);
 
 		E(" /* ");
 		E(param.name);
@@ -222,13 +271,14 @@ gen STARTSUB():s
 	count := 0;
 	while count != $s.subr.num_input_parameters loop
 		param := GetInputParameter($s.subr, count);
+		pid := Pop();
 
 		E("\t*(i");
 		E_u8(param.vardata.type.typedata.width as uint8);
 		E("*)(intptr_t)(");
 		E_symref(param, 0);
 		E(") = p");
-		E_u16(Pop());
+		E_u16(pid);
 		E("; /*");
 		E(param.name);
 		E(" */\n");
@@ -245,9 +295,10 @@ gen ENDSUB():s
 	while count != 0 loop
 		count := count - 1;
 		var param := GetOutputParameter($s.subr, count);
+		var pid := Pop();
 
 		E("\t*p");
-		E_u16(Pop());
+		E_u16(pid);
 		E(" = *(i");
 		E_u8(param.vardata.type.typedata.width as uint8);
 		E("*)(intptr_t)(");
@@ -259,15 +310,15 @@ gen ENDSUB():s
 	EmitterPopChunk('S');
 }
 
-gen PUSHARG1(v1);
-gen PUSHARG2(v2);
-gen PUSHARG4(v4);
-gen PUSHARG8(v8);
+gen PUSHARG1(v1) { PushArg(Pop()); }
+gen PUSHARG2(v2) { PushArg(Pop()); }
+gen PUSHARG4(v4) { PushArg(Pop()); }
+gen PUSHARG8(v8) { PushArg(Pop()); }
 
-gen v1 := POPARG1();
-gen v2 := POPARG2();
-gen v4 := POPARG4();
-gen v8 := POPARG8();
+gen v1 := POPARG1() { PushVid(PopArg()); }
+gen v2 := POPARG2() { PushVid(PopArg()); }
+gen v4 := POPARG4() { PushVid(PopArg()); }
+gen v8 := POPARG8() { PushVid(PopArg()); }
 
 %{
 	sub Call(subr: [Subroutine])
@@ -322,7 +373,7 @@ gen v8 := POPARG8();
 
 		count := 0;
 		while count != subr.num_input_parameters loop
-			var vid := Pop();
+			var vid := PopArg();
 			comma();
 			E("v");
 			E_u16(vid);
@@ -338,26 +389,28 @@ gen v8 := POPARG8();
 		count := 0;
 		while count != subr.num_output_parameters loop
 			vid := outputvid + (count as Slot);
-			PushVid(vid);
+			PushArg(vid);
 			count := count + 1;
 		end loop;
 	end sub;
 %}
 
 gen CALL():s         { Call($s.subr); }
-gen v1 := CALLE1():s { Call($s.subr); }
-gen v2 := CALLE2():s { Call($s.subr); }
-gen v4 := CALLE4():s { Call($s.subr); }
-gen v8 := CALLE8():s { Call($s.subr); }
+gen v1 := CALLE1():s { Call($s.subr); PushVid(PopArg()); }
+gen v2 := CALLE2():s { Call($s.subr); PushVid(PopArg()); }
+gen v4 := CALLE4():s { Call($s.subr); PushVid(PopArg()); }
+gen v8 := CALLE8():s { Call($s.subr); PushVid(PopArg()); }
 
 // --- Core conversions --------------------------------------------------
 
 %{
 	sub LoadConstant(width: uint8, value: Arith)
+		var vid := Push();
+
 		E("\ti");
 		E_u8(width);
 		E(" v");
-		E_u16(Push());
+		E_u16(vid);
 		E(" = (i");
 		E_u8(width);
 		E(")");
@@ -373,8 +426,10 @@ gen v8 := CONSTANT():c { LoadConstant(8, $c.value); }
 
 gen v8 := ADDRESS():a
 {
+	var vid := Push();
+
 	E("\ti8 v");
-	E_u16(Push());
+	E_u16(vid);
 	E(" = (i8)(intptr_t)(");
 	E_symref($a.sym, $a.off);
 	E(");\n");
@@ -426,10 +481,11 @@ gen v8 := LOAD8(v8:addr) { LoadVV(8); }
 	sub Op2VV(width: uint8, op: string)
 		var rhsid := Pop();
 		var lhsid := Pop();
+		var vid := Push();
 		E("\ti");
 		E_u8(width);
 		E(" v");
-		E_u16(Push());
+		E_u16(vid);
 		E(" = v");
 		E_u16(lhsid);
 		E(op);
@@ -440,10 +496,11 @@ gen v8 := LOAD8(v8:addr) { LoadVV(8); }
 
 	sub Op2VC(width: uint8, op: string, rhs: Arith)
 		var lhsid := Pop();
+		var vid := Push();
 		E("\ti");
 		E_u8(width);
 		E(" v");
-		E_u16(Push());
+		E_u16(vid);
 		E(" = v");
 		E_u16(lhsid);
 		E(op);
@@ -455,10 +512,11 @@ gen v8 := LOAD8(v8:addr) { LoadVV(8); }
 	sub Op2VVSigned(width: uint8, op: string)
 		var rhsid := Pop();
 		var lhsid := Pop();
+		var vid := Push();
 		E("\ti");
 		E_u8(width);
 		E(" v");
-		E_u16(Push());
+		E_u16(vid);
 		E(" = (s");
 		E_u8(width);
 		E(")v");
@@ -473,10 +531,11 @@ gen v8 := LOAD8(v8:addr) { LoadVV(8); }
 
 	sub Op2VCSigned(width: uint8, op: string, rhs: Arith)
 		var lhsid := Pop();
+		var vid := Push();
 		E("\ti");
 		E_u8(width);
 		E(" v");
-		E_u16(Push());
+		E_u16(vid);
 		E(" = v");
 		E_u16(lhsid);
 		E(op);
@@ -579,10 +638,11 @@ gen v8 := EOR8(v8:lhs, CONSTANT():rhs)  { Op2VC(8, "^", $rhs.value); }
 %{
 	sub Op1V(width: uint8, op: string)
 		var valid := Pop();
+		var vid := Push();
 		E("\ti");
 		E_u8(width);
 		E(" v");
-		E_u16(Push());
+		E_u16(vid);
 		E(" = ");
 		E(op);
 		E("v");
@@ -606,10 +666,11 @@ gen v8 := NOT8(v8) { Op1V(8, "~"); }
 	sub Shift(width: uint8, type: string, op: string)
 		var rhsid := Pop();
 		var lhsid := Pop();
+		var vid := Push();
 		E("\ti");
 		E_u8(width);
 		E(" v");
-		E_u16(Push());
+		E_u16(vid);
 		E(" = ((");
 		E(type);
 		E(")v");
@@ -739,11 +800,12 @@ gen ENDCASE()
 
 %{
 	sub Cast(src: uint8, dest: uint8, sext: uint8)
-		var vid := Pop();
+		var lhsid := Pop();
+		var vid := Push();
 		E("\ti");
 		E_u8(dest);
 		E(" v");
-		E_u16(Push());
+		E_u16(vid);
 		E(" = ");
 		if sext != 0 then
 			E("(s");
@@ -753,7 +815,7 @@ gen ENDCASE()
 			E(")");
 		end if;
 		E("v");
-		E_u16(vid);
+		E_u16(lhsid);
 		E(";\n");
 	end sub;
 %}
@@ -814,8 +876,9 @@ gen v4 := CAST84(v8):c { Cast(8, 4, $c.sext); }
 
 gen v8 := STRING():s
 {
+	var vid := Push();
 	E("\ti8 v");
-	E_u16(Push());
+	E_u16(vid);
 	E(" = (i8)(intptr_t)");
 	EmitByte(COO_ESCAPE_THISCOO);
 	EmitByte('s');

--- a/src/cowcom/archz80.cow.ng
+++ b/src/cowcom/archz80.cow.ng
@@ -748,6 +748,9 @@
 
 	sub ArchEndInstruction()
 	end sub;
+
+	sub ArchEndGroup()
+	end sub;
 %}
 
 wordsize uint32;

--- a/src/cowcom/archz80.cow.ng
+++ b/src/cowcom/archz80.cow.ng
@@ -756,6 +756,7 @@
 wordsize uint32;
 
 register a b c d e h l hl de bc hlhl dede bcbc ix iy;
+register param;
 
 regclass r8 := a|b|d|h;
 regclass r16 := hl|de|bc|ix|iy;
@@ -773,6 +774,8 @@ regdata dede uses dede|de|d|e compatible r32;
 regdata hlhl uses hlhl|hl|h|l compatible r32;
 regdata ix                    compatible r16;
 regdata iy                    compatible r16;
+
+regdata param stacked;
 
 // --- Core things ----------------------------------------------------------
 
@@ -922,34 +925,36 @@ gen ENDSUB():s
 	EmitterPopChunk('S');
 }
 
-gen CALL():s
+gen CALL(param):s
 		{ E_call($s.subr); }
 	
-gen a := CALLE1():s
+gen a := CALLE1(param):s
 		{ E_call($s.subr); }
 
-gen hl := CALLE2():s
+gen hl := CALLE2(param):s
 		{ E_call($s.subr); }
 
-gen hlhl := CALLE4():s
+gen hlhl := CALLE4(param):s
 		{ E_call($s.subr); }
 
-gen PUSHARG1(a, remaining==0);
+gen param := END();
 
-gen PUSHARG1(a|b|d|h:lhs, remaining!=0)
+gen param := ARG1(param, a, remaining==0);
+
+gen param := ARG1(param, a|b|d|h:lhs, remaining!=0)
 		{ E_push($lhs); }
 	
-gen PUSHARG2(hl, remaining==0);
+gen param := ARG2(param, hl, remaining==0);
 
-gen PUSHARG2(bc|de|hl:lhs, remaining!=0)
+gen param := ARG2(param, bc|de|hl:lhs, remaining!=0)
 		{ E_push($lhs); }
 
-gen PUSHARG2(CALLE2():s)
+gen param := ARG2(CALLE2(param):s)
 		{ E_call($s.subr); }
 
-gen PUSHARG4(hlhl, remaining==0);
+gen param := ARG4(param, hlhl, remaining==0);
 
-gen PUSHARG4(r32:lhs, remaining!=0)
+gen param := ARG4(param, r32:lhs, remaining!=0)
 		{ ArchEmitMove($lhs, 0); }
 
 gen a := POPARG1(remaining==0);

--- a/src/cowcom/build.lua
+++ b/src/cowcom/build.lua
@@ -1,4 +1,4 @@
-local ARCHS = { "8080", "z80", "cgen" }
+local ARCHS = { "z80", "8080", "cgen" }
 
 lemoncowgol {
 	ins = { "src/cowcom/parser.y" },

--- a/src/cowcom/codegen.coh
+++ b/src/cowcom/codegen.coh
@@ -383,6 +383,8 @@ sub Generate(rootnode: [Node])
 		#print_i8(ruleid);
 		#print(" op ");
 		#print_i8(node.op);
+		#print(" producing ");
+		#print_hex_i32(rule.producable_regs as uint32);
 		#print(" ");
 		#print_hex_i32(node as intptr as uint32);
 		#print_nl();
@@ -552,6 +554,7 @@ sub Generate(rootnode: [Node])
 		ShuffleRegisters(&next_instruction.spills[0]);
 		ArchEndInstruction();
 	end loop;
+	ArchEndGroup();
 
 	Discard(rootnode);
 end sub;

--- a/src/cowlink/asmwrite.coh
+++ b/src/cowlink/asmwrite.coh
@@ -47,6 +47,8 @@ sub WriteSubroutinesToOutputFile(coo: [Coo])
 	sub CopySourceChunk()
 		var subid: uint16;
 		var subr: [Subroutine];
+		var wid: uint8;
+		var off: Size;
 
 		while length != 0 loop
 			GetC();
@@ -67,11 +69,18 @@ sub WriteSubroutinesToOutputFile(coo: [Coo])
 
 				when COO_ESCAPE_WSREF:
 					subid := ReadH4();
-					var wid := ReadH2();
-					var off := ReadH4();
+					wid := ReadH2();
+					off := ReadH4();
 					subr := FindOrCreateSub(coo, subid);
 					subr := Deref(subr);
 					ArchEmitWSRef(wid, subr.workspaceAddress[wid] + off);
+
+				when COO_ESCAPE_WSSIZE:
+					subid := ReadH4();
+					wid := ReadH2();
+					subr := FindOrCreateSub(coo, subid);
+					subr := Deref(subr);
+					ArchEmitWSRef(wid, subr.workspaceSize[wid]);
 
 				when else:
 					EmitByte(c);

--- a/src/cowlink/graph.coh
+++ b/src/cowlink/graph.coh
@@ -81,10 +81,8 @@ sub PlaceSubroutines(subroutine: [Subroutine])
 		var watermark: Size[NUM_WORKSPACES];
 		i := 0;
 		while i != NUM_WORKSPACES loop
-			var w := ArchAlignUp(
-				subroutine.workspaceAddress[i] + subroutine.workspaceSize[i],
-				8);
-			watermark[i] := w;
+			var w := subroutine.workspaceAddress[i] + subroutine.workspaceSize[i];
+			watermark[i] := ArchAlignUp(w, 8);
 			if w > workspaceSize[i] then
 				workspaceSize[i] := w;
 			end if;
@@ -108,11 +106,23 @@ sub PlaceSubroutines(subroutine: [Subroutine])
 				while i != NUM_WORKSPACES loop
 					var curAddr := called.workspaceAddress[i];
 					var reqAddr := watermark[i];
-					if (reqAddr > curAddr) or ((called.state & SUB_USED) == 0) then
+					if reqAddr > curAddr then
+						#print(subroutine.name);
+						#print(" calling ");
+						#print(called.name);
+						#print(" -> ");
+						#print_hex_i16(reqAddr);
+						#print_nl();
 						called.workspaceAddress[i] := reqAddr;
 						# The subroutine's workspace has moved, so make sure it
 						# gets reprocessed.
 						push(called);
+					end if;
+					if (called.state & SUB_USED) == 0 then
+						# Subroutines which we know haven't been processed yet
+						# always go on the queue.
+						push(called);
+						called.state := called.state | SUB_USED;
 					end if;
 					i := i + 1;
 				end loop;

--- a/src/midcodes.coh.tab
+++ b/src/midcodes.coh.tab
@@ -22,10 +22,23 @@ y 0 0 INIT(value: int32) = ("%d", $$.value)
 
 - 0 0 LABEL(label: uint16) = ("%d", $$.label)
 - 0 0 JUMP(label: uint16) = ("%d", $$.label)
-- 1 0 CALLS()
-- 0 0 CALL(subr: [Subroutine]) = ("%s", $$.subr.name)
-y 0 1 CALLE(subr: [Subroutine]) = ("%s", $$.subr.name)
 - 0 0 RETURN()
+
+# These take a parameter list: a chain of ARG nodes containing the subroutine
+# arguments. Any return arguments are pushed onto the argument stack.
+- 1 0 CALL(subr: [Subroutine]) = ("%s", $$.subr.name)
+y 1 1 CALLE(subr: [Subroutine]) = ("%s", $$.subr.name)
+
+# Represents an argument to a call. The LHS points at the next argument or an
+# END. The RHS is the value. The values are left-to-right, so that the first
+# argument to be generated and pushed is the deepest in the list.
+y 2 1 ARG(subr: [Subroutine], remaining: uint8)
+
+# POPARG is a leaf. Because the parameter stack and the spill stack occupy
+# the same physical space (at least on most architectures), POPARG must be the
+# first node actually generated in any tree. The frontend only generates it
+# for STORE(POPARG(), something) statements, which meets this requirement.
+y 0 1 POPARG(subr: [Subroutine], remaining: uint8)
 
 - 0 1 CONSTANT(value: int32) = ("%d", $$.value)
 - 0 1 STRING(text: string) = ("...")
@@ -50,14 +63,6 @@ y 1 1 CAST1(sext: uint8)
 y 1 1 CAST2(sext: uint8)
 y 1 1 CAST4(sext: uint8)
 y 1 1 CAST8(sext: uint8)
-
-# PUSHARG is a root node, but POPARG is a leaf. However, because the parameter
-# stack and the spill stack occupy the same physical space (at least on most
-# architectures), POPARG must be the first node actually generated in any
-# tree. The frontend only generates it for STORE(POPARG(), something)
-# statements, which meets this requirement.
-y 1 0 PUSHARG(subr: [Subroutine], remaining: uint8)
-y 0 1 POPARG(subr: [Subroutine], remaining: uint8)
 
 # The order here is important. 
 y 1 1 NOT()

--- a/tests/conditionals.good
+++ b/tests/conditionals.good
@@ -53,3 +53,4 @@ isletter(70): yes
 isletter(200): no
 andor1: yes
 orand1: yes
+andfuncs: yes

--- a/tests/conditionals.test.cow
+++ b/tests/conditionals.test.cow
@@ -157,3 +157,13 @@ sub orand1()
 end sub;
 orand1();
 
+sub andfuncs()
+	print("andfuncs");
+	sub returns(x: uint8): (result: uint8)
+		result := x;
+	end sub;
+
+	if (returns(0) == 0) and (returns(1) == 1) then yes(); else no(); end if;
+end sub;
+andfuncs();
+

--- a/tests/inputparams.good
+++ b/tests/inputparams.good
@@ -5,3 +5,4 @@ twoint16: : yes
 mixed1: : yes
 mixed2: : yes
 lots: : yes
+callsinexpression: yes

--- a/tests/inputparams.test.cow
+++ b/tests/inputparams.test.cow
@@ -43,3 +43,14 @@ sub lots(i1: int8, i2: int8, i3: int8, i4: int8, i5: int8, i6: int8)
 end sub;
 lots(1, 2, 3, 4, 5, 6);
 
+# This tickles a bug in the old cowcom where arguments passed to
+# subroutines inside expressions weren't compiled correctly.
+sub callsinexpressions()
+print("callsinexpression");
+	sub returns(i1: uint8): (i2: uint8)
+		i2 := i1;
+	end sub;
+	if (returns(1) + returns(2)) == 3 then yes(); else no(); end if;
+end sub;
+callsinexpressions();
+

--- a/toolchains.lua
+++ b/toolchains.lua
@@ -33,7 +33,7 @@ toolchain_ocgen = {
 
 toolchain_ncpm = {
 	name = "ncpm",
-	compiler = "bin/cowcom.8080.ocgen.exe",
+	compiler = "bin/cowcom.8080.nncgen.exe",
 	linker = cowlink_cpm,
 	assembler = buildzmac,
 	runtime = "rt/cpm",
@@ -44,7 +44,7 @@ toolchain_ncpm = {
 
 toolchain_ncpmz = {
 	name = "ncpmz",
-	compiler = "bin/cowcom.z80.ocgen.exe",
+	compiler = "bin/cowcom.z80.nncgen.exe",
 	linker = cowlink_cpmz,
 	assembler = buildzmac,
 	runtime = "rt/cpmz",
@@ -64,6 +64,17 @@ toolchain_ncgen = {
 	tester = nativetest
 }
 
+toolchain_nncgen = {
+	name = "nncgen",
+	compiler = "bin/cowcom.cgen.ncgen.exe",
+	linker = cowlink_cgen,
+	assembler = buildcgen,
+	runtime = "rt/cgen",
+	asmext = ".c",
+	binext = ".exe",
+	tester = nativetest
+}
+
 ALL_TOOLCHAINS = {
 	toolchain_olx386,
 	toolchain_olxthumb2,
@@ -71,5 +82,6 @@ ALL_TOOLCHAINS = {
 	toolchain_ncpm,
 	toolchain_ncpmz,
 	toolchain_ncgen,
+	toolchain_nncgen,
 }
 


### PR DESCRIPTION
Turns out there was a fundamental design issue in cowcom in the way arguments were passed which was causing bad code when subroutines were embedded inside conditionals or complex expressions. This resolves this. We now have a nncgen toolchain which uses the compiler produced by ncgen, which works absolutely fine; the cpm and cpmz targets use nncgen.