### PR TITLE
Lots of 6502 backend optimisations

### DIFF
--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -1083,6 +1083,7 @@ gen STARTSUB():s
                 E_st(REG_A);
                 E_symref(param, 0);
                 E_nl();
+                RegCacheLeavesValue(REG_A, param, 0);
 
             when 2:
                 if count != lastparam then
@@ -1103,6 +1104,8 @@ gen STARTSUB():s
                 E_st(REG_X);
                 E_symref(param, 1);
                 E_nl();
+
+                RegCacheLeavesValue(REG_XA, param, 0);
 
             when 4:
                 # WARNING: little endian on stack!

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -16,6 +16,10 @@
     var ptrsp: uint8 := 0;
     var inasm: uint8 := 0;
 
+    record ArchSubroutine
+        seen_return: uint8;
+    end record;
+
     record Extern
         name: string;
         id: uint16;
@@ -1024,6 +1028,8 @@ gen stacki4 := LOAD4(p16)                        { var op := PeekOp(); op.mode :
 
 gen STARTSUB():s
 {
+    $s.subr.arch := Alloc(@bytesof ArchSubroutine) as [ArchSubroutine];
+
     RegCacheReset();
 
     EmitterPushChunk();
@@ -1131,20 +1137,26 @@ gen STARTSUB():s
 
 gen ENDSUB():s
 {
-    E("end_");
-    E_subref(current_subr);
-    E(":\n");
+    if $s.subr.arch.seen_return != 0 then
+        E("end_");
+        E_subref(current_subr);
+        E(":\n");
+    end if;
 
     var i: uint8 := 0;
     var count := $s.subr.num_output_parameters;
     while i != count loop
         var param := GetOutputParameter($s.subr, i);
 
+        var cache: RegId;
         case param.vardata.type.typedata.width is
             when 1:
-                E_ld(REG_A);
-                E_symref(param, 0);
-                E_nl();
+                cache := RegCacheFindValue(param, 0) & REG_A;
+                if cache == 0 then
+                    E_ld(REG_A);
+                    E_symref(param, 0);
+                    E_nl();
+                end if;
                 if i != (count-1) then
                     E_pha();
                 end if;
@@ -1162,13 +1174,16 @@ gen ENDSUB():s
                     E_nl();
                     E_pha();
                 else
-                    E_ld(REG_A);
-                    E_symref(param, 0);
-                    E_nl();
+                    cache := RegCacheFindValue(param, 0) & REG_XA;
+                    if cache == 0 then
+                        E_ld(REG_A);
+                        E_symref(param, 0);
+                        E_nl();
 
-                    E_ld(REG_X);
-                    E_symref(param, 1);
-                    E_nl();
+                        E_ld(REG_X);
+                        E_symref(param, 1);
+                        E_nl();
+                    end if;
                 end if;
 
             when 4:
@@ -1217,10 +1232,13 @@ gen ENDSUB():s
         EmitterDeclareWorkspace($s.subr, i, $s.subr.workspace[i]);
         i := i + 1;
     end loop;
+
+    Free($s.subr.arch as [uint8]);
 }
 
 gen RETURN()
 {
+    current_subr.arch.seen_return := 1;
     E("\tjmp end_");
     E_subref(current_subr);
     E_nl();

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -1238,10 +1238,19 @@ gen ENDSUB():s
 
 gen RETURN()
 {
-    current_subr.arch.seen_return := 1;
-    E("\tjmp end_");
-    E_subref(current_subr);
-    E_nl();
+    if (IsSimpleSub(current_subr) != 0) and (current_subr.num_output_parameters == 0) then
+        E_rts();
+    else
+        current_subr.arch.seen_return := 1;
+        $if ARCH_65C02
+            E_insn("bra");
+        $else
+            E_insn("jmp");
+        $endif
+        E("end_");
+        E_subref(current_subr);
+        E_nl();
+    end if;
 }
 
 gen CALL(param):s uses x|y|a

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -272,6 +272,7 @@
     end sub;
 
     sub E_st(reg: RegId)
+        R_flush(reg);
         case reg is
             when REG_A: E("\tsta");
             when REG_X: E("\tstx");
@@ -290,6 +291,10 @@
 
     sub E_stx()
         E_st(REG_X);
+    end sub;
+
+    sub E_sty()
+        E_st(REG_Y);
     end sub;
 
     sub E_cp(reg: RegId)
@@ -1322,6 +1327,7 @@ gen STORE1(a:lhs, ptrs) uses y
     var op := PopAndDerefOp();
 
     DoParamDirect_sta(op, 0);
+    RegCacheFlushValues();
 }
 
 gen STORE1(a|x|y:lhs, ADDRESS():a)
@@ -1338,6 +1344,7 @@ $ifdef ARCH_65C02
         E_stz();
         E_symref($a.sym, $a.off);
         E_nl();
+        RegCacheFlushValues();
     }
 $endif
 
@@ -1346,6 +1353,7 @@ gen STORE1(a, ADD2(ptrs, CONSTANT(value>=0, value<=255):c)) uses y
     var dest := PopAndDerefOp();
     E_loadconst(REG_Y, $c.value as uint8);
     DoParamIndirect_sta(dest);
+    RegCacheFlushValues();
 }
 
 gen STORE1(a, ADD2(ADDRESS():a, CAST12(x, sext==0)))
@@ -1353,6 +1361,7 @@ gen STORE1(a, ADD2(ADDRESS():a, CAST12(x, sext==0)))
     E_sta();
     E_symref($a.sym, $a.off);
     E_x_nl();
+    RegCacheFlushValues();
 }
 
 $ifdef ARCH_65C02
@@ -1361,6 +1370,7 @@ $ifdef ARCH_65C02
         E_stz();
         E_symref($a.sym, $a.off);
         E_x_nl();
+        RegCacheFlushValues();
     }
 $endif
 
@@ -1368,6 +1378,7 @@ gen STORE1(a, ADD2(ptrs, CAST12(y, sext==0)))
 {
     var dest := PopAndDerefOp();
     DoParamIndirect_sta(dest);
+    RegCacheFlushValues();
 }
 
 gen a|x|y := LOAD1(ADDRESS():a)
@@ -1458,6 +1469,43 @@ gen a := SUB1(a, in1s) uses y { paramwidth := 1; E_sec(); DoParamDirect(PopOp(),
 gen a := OR1 (a, in1s) uses y { paramwidth := 1;          DoParamDirect(PopOp(), "ora", 0); }
 gen a := AND1(a, in1s) uses y { paramwidth := 1;          DoParamDirect(PopOp(), "and", 0); }
 gen a := EOR1(a, in1s) uses y { paramwidth := 1;          DoParamDirect(PopOp(), "eor", 0); }
+
+%{
+    sub is_inc_or_dec(value: Arith): (result: uint8)
+        result := 0;
+        if (value == 1) or (value == -1) then
+            result := 1;
+        end if;
+    end sub;
+%}
+
+gen STORE1(ADD1(LOAD1(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS():a2) uses x cost 100
+{
+    if ($a1.sym == $a2.sym) and ($a1.off == $a2.off) then
+        if $c.value < 0 then
+            E_insn("dec");
+        else
+            E_insn("inc");
+        end if;
+        E_symref($a1.sym, $a1.off);
+        E_nl();
+    else
+        E_ldx();
+        E_symref($a1.sym, $a1.off);
+        E_nl();
+
+        if $c.value < 0 then
+            E_dex();
+        else
+            E_inx();
+        end if;
+
+        E_stx();
+        E_symref($a2.sym, $a2.off);
+        E_nl();
+    end if;
+    RegCacheFlushValues();
+}
 
 %{
     sub Shift1(insn: string, amount: uint8)
@@ -1588,6 +1636,8 @@ $ifdef ARCH_65C02
         E_stz();
         E_symref($a.sym, $a.off+1);
         E_nl();
+
+        RegCacheFlushValues();
     }
 $endif
 
@@ -1598,6 +1648,8 @@ gen STORE2(xa, ptrs) uses y
     DoParamDirect_sta(op, 0);
     E_txa();
     DoParamDirect_sta(op, 1);
+
+    RegCacheFlushValues();
 }
 
 gen STORE2(xa, ADD2(ptrs, CONSTANT(value>=0, value<=254):c)) uses y
@@ -1608,6 +1660,94 @@ gen STORE2(xa, ADD2(ptrs, CONSTANT(value>=0, value<=254):c)) uses y
     DoParamDirect_sta(dest, off+0);
     E_txa();
     DoParamDirect_sta(dest, off+1);
+
+    RegCacheFlushValues();
+}
+
+gen STORE2(ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS():a2) uses x|y|a cost 100
+{
+    var lid := AllocPlabel();
+    if ($a1.sym == $a2.sym) and ($a1.off == $a2.off) then
+        if $c.value < 0 then
+            E_lda();
+            E_symref($a1.sym, $a1.off);
+            E_nl();
+
+            E_bne_p(lid);
+
+            E_insn("dec");
+            E_symref($a1.sym, $a1.off+1);
+            E_nl();
+
+            E_plabel(lid);
+            
+            E_insn("dec");
+            E_symref($a1.sym, $a1.off);
+            E_nl();
+        else
+            E_insn("inc");
+            E_symref($a1.sym, $a1.off);
+            E_nl();
+
+            E_bne_p(lid);
+
+            E_insn("inc");
+            E_symref($a1.sym, $a1.off+1);
+            E_nl();
+
+            E_plabel(lid);
+        end if;
+
+        RegCacheFlushValues();
+    else
+        $ifdef ARCH_65C02
+            const LOWREG := REG_A;
+        $else
+            const LOWREG := REG_Y;
+        $endif
+
+        var cache := RegCacheFindValue($a1.sym, $a1.off);
+        if cache != REG_XA then
+            E_ldx();
+            E_symref($a1.sym, $a1.off+1);
+            E_nl();
+
+            E_ld(LOWREG);
+            E_symref($a1.sym, $a1.off);
+            E_nl();
+        else
+            $ifdef ARCH_65C02
+                # Highreg is already in A, where we want it.
+            $else
+                E_tay();
+            $endif
+        end if;
+
+        if $c.value < 0 then
+            E_bne_p(lid);
+            E_dex();
+            E_plabel(lid);
+            E_dec(LOWREG);
+        else
+            E_inc(LOWREG);
+            E_bne_p(lid);
+            E_inx();
+            E_plabel(lid);
+        end if;
+
+        E_stx();
+        E_symref($a2.sym, $a2.off+1);
+        E_nl();
+
+        E_st(LOWREG);
+        E_symref($a2.sym, $a2.off);
+        E_nl();
+
+        RegCacheFlushValues();
+        $ifdef ARCH_65C02
+            RegCacheLeavesValue(REG_XA, $a2.sym, $a2.off);
+        $endif
+    end if;
 }
 
 %{
@@ -1635,6 +1775,8 @@ gen STORE2(xa, ADD2(ptrs, CONSTANT(value>=0, value<=254):c)) uses y
         E_txa();
         DoParamDirect(rhs, insn, 1);
         DoParamDirect(dest, "sta", 1);
+
+        RegCacheFlushValues();
     end sub;
 
     sub DoXA_neg()
@@ -1753,6 +1895,8 @@ gen xa := REMS2(xa, in2s) uses y { Rem2("_divs2r"); }
 
         E_dey();
         E_bpl_p(lid);
+
+        RegCacheFlushValues();
     end sub;
 %}
 
@@ -1782,6 +1926,8 @@ gen v32 := LOAD4(ptrs) uses a|x|y
 
         E_dey();
         E_bpl_p(lid);
+
+        RegCacheFlushValues();
     end sub;
 
     sub Do2Op4_neg(lhs: [Operand], dest: [Operand])
@@ -1798,6 +1944,8 @@ gen v32 := LOAD4(ptrs) uses a|x|y
         E_iny();
         E_dex();
         E_bne_p(lid);
+
+        RegCacheFlushValues();
     end sub;
 %}
 
@@ -1820,6 +1968,8 @@ gen STORE4(NOT4(in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var lhs :
         E_iny();
         E_dex();
         E_bne_p(lid);
+
+        RegCacheFlushValues();
     end sub;
 %}
 
@@ -1873,6 +2023,8 @@ gen STORE4(EOR4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var
 
         E_dey();
         E_bpl_p(lid);
+
+        RegCacheFlushValues();
     end sub;
 
     sub MulOrDivOrRem4ToV32(name: string, resultoffset: uint8)
@@ -2077,6 +2229,8 @@ gen xa := CAST12(a):c uses y
         DoParamDirect_sta(dest, 1);
         DoParamDirect_sta(dest, 2);
         DoParamDirect_sta(dest, 3);
+
+        RegCacheFlushValues();
     end sub;
 %}
 
@@ -2102,6 +2256,8 @@ gen STORE4(CAST14(a):c, ptrs) uses y { var dest := PopAndDerefOp(); Cast14(dest,
 
         DoParamDirect_sta(dest, 2);
         DoParamDirect_sta(dest, 3);
+
+        RegCacheFlushValues();
     end sub;
 %}
 

--- a/src/cowcom/types.coh
+++ b/src/cowcom/types.coh
@@ -87,6 +87,7 @@ record Subroutine
 	old_break_label: LabelRef;
 	old_continue_label: LabelRef;
 	old_call: [Subroutine];
+	arch: [ArchSubroutine];
 end record;
 
 record LoopLabels

--- a/tests/addsub-16bit.good
+++ b/tests/addsub-16bit.good
@@ -1,3 +1,7 @@
+one+ONE=TWO: yes
+one-ONE=ZERO: yes
+i:=one+ONE=TWO: yes
+i:=one-ONE=ZERO: yes
 one+two==three: yes
 one+mtwo==mone: yes
 one+one==two: yes

--- a/tests/addsub-16bit.test.cow
+++ b/tests/addsub-16bit.test.cow
@@ -17,6 +17,13 @@ var one: int16 := ONE;
 var two: int16 := TWO;
 var three: int16 := THREE;
 
+print("one+ONE=TWO"); if one+ONE==TWO then yes(); else no(); end if;
+print("one-ONE=ZERO"); if one-ONE==ZERO then yes(); else no(); end if;
+
+var i: int16;
+print("i:=one+ONE=TWO"); i := one+ONE; if i==TWO then yes(); else no(); end if;
+print("i:=one-ONE=ZERO"); i := one-ONE; if i==ZERO then yes(); else no(); end if;
+
 print("one+two==three"); if one+two==three then yes(); else no(); end if;
 print("one+mtwo==mone"); if one+mtwo==mone then yes(); else no(); end if;
 print("one+one==two"); if one+one==two then yes(); else no(); end if;

--- a/tools/newgen/main.c
+++ b/tools/newgen/main.c
@@ -425,7 +425,7 @@ static void print_predicate(int index, bool* first, Node* template, Predicate* p
 		{
 			case IS:
 				#if defined COWGOL
-					fprintf(outfp, " (is_%s([n + %d * @bytesof intptr].", predicate->u.callback, index);
+					fprintf(outfp, " (is_%s(slots[%d].", predicate->u.callback, index);
 				#else
 					fprintf(outfp, " (is_%s(n[%d]->u.", predicate->u.callback, index);
 				#endif
@@ -435,7 +435,7 @@ static void print_predicate(int index, bool* first, Node* template, Predicate* p
 
 			default:
 				#if defined COWGOL
-					fprintf(outfp, " ([n + %d * @bytesof intptr].", index);
+					fprintf(outfp, " (slots[%d].", index);
 				#else
 					fprintf(outfp, " (n[%d]->u.", index);
 				#endif
@@ -455,6 +455,8 @@ static void create_match_predicates(void)
 {
 	#if defined COWGOL
 		fprintf(outfp, "sub MatchPredicate(rule: uint8, n: [[Node]]): (matches: uint8)\n");
+		fprintf(outfp, "var slots: [Node][%d];\n", maxdepth);
+		fprintf(outfp, "MemCopy(n as [uint8], @bytesof slots, &slots[0] as [uint8]);\n");
 		fprintf(outfp, "matches := 0;\n");
 		fprintf(outfp, "case rule is\n");
 	#else


### PR DESCRIPTION
After deciding that I couldn't optimise it any more, I optimised it some more. cowlink.bbct has gone from 9155 to 8779 bytes, and cowcom.8080.bbct has gone from 57843 to 56960. Sadly the 6502 compilers are still way too big to run on an actual 6502.