### PR TITLE
More minor byte shaving and optimisations

### DIFF
--- a/rt/bbct/cowgol.cos
+++ b/rt/bbct/cowgol.cos
@@ -509,5 +509,49 @@
     eor #$ff
     rts
 
+&X _when4
+&W _when4 1 4
+; Compares the 32-bit value pointed at by `$.2.0to1 with the value immediately
+; after the call instruction and sets the flags appropriately.
+``:
+    ; Pop the return address and add one to it.
+    pla
+    sta `$.1.2
+    pla
+    sta `$.1.3
+    inc `$.1.2
+    bne +
+    inc `$.1.3
++
+    ; Now compare the two numbers.
+
+    ldy #3
+-
+    lda (`$.1.0), y
+    cmp (`$.1.2), y
+    bne +
+    dey
+    bpl -
++
+    ; Z will be unset here because Y just decremented to 0xff, so increment
+    ; it so it's zero again.
+    iny
+
+    ; Increment the address to skip the value.
+
+    php
+    clc
+    lda `$.1.2
+    adc #4
+    sta `$.1.2
+    bcc +
+    inc `$.1.3
++
+    plp
+
+    ; Return.
+
+    jmp (`$.1.2)
+    
 ; vim: sw=4 ts=4 et
 

--- a/rt/bbct/file.coh
+++ b/rt/bbct/file.coh
@@ -137,7 +137,7 @@ sub FCBExt(fcb: [FCB]): (len: uint32)
 	@asm "ldy", channel;
 	@asm "jsr $ffda"; # OSARGS
 
-	len := [&ptr1 as [uint32]];
+	len := [@alias &ptr1 as [uint32]];
 end sub;
 
 sub fcb_i_nextchar(fcb: [FCB])

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -18,6 +18,8 @@
 
     record ArchSubroutine
         seen_return: uint8;
+        end_label: LabelRef;
+        rts_label: LabelRef;
     end record;
 
     record Extern
@@ -97,10 +99,86 @@
         RegCacheFlush(FindConflictingRegisters(reg));
     end sub;
 
+    const OC_ADC := 0;
+    const OC_SBC := 1;
+    const OC_AND := 2;
+    const OC_ORA := 3;
+    const OC_EOR := 4;
+    const OC_LDA := 5;
+    const OC_LDX := 6;
+    const OC_LDY := 7;
+    const OC_STA := 8;
+    const OC_STX := 9;
+    const OC_STY := 10;
+    const OC_PHP := 11;
+    const OC_PHA := 12;
+    const OC_PLP := 13;
+    const OC_PLA := 14;
+    const OC_TAX := 15;
+    const OC_TXA := 16;
+    const OC_TAY := 17;
+    const OC_TYA := 18;
+    const OC_BEQ := 19;
+    const OC_BNE := 20;
+    const OC_BVS := 21;
+    const OC_BCC := 22;
+    const OC_BCS := 23;
+    const OC_CLC := 24;
+    const OC_SEC := 25;
+    const OC_RTS := 26;
+    const OC_JSR := 27;
+    const OC_JMP := 28;
+    const OC_PHX := 29;
+    const OC_PHY := 30;
+    const OC_PLX := 31;
+    const OC_PLY := 32;
+    const OC_TSX := 33;
+    const OC_TXS := 34;
+    const OC_ROL := 35;
+    const OC_STZ := 36;
+    const OC_CMP := 37;
+    const OC_CPX := 38;
+    const OC_CPY := 39;
+    const OC_INX := 40;
+    const OC_INY := 41;
+    const OC_DEX := 42;
+    const OC_DEY := 43;
+    const OC_INC := 44;
+    const OC_DEC := 45;
+
+    sub E_oc(oc: uint8)
+        var ocs: string[] := {
+            "adc", "sbc", "and", "ora", "eor", "lda", "ldx", "ldy",
+            "sta", "stx", "sty", "php", "pha", "plp", "pla", "tax",
+            "txa", "tay", "tya", "beq", "bne", "bvs", "bcc", "bcs",
+            "clc", "sec", "rts", "jsr", "jmp", "phx", "phy", "plx",
+            "ply", "tsx", "txs", "rol", "stz", "cmp", "cpx", "cpy",
+            "inx", "iny", "dex", "dey", "inc", "dec"
+        };
+
+        E_tab();
+        E(ocs[oc]);
+        E_space();
+    end sub;
+
+    sub E_ocnl(oc: uint8)
+        E_oc(oc);
+        E_nl();
+    end sub;
+
     sub E_insn(insn: string)
         E_tab();
         E(insn);
         E_space();
+    end sub;
+
+    sub E_plusone()
+        E("+1");
+    end sub;
+
+    sub E_label(label: LabelRef)
+        E_labelref(label);
+        E(":\n");
     end sub;
 
     var labelid: uint16 := 0;
@@ -137,13 +215,13 @@
     end sub;
 
     sub E_bne_p(label: LabelRef)
-        E_insn("bne");
+        E_oc(OC_BNE);
         E_plabelref(label);
         E_nl();
     end sub;
 
     sub E_bcs_p(label: LabelRef)
-        E_insn("bcs");
+        E_oc(OC_BCS);
         E_plabelref(label);
         E_nl();
     end sub;
@@ -234,123 +312,87 @@
         E_jump("bmi", label);
     end sub;
 
-    sub E_rts() E("\trts\n"); end sub;
-    sub E_clc() E("\tclc\n"); end sub;
-    sub E_sec() E("\tsec\n"); end sub;
-    sub E_pha() E("\tpha\n"); end sub;
-    sub E_phx() E("\tphx\n"); end sub;
-    sub E_phy() E("\tphy\n"); end sub;
-    sub E_plp() E("\tplp\n"); end sub;
-    sub E_pla() R_flush(REG_A); E("\tpla\n"); end sub;
-    sub E_plx() R_flush(REG_X); E("\tplx\n"); end sub;
-    sub E_ply() R_flush(REG_Y); E("\tply\n"); end sub;
-    sub E_txa() R_flush(REG_A); E("\ttxa\n"); end sub;
-    sub E_tya() R_flush(REG_A); E("\ttya\n"); end sub;
-    sub E_tax() R_flush(REG_X); E("\ttax\n"); end sub;
-    sub E_tay() R_flush(REG_Y); E("\ttay\n"); end sub;
-    sub E_tsx() R_flush(REG_X); E("\ttsx\n"); end sub;
-    sub E_txs() E("\ttxs\n"); end sub;
-    sub E_not() R_flush(REG_A); E("\teor #255\n"); end sub;
-    sub E_rol() R_flush(REG_A); E("\trol\n"); end sub;
+    sub E_rts() E_ocnl(OC_RTS); end sub;
+    sub E_clc() E_ocnl(OC_CLC); end sub;
+    sub E_sec() E_ocnl(OC_SEC); end sub;
+    sub E_pha() E_ocnl(OC_PHA); end sub;
+    sub E_phx() E_ocnl(OC_PHX); end sub;
+    sub E_phy() E_ocnl(OC_PHY); end sub;
+    sub E_plp() E_ocnl(OC_PLP); end sub;
+    sub E_pla() R_flush(REG_A); E_ocnl(OC_PLA); end sub;
+    sub E_plx() R_flush(REG_X); E_ocnl(OC_PLX); end sub;
+    sub E_ply() R_flush(REG_Y); E_ocnl(OC_PLY); end sub;
+    sub E_txa() R_flush(REG_A); E_ocnl(OC_TXA); end sub;
+    sub E_tya() R_flush(REG_A); E_ocnl(OC_TYA); end sub;
+    sub E_tax() R_flush(REG_X); E_ocnl(OC_TAX); end sub;
+    sub E_tay() R_flush(REG_Y); E_ocnl(OC_TAY); end sub;
+    sub E_tsx() R_flush(REG_X); E_ocnl(OC_TSX); end sub;
+    sub E_rol() R_flush(REG_A); E_ocnl(OC_ROL); end sub;
+    sub E_txs() E_ocnl(OC_TXS); end sub;
+    sub E_not() R_flush(REG_A); E_oc(OC_EOR); E("#255\n"); end sub;
 
     sub E_ld(reg: RegId)
         R_flush(reg);
         case reg is
-            when REG_A: E("\tlda");
-            when REG_X: E("\tldx");
-            when REG_Y: E("\tldy");
+            when REG_A: E_oc(OC_LDA);
+            when REG_X: E_oc(OC_LDX);
+            when REG_Y: E_oc(OC_LDY);
         end case;
-        E_space();
-    end sub;
-
-    sub E_lda()
-        E_ld(REG_A);
-    end sub;
-
-    sub E_ldx()
-        E_ld(REG_X);
-    end sub;
-
-    sub E_ldy()
-        E_ld(REG_Y);
     end sub;
 
     sub E_st(reg: RegId)
         R_flush(reg);
         case reg is
-            when REG_A: E("\tsta");
-            when REG_X: E("\tstx");
-            when REG_Y: E("\tsty");
+            when REG_A: E_oc(OC_STA);
+            when REG_X: E_oc(OC_STX);
+            when REG_Y: E_oc(OC_STY);
         end case;
-        E_space();
     end sub;
 
-    sub E_stz()
-        E("\tstz ");
-    end sub;
-
-    sub E_sta()
-        E_st(REG_A);
-    end sub;
-
-    sub E_stx()
-        E_st(REG_X);
-    end sub;
-
-    sub E_sty()
-        E_st(REG_Y);
-    end sub;
+    sub E_lda() E_ld(REG_A); end sub;
+    sub E_ldx() E_ld(REG_X); end sub;
+    sub E_ldy() E_ld(REG_Y); end sub;
+    sub E_sta() E_st(REG_A); end sub;
+    sub E_stx() E_st(REG_X); end sub;
+    sub E_sty() E_st(REG_Y); end sub;
+    sub E_stz() E_oc(OC_STZ); end sub;
 
     sub E_cp(reg: RegId)
         case reg is
-            when REG_A: E("\tcmp");
-            when REG_X: E("\tcpx");
-            when REG_Y: E("\tcpy");
+            when REG_A: E_oc(OC_CMP);
+            when REG_X: E_oc(OC_CPX);
+            when REG_Y: E_oc(OC_CPY);
         end case;
-        E_space();
     end sub;
 
-    sub E_cmp()
-        E_cp(REG_A);
-    end sub;
+    sub E_cmp() E_cp(REG_A); end sub;
+    sub E_cpx() E_cp(REG_X); end sub;
+    sub E_cpy() E_cp(REG_Y); end sub;
 
-    sub E_cpx()
-        E_cp(REG_X);
-    end sub;
+    sub E_inc() E_oc(OC_INC); end sub;
+    sub E_dec() E_oc(OC_DEC); end sub;
+    
+    sub E_a() EmitByte('a'); end sub;
 
-    sub E_cpy()
-        E_cp(REG_Y);
-    end sub;
+    sub E_ina() R_flush(REG_X); E_inc(); E_a(); end sub;
+    sub E_dea() R_flush(REG_X); E_dec(); E_a(); end sub;
 
-    sub E_inx()
-        R_flush(REG_X);
-        E("\tinx\n");
-    end sub;
+    sub E_inx() R_flush(REG_X); E_ocnl(OC_INX); end sub;
+    sub E_iny() R_flush(REG_Y); E_ocnl(OC_INY); end sub;
+    sub E_dex() R_flush(REG_X); E_ocnl(OC_DEX); end sub;
+    sub E_dey() R_flush(REG_Y); E_ocnl(OC_DEY); end sub;
 
-    sub E_iny()
-        R_flush(REG_Y);
-        E("\tiny\n");
-    end sub;
-
-    sub E_dex()
-        R_flush(REG_X);
-        E("\tdex\n");
-    end sub;
-
-    sub E_dey()
-        R_flush(REG_Y);
-        E("\tdey\n");
-    end sub;
-
-    sub E_inc(reg: RegId)
+    sub E_increment(reg: RegId)
         case reg is
             when REG_A:
                 R_flush(REG_A);
                 $ifdef ARCH_65C02
-                    E("\tinc a\n");
+                    E_inc();
+                    E("a\n");
                 $else
                     E_clc();
-                    E("\tadc #1\n");
+                    E_oc(OC_ADC);
+                    E("#1\n");
                 $endif
 
             when REG_X: E_inx();
@@ -358,15 +400,17 @@
         end case;
     end sub;
 
-    sub E_dec(reg: RegId)
+    sub E_decrement(reg: RegId)
         case reg is
             when REG_A:
                 R_flush(REG_A);
                 $ifdef ARCH_65C02
-                    E("\tdec a\n");
+                    E_dec();
+                    E("a\n");
                 $else
                     E_sec();
-                    E("\tsbc #1\n");
+                    E_oc(OC_SBC);
+                    E("#1\n");
                 $endif
 
             when REG_X: E_dex();
@@ -390,7 +434,7 @@
 
     sub E_call(subr: [Subroutine])
         R_flushall();
-        E("\tjsr ");
+        E_oc(OC_JSR);
         E_subref(subr);
         E_nl();
     end sub;
@@ -418,11 +462,11 @@
                 $endif
                 cache := RegCacheFindConstant(value-1) & reg & INCABLE;
                 if cache != 0 then
-                    E_inc(reg);
+                    E_increment(reg);
                 else
                     cache := RegCacheFindConstant(value+1) & reg & INCABLE;
                     if cache != 0 then
-                        E_dec(reg);
+                        E_decrement(reg);
                     else
                         E_ld(reg);
                         E_const(value);
@@ -1029,6 +1073,8 @@ gen stacki4 := LOAD4(p16)                        { var op := PeekOp(); op.mode :
 gen STARTSUB():s
 {
     $s.subr.arch := Alloc(@bytesof ArchSubroutine) as [ArchSubroutine];
+    $s.subr.arch.end_label := AllocLabel();
+    $s.subr.arch.rts_label := AllocLabel();
 
     RegCacheReset();
 
@@ -1064,12 +1110,13 @@ gen STARTSUB():s
                 E_iny();
             $endif
 
-            E("\tstx rts_");
-            E_subref($s.subr);
+            E_stx();
+            E_labelref($s.subr.arch.rts_label);
             E_nl();
 
-            E("\tsty 1+rts_");
-            E_subref($s.subr);
+            E_sty();
+            E_labelref($s.subr.arch.rts_label);
+            E_plusone();
             E_nl();
 
             popped := 1;
@@ -1137,10 +1184,8 @@ gen STARTSUB():s
 
 gen ENDSUB():s
 {
-    if $s.subr.arch.seen_return != 0 then
-        E("end_");
-        E_subref(current_subr);
-        E(":\n");
+    if current_subr.arch.seen_return != 0 then
+        E_label(current_subr.arch.end_label);
     end if;
 
     var i: uint8 := 0;
@@ -1208,9 +1253,8 @@ gen ENDSUB():s
     if IsSimpleSub(current_subr) != 0 then
         E_rts();
     else
-        E("rts_");
-        E_subref(current_subr);
-        E(" = *+1\n");
+        E_labelref(current_subr.arch.rts_label);
+        E("=*+1\n");
         E("\tjmp $ffff\n");
     end if;
 
@@ -1242,14 +1286,7 @@ gen RETURN()
         E_rts();
     else
         current_subr.arch.seen_return := 1;
-        $if ARCH_65C02
-            E_insn("bra");
-        $else
-            E_insn("jmp");
-        $endif
-        E("end_");
-        E_subref(current_subr);
-        E_nl();
+        E_jmp(current_subr.arch.end_label);
     end if;
 }
 
@@ -1513,9 +1550,9 @@ gen STORE1(ADD1(LOAD1(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS()
 {
     if ($a1.sym == $a2.sym) and ($a1.off == $a2.off) then
         if $c.value < 0 then
-            E_insn("dec");
+            E_dec();
         else
-            E_insn("inc");
+            E_inc();
         end if;
         E_symref($a1.sym, $a1.off);
         E_nl();
@@ -1705,23 +1742,23 @@ gen STORE2(ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS()
 
             E_bne_p(lid);
 
-            E_insn("dec");
+            E_dec();
             E_symref($a1.sym, $a1.off+1);
             E_nl();
 
             E_plabel(lid);
             
-            E_insn("dec");
+            E_dec();
             E_symref($a1.sym, $a1.off);
             E_nl();
         else
-            E_insn("inc");
+            E_inc();
             E_symref($a1.sym, $a1.off);
             E_nl();
 
             E_bne_p(lid);
 
-            E_insn("inc");
+            E_inc();
             E_symref($a1.sym, $a1.off+1);
             E_nl();
 
@@ -1757,9 +1794,9 @@ gen STORE2(ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS()
             E_bne_p(lid);
             E_dex();
             E_plabel(lid);
-            E_dec(LOWREG);
+            E_decrement(LOWREG);
         else
-            E_inc(LOWREG);
+            E_increment(LOWREG);
             E_bne_p(lid);
             E_inx();
             E_plabel(lid);
@@ -2367,7 +2404,7 @@ gen STARTCASE4(v32)
 
 gen WHENCASE1():c
 {
-    E_insn("cmp");
+    E_cmp();
     E_const($c.value as uint8);
     E_nl();
     E_bne($c.falselabel);
@@ -2375,12 +2412,12 @@ gen WHENCASE1():c
 
 gen WHENCASE2():c uses a
 {
-    E_insn("cmp");
+    E_cmp();
     E_const($c.value as uint8);
     E_nl();
     E_bne($c.falselabel);
 
-    E_insn("cpx");
+    E_cpx();
     E_const(($c.value>>8) as uint8);
     E_nl();
     E_bne($c.falselabel);

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -1302,7 +1302,6 @@ gen STORE1(a:lhs, ptrs) uses y
     var op := PopAndDerefOp();
 
     DoParamDirect_sta(op, 0);
-    RegCacheFlushValues();
 }
 
 gen STORE1(a|x|y:lhs, ADDRESS():a)
@@ -1319,7 +1318,6 @@ $ifdef ARCH_65C02
         E_stz();
         E_symref($a.sym, $a.off);
         E_nl();
-        RegCacheFlushValues();
     }
 $endif
 
@@ -1328,7 +1326,6 @@ gen STORE1(a, ADD2(ptrs, CONSTANT(value>=0, value<=255):c)) uses y
     var dest := PopAndDerefOp();
     E_loadconst(REG_Y, $c.value as uint8);
     DoParamIndirect_sta(dest);
-    RegCacheFlushValues();
 }
 
 gen STORE1(a, ADD2(ADDRESS():a, CAST12(x, sext==0)))
@@ -1336,7 +1333,6 @@ gen STORE1(a, ADD2(ADDRESS():a, CAST12(x, sext==0)))
     E_sta();
     E_symref($a.sym, $a.off);
     E_x_nl();
-    RegCacheFlushValues();
 }
 
 $ifdef ARCH_65C02
@@ -1345,7 +1341,6 @@ $ifdef ARCH_65C02
         E_stz();
         E_symref($a.sym, $a.off);
         E_x_nl();
-        RegCacheFlushValues();
     }
 $endif
 
@@ -1353,7 +1348,6 @@ gen STORE1(a, ADD2(ptrs, CAST12(y, sext==0)))
 {
     var dest := PopAndDerefOp();
     DoParamIndirect_sta(dest);
-    RegCacheFlushValues();
 }
 
 gen a|x|y := LOAD1(ADDRESS():a)
@@ -1481,7 +1475,6 @@ gen STORE1(ADD1(LOAD1(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS()
         E_symref($a2.sym, $a2.off);
         E_nl();
     end if;
-    RegCacheFlushValues();
 }
 
 %{
@@ -1611,8 +1604,6 @@ $ifdef ARCH_65C02
         E_stz();
         E_symref($a.sym, $a.off+1);
         E_nl();
-
-        RegCacheFlushValues();
     }
 $endif
 
@@ -1623,8 +1614,6 @@ gen STORE2(xa, ptrs) uses y
     DoParamDirect_sta(op, 0);
     E_txa();
     DoParamDirect_sta(op, 1);
-
-    RegCacheFlushValues();
 }
 
 gen STORE2(xa, ADD2(ptrs, CONSTANT(value>=0, value<=254):c)) uses y
@@ -1635,8 +1624,6 @@ gen STORE2(xa, ADD2(ptrs, CONSTANT(value>=0, value<=254):c)) uses y
     DoParamDirect_sta(dest, off+0);
     E_txa();
     DoParamDirect_sta(dest, off+1);
-
-    RegCacheFlushValues();
 }
 
 gen STORE2(ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS():a2) uses x|y|a cost 100
@@ -1672,8 +1659,6 @@ gen STORE2(ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS()
 
             E_label(lid);
         end if;
-
-        RegCacheFlushValues();
     else
         $ifdef ARCH_65C02
             const LOWREG := REG_A;
@@ -1718,7 +1703,6 @@ gen STORE2(ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS()
         E_symref($a2.sym, $a2.off);
         E_nl();
 
-        RegCacheFlushValues();
         $ifdef ARCH_65C02
             RegCacheLeavesValue(REG_XA, $a2.sym, $a2.off);
         $endif
@@ -1748,8 +1732,6 @@ gen STORE2(ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS()
         E_txa();
         DoParamDirect(rhs, oc, 1);
         DoParamDirect(dest, OC_STA, 1);
-
-        RegCacheFlushValues();
     end sub;
 
     sub DoXA_neg()
@@ -1870,8 +1852,6 @@ gen xa := REMS2(xa, in2s) uses y { Rem2("_divs2r"); }
 
         E_dey();
         E_bpl(lid);
-
-        RegCacheFlushValues();
     end sub;
 %}
 
@@ -1900,8 +1880,6 @@ gen v32 := LOAD4(ptrs) uses a|x|y
 
         E_dey();
         E_bpl(lid);
-
-        RegCacheFlushValues();
     end sub;
 
     sub Do2Op4_neg(lhs: [Operand], dest: [Operand])
@@ -1917,8 +1895,6 @@ gen v32 := LOAD4(ptrs) uses a|x|y
         E_iny();
         E_dex();
         E_bne(lid);
-
-        RegCacheFlushValues();
     end sub;
 %}
 
@@ -1955,8 +1931,6 @@ gen STORE4(NOT4(in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var lhs :
             E_dex();
             E_bne(lid);
         end if;
-
-        RegCacheFlushValues();
     end sub;
 %}
 
@@ -2003,8 +1977,6 @@ gen STORE4(EOR4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var
 
         E_dey();
         E_bpl(lid);
-
-        RegCacheFlushValues();
     end sub;
 
     sub MulOrDivOrRem4ToV32(name: string, resultoffset: uint8)
@@ -2198,8 +2170,6 @@ gen xa := CAST12(a):c uses y
         DoParamDirect_sta(dest, 1);
         DoParamDirect_sta(dest, 2);
         DoParamDirect_sta(dest, 3);
-
-        RegCacheFlushValues();
     end sub;
 %}
 
@@ -2225,8 +2195,6 @@ gen STORE4(CAST14(a):c, ptrs) uses y { var dest := PopAndDerefOp(); Cast14(dest,
 
         DoParamDirect_sta(dest, 2);
         DoParamDirect_sta(dest, 3);
-
-        RegCacheFlushValues();
     end sub;
 %}
 

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -766,7 +766,7 @@ gen JUMP():j
         DerefOp(op);
     end sub;
 
-    sub DoParamIndirect(operand: [Operand], oc: uint8)
+    sub DoParamIndirect(operand: [Operand], oc: uint8, off: Size)
         E_oc(oc);
         case operand.mode is
             when MODE_CONST:
@@ -794,12 +794,15 @@ gen JUMP():j
                 print_i8(operand.mode);
                 EndError();
         end case;
+        if off != 0 then
+            E_i16(off as int16);
+        end if;
         E_y_nl();
     end sub;
 
-    sub DoParamIndirect_lda(operand: [Operand]) DoParamIndirect(operand, OC_LDA); end sub; 
-    sub DoParamIndirect_sta(operand: [Operand]) DoParamIndirect(operand, OC_STA); end sub; 
-    sub DoParamIndirect_sbc(operand: [Operand]) DoParamIndirect(operand, OC_SBC); end sub;
+    sub DoParamIndirect_lda(operand: [Operand]) DoParamIndirect(operand, OC_LDA, 0); end sub; 
+    sub DoParamIndirect_sta(operand: [Operand]) DoParamIndirect(operand, OC_STA, 0); end sub; 
+    sub DoParamIndirect_sbc(operand: [Operand]) DoParamIndirect(operand, OC_SBC, 0); end sub;
 
     sub DoParamDirect(operand: [Operand], oc: uint8, offset: uint8)
         var m := operand.mode;
@@ -1072,16 +1075,15 @@ gen STARTSUB():s
             when 4:
                 # WARNING: little endian on stack!
                 PopReturnAddress();
-                E_loadconst(REG_Y, 0);
-                E_loadconst(REG_X, 4);
+                E_loadconst(REG_Y, -4);
                 var lid := E_new_label();
                 E_pla();
+                
                 E_st(REG_A);
-                E_symref(param, 0);
+                E_symref(param, -252);
                 E_y_nl();
-                E_iny();
-                E_dex();
 
+                E_iny();
                 E_bne(lid);
         end case;
     end loop;
@@ -1144,17 +1146,15 @@ gen ENDSUB():s
                 # Push from low to high so the value ends up in big-endian
                 # order on the stack. This allows the caller to pop it off
                 # using smaller code.
-                E_loadconst(REG_Y, 0);
-                E_loadconst(REG_X, 3);
+                E_loadconst(REG_Y, -4);
                 var lid := E_new_label();
 
                 E_ld(REG_A);
-                E_symref(param, 0);
+                E_symref(param, -252);
                 E_y_nl();
                 E_pha();
                 E_iny();
-                E_dex();
-                E_bpl(lid);
+                E_bne(lid);
         end case;
         i := i + 1;
     end loop;
@@ -1920,17 +1920,32 @@ gen STORE4(NOT4(in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var lhs :
 
 %{
     sub Do3Op4(oc: uint8, lhs: [Operand], rhs: [Operand], dest: [Operand])
-        E_loadconst(REG_Y, 0);
-        E_loadconst(REG_X, 4);
-        var lid := E_new_label();
+        var lid: LabelRef;
+        if (lhs.mode > MODE_STACKI) and (rhs.mode > MODE_STACKI) and (dest.mode > MODE_STACKI) then
+            # None of the operands are indirected, so we can use a more efficient loop.
 
-        DoParamIndirect_lda(lhs);
-        DoParamIndirect(rhs, oc);
-        DoParamIndirect_sta(dest);
+            E_loadconst(REG_Y, -4);
+            lid := E_new_label();
 
-        E_iny();
-        E_dex();
-        E_bne(lid);
+            DoParamIndirect(lhs, OC_LDA, -252);
+            DoParamIndirect(rhs, oc, -252);
+            DoParamIndirect(dest, OC_STA, -252);
+
+            E_iny();
+            E_bne(lid);
+        else
+            E_loadconst(REG_Y, 0);
+            E_loadconst(REG_X, 4);
+            lid := E_new_label();
+
+            DoParamIndirect_lda(lhs);
+            DoParamIndirect(rhs, oc, 0);
+            DoParamIndirect_sta(dest);
+
+            E_iny();
+            E_dex();
+            E_bne(lid);
+        end if;
 
         RegCacheFlushValues();
     end sub;
@@ -2107,7 +2122,7 @@ gen BLTS2(xa:lhs, in2s:rhs):c
         var lid := E_new_label();
 
         DoParamIndirect_lda(lhs);
-        DoParamIndirect(rhs, OC_CMP);
+        DoParamIndirect(rhs, OC_CMP, 0);
         E_bne(node.beq0.falselabel);
 
         E_dey();

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -1810,6 +1810,15 @@ gen xa := LSHIFT2(xa, y) { E_callhelper("_lshift2"); }
 gen xa := RSHIFTU2(xa, y) { E_callhelper("_rshiftu2"); }
 gen xa := RSHIFTS2(xa, y) { E_callhelper("_rshifts2"); }
 
+gen xa := RSHIFTU2(xa, CONSTANT(value==8))
+{
+    E_txa();
+    E_loadconst(REG_X, 0);
+}
+
+gen a := CAST21(RSHIFTU2(xa, CONSTANT(value==8))) { E_txa(); }
+gen a := CAST21(RSHIFTS2(xa, CONSTANT(value==8))) { E_txa(); }
+
 %{
     sub MulOrDiv2(name: string)
         var e := GetHelper("_mathpad");

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -172,6 +172,10 @@
         E_nl();
     end sub;
 
+    sub E_db() E("\t.byte "); end sub;
+    sub E_dw() E("\t.word "); end sub;
+    sub E_dl() E("\t.dword "); end sub;
+
     sub E_plusone()
         E("+1");
     end sub;
@@ -188,10 +192,7 @@
     end sub;
 
     sub E_stackref(sid: uint16)
-        EmitByte(COO_ESCAPE_WSREF);
-        E_h16(current_subr.id);
-        E_h8((sid >> 8) as uint8);
-        E_h16(sid & 0xff);
+        E_wsref(current_subr.id, (sid>>8) as uint8, sid & 0xff);
     end sub;
 
     sub E_stackrefi(sid: uint16)
@@ -205,31 +206,22 @@
             E(sym.vardata.externname);
             E_i16(off as int16);
         else
-            EmitByte(COO_ESCAPE_WSREF);
-            E_h16(sym.vardata.subr.id);
+            var wsid: uint8 := VARMEM_WS;
             if IsPtr(sym.vardata.type) != 0 then
-                E_h8(PTRMEM_WS);
-            else
-                E_h8(VARMEM_WS);
+                wsid := PTRMEM_WS;
             end if;
-            E_h16(sym.vardata.offset + off);
+            E_wsref(sym.vardata.subr.id, wsid, sym.vardata.offset + off);
         end if;
     end sub;
 
-    sub E_y_nl() E(",y\n"); end sub;
-    sub E_x_nl() E(",x\n"); end sub;
+    sub E_y_nl()    E(",y\n"); end sub;
+    sub E_x_nl()    E(",x\n"); end sub;
+    sub E_constlo() E("#<"); end sub; 
+    sub E_consthi() E("#>"); end sub; 
 
     sub E_const(value: uint8)
         EmitByte('#');
         E_u8(value);
-    end sub;
-
-    sub E_constlo()
-        E("#<");
-    end sub;
-
-    sub E_consthi()
-        E("#>");
     end sub;
 
     sub E_jump(oc: uint8, label: LabelRef)
@@ -489,21 +481,10 @@
         end if;
     end sub;
 
-    sub E_jumps_beq_bne(node: [Node])
-        E_jumps_with_fallthrough(OC_BEQ, OC_BNE, node);
-    end sub;
-
-    sub E_jumps_bcs_bcc(node: [Node])
-        E_jumps_with_fallthrough(OC_BCS, OC_BCC, node);
-    end sub;
-
-    sub E_jumps_bcc_bcs(node: [Node])
-        E_jumps_with_fallthrough(OC_BCC, OC_BCS, node);
-    end sub;
-
-    sub E_jumps_bmi_bpl(node: [Node])
-        E_jumps_with_fallthrough(OC_BMI, OC_BPL, node);
-    end sub;
+    sub E_jumps_beq_bne(node: [Node]) E_jumps_with_fallthrough(OC_BEQ, OC_BNE, node); end sub; 
+    sub E_jumps_bcs_bcc(node: [Node]) E_jumps_with_fallthrough(OC_BCS, OC_BCC, node); end sub; 
+    sub E_jumps_bcc_bcs(node: [Node]) E_jumps_with_fallthrough(OC_BCC, OC_BCS, node); end sub; 
+    sub E_jumps_bmi_bpl(node: [Node]) E_jumps_with_fallthrough(OC_BMI, OC_BPL, node); end sub; 
 
     sub AllocConst(value: Arith): (lid: uint16)
         var c := constants;
@@ -530,7 +511,7 @@
         E_h16(current_subr.id);
 
         E_label(lid);
-        E("\t.byte ");
+        E_db();
 
         loop
             var c := [data];
@@ -643,7 +624,6 @@ gen JUMP():j
     var opstack: [Operand][OPERAND_STACK_SIZE];
     var first_operand: [Operand] := 0 as [Operand];
     var opsp: uint8 := 0;
-    var paramwidth: uint8;
 
     sub RegWidth(reg: RegId): (width: uint8)
         if (reg & REG_V8) != 0 then
@@ -1309,7 +1289,6 @@ gen v8 := FALLBACK(a|x|y:rhs) cost -1000
 gen a := FALLBACK(v8) uses y cost -1000
 {
     var op := PopOp();
-    paramwidth := 1;
     DoParamDirect_lda(op, 0);
 }
 
@@ -1462,11 +1441,11 @@ $ifdef ARCH_65C02
             { SmallAdditionOrSubtraction(OC_DEC, -($c.value as int8) as uint8); }
 $endif
 
-gen a := ADD1(a, in1s) uses y { paramwidth := 1; E_clc(); DoParamDirect(PopOp(), OC_ADC, 0); }
-gen a := SUB1(a, in1s) uses y { paramwidth := 1; E_sec(); DoParamDirect(PopOp(), OC_SBC, 0); }
-gen a := OR1 (a, in1s) uses y { paramwidth := 1;          DoParamDirect(PopOp(), OC_ORA, 0); }
-gen a := AND1(a, in1s) uses y { paramwidth := 1;          DoParamDirect(PopOp(), OC_AND, 0); }
-gen a := EOR1(a, in1s) uses y { paramwidth := 1;          DoParamDirect(PopOp(), OC_EOR, 0); }
+gen a := ADD1(a, in1s) uses y { E_clc(); DoParamDirect(PopOp(), OC_ADC, 0); }
+gen a := SUB1(a, in1s) uses y { E_sec(); DoParamDirect(PopOp(), OC_SBC, 0); }
+gen a := OR1 (a, in1s) uses y {          DoParamDirect(PopOp(), OC_ORA, 0); }
+gen a := AND1(a, in1s) uses y {          DoParamDirect(PopOp(), OC_AND, 0); }
+gen a := EOR1(a, in1s) uses y {          DoParamDirect(PopOp(), OC_EOR, 0); }
 
 %{
     sub is_inc_or_dec(value: Arith): (result: uint8)
@@ -1550,7 +1529,6 @@ gen a16 := FALLBACK(xa) cost -1000
 gen xa := FALLBACK(a16) uses y cost -1000
 {
     var op := PopOp();
-    paramwidth := 2;
     DoParamDirect_lda(op, 0);
     DoParamDirect(op, OC_LDX, 1);
 }
@@ -1751,7 +1729,6 @@ gen STORE2(ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS()
     sub DoXA(oc: uint8)
         var rhs := PopOp();
 
-        paramwidth := 2;
         R_flush(REG_A|REG_X|REG_XA);
         DoParamDirect(rhs, oc, 0);
         E_pha();
@@ -1765,7 +1742,6 @@ gen STORE2(ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS()
         var dest := PopAndDerefOp();
         var rhs := PopOp();
 
-        paramwidth := 2;
         R_flush(REG_A|REG_X|REG_XA);
         DoParamDirect(rhs, oc, 0);
         DoParamDirect(dest, OC_STA, 0);
@@ -1779,7 +1755,6 @@ gen STORE2(ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS()
     sub DoXA_neg()
         var rhs := PopOp();
 
-        paramwidth := 2;
         R_flush(REG_A|REG_X|REG_XA);
 
         E_sec();
@@ -1796,7 +1771,6 @@ gen STORE2(ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS()
     sub DoXA_not()
         var rhs := PopOp();
 
-        paramwidth := 2;
         R_flush(REG_A|REG_X|REG_XA);
 
         DoParamDirect_lda(rhs, 0);
@@ -1841,17 +1815,14 @@ gen xa := RSHIFTS2(xa, y) { E_callhelper("_rshifts2"); }
         var e := GetHelper("_mathpad");
 
         E_sta();
-        EmitByte(COO_ESCAPE_WSREF);
-        E_h16(e.id);
-        E("010000\n");
+        E_wsref(e.id, PTRMEM_WS, 0);
+        E_nl();
 
         E_stx();
-        EmitByte(COO_ESCAPE_WSREF);
-        E_h16(e.id);
-        E("010001\n");
+        E_wsref(e.id, PTRMEM_WS, 1);
+        E_nl();
 
         var rhs := PopOp();
-        paramwidth := 2;
         DoParamDirect_lda(rhs, 0);
         DoParamDirect(rhs, OC_LDX, 1);
         E_callhelper(name);
@@ -1863,14 +1834,12 @@ gen xa := RSHIFTS2(xa, y) { E_callhelper("_rshifts2"); }
         var e := GetHelper("_mathpad");
 
         E_lda();
-        EmitByte(COO_ESCAPE_WSREF);
-        E_h16(e.id);
-        E("010004\n");
+        E_wsref(e.id, PTRMEM_WS, 4);
+        E_nl();
 
         E_ldx();
-        EmitByte(COO_ESCAPE_WSREF);
-        E_h16(e.id);
-        E("010005\n");
+        E_wsref(e.id, PTRMEM_WS, 5);
+        E_nl();
     end sub;
 %}
 
@@ -1913,7 +1882,6 @@ gen v32 := LOAD4(ptrs) uses a|x|y
 
 %{
     sub Do2Op4_not(lhs: [Operand], dest: [Operand])
-        paramwidth := 4;
         E_loadconst(REG_Y, 3);
         var lid := E_new_label();
 
@@ -1928,7 +1896,6 @@ gen v32 := LOAD4(ptrs) uses a|x|y
     end sub;
 
     sub Do2Op4_neg(lhs: [Operand], dest: [Operand])
-        paramwidth := 4;
         E_loadconst(REG_X, 4);
         E_loadconst(REG_Y, 0);
         E_sec();
@@ -1953,9 +1920,8 @@ gen STORE4(NOT4(in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var lhs :
 
 %{
     sub Do3Op4(oc: uint8, lhs: [Operand], rhs: [Operand], dest: [Operand])
-        paramwidth := 4;
         E_loadconst(REG_Y, 0);
-        E_loadconst(REG_X, paramwidth);
+        E_loadconst(REG_X, 4);
         var lid := E_new_label();
 
         DoParamIndirect_lda(lhs);
@@ -1985,37 +1951,30 @@ gen STORE4(EOR4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var
     sub MulOrDivOrRem4(name: string, resultoffset: uint8, lhs: [Operand], rhs: [Operand], dest: [Operand])
         var e := GetHelper("_mathpad");
 
-        paramwidth := 4;
         E_loadconst(REG_Y, 3);
         var lid := E_new_label();
 
         DoParamIndirect_lda(lhs);
-        E("\tsta ");
-        EmitByte(COO_ESCAPE_WSREF);
-        E_h16(e.id);
-        E("010000, y\n");
+        E_sta();
+        E_wsref(e.id, PTRMEM_WS, 0);
+        E_y_nl();
 
         DoParamIndirect_lda(rhs);
-        E("\tsta ");
-        EmitByte(COO_ESCAPE_WSREF);
-        E_h16(e.id);
-        E("010008, y\n");
+        E_sta();
+        E_wsref(e.id, PTRMEM_WS, 8);
+        E_y_nl();
 
         E_dey();
         E_bpl(lid);
 
         E_callhelper(name);
 
-        paramwidth := 4;
         E_loadconst(REG_Y, 3);
         lid := E_new_label();
 
-        E("\tlda ");
-        EmitByte(COO_ESCAPE_WSREF);
-        E_h16(e.id);
-        E_h8(1);
-        E_h16(resultoffset as uint16);
-        E(", y\n");
+        E_lda();
+        E_wsref(e.id, PTRMEM_WS, resultoffset as uint16);
+        E_y_nl();
         DoParamIndirect_sta(dest);
 
         E_dey();
@@ -2079,7 +2038,6 @@ gen BEQ0(CONSTANT():lhs, CONSTANT():rhs):b
 gen BEQ1(a:lhs, in1s:rhs):b
 {
     var rhs := PopOp();
-    paramwidth := 1;
     DoParamDirect(rhs, OC_CMP, 0);
     E_jumps_beq_bne(self.n[0]);
 }
@@ -2087,7 +2045,6 @@ gen BEQ1(a:lhs, in1s:rhs):b
 gen BLTU1(a:lhs, in1s:rhs):b
 {
     var rhs := PopOp();
-    paramwidth := 1;
     DoParamDirect(rhs, OC_CMP, 0);
     E_jumps_bcc_bcs(self.n[0]);
 }
@@ -2095,7 +2052,6 @@ gen BLTU1(a:lhs, in1s:rhs):b
 gen BLTS1(a:lhs, in1s:rhs):b
 {
     var rhs := PopOp();
-    paramwidth := 1;
     E_sec();
     DoParamDirect(rhs, OC_SBC, 0);
     E("\tbvc *+4\n");
@@ -2106,28 +2062,24 @@ gen BLTS1(a:lhs, in1s:rhs):b
 gen BEQ2(xa:lhs, in2s:rhs):b
 {
     var rhs := PopOp();
-    paramwidth := 2;
     DoParamDirect(rhs, OC_CMP, 0);
     E_bne($b.falselabel);
 
-    paramwidth := 1;
+    var oc: uint8 := OC_CPX;
     if ($rhs & REGCLASS_DEREFS) != 0 then
         E_txa();
-        DoParamDirect(rhs, OC_CMP, 1);
-    else
-        DoParamDirect(rhs, OC_CPX, 1);
+        oc := OC_CMP;
     end if;
+    DoParamDirect(rhs, oc, 1);
     E_jumps_beq_bne(self.n[0]);
 }
 
 gen BLTU2(xa:lhs, in2s:rhs):c
 {
     var rhs := PopOp();
-    paramwidth := 2;
     E_sec();
     DoParamDirect(rhs, OC_SBC, 0);
 
-    paramwidth := 1;
     E_txa();
     DoParamDirect(rhs, OC_SBC, 1);
     E_jumps_bcc_bcs(self.n[0]);
@@ -2136,11 +2088,9 @@ gen BLTU2(xa:lhs, in2s:rhs):c
 gen BLTS2(xa:lhs, in2s:rhs):c
 {
     var rhs := PopOp();
-    paramwidth := 2;
     E_sec();
     DoParamDirect(rhs, OC_SBC, 0);
 
-    paramwidth := 1;
     E_txa();
     DoParamDirect(rhs, OC_SBC, 1);
     E("\tbvc *+4\n");
@@ -2150,11 +2100,10 @@ gen BLTS2(xa:lhs, in2s:rhs):c
 
 %{
     sub DoCmp4EQ(node: [Node])
-        paramwidth := 4;
         var rhs := PopOp();
         var lhs := PopOp();
 
-        E_loadconst(REG_Y, paramwidth-1);
+        E_loadconst(REG_Y, 3);
         var lid := E_new_label();
 
         DoParamIndirect_lda(lhs);
@@ -2170,7 +2119,6 @@ gen BLTS2(xa:lhs, in2s:rhs):c
     end sub;
 
     sub DoCmp4LT(node: [Node], sext: uint8)
-        paramwidth := 4;
         var rhs := PopOp();
         var lhs := PopOp();
 
@@ -2272,14 +2220,12 @@ gen a := CAST21(in2s|xa:rhs)
 gen a := CAST41(in4s)
 {
     var op := PopOp();
-    paramwidth := 1;
     DoParamDirect_lda(op, 0);
 }
 
 gen xa := CAST42(in4s)
 {
     var op := PopOp();
-    paramwidth := 2;
     DoParamDirect_lda(op, 1);
     E_tax();
     DoParamDirect_lda(op, 0);
@@ -2302,7 +2248,6 @@ gen STARTCASE2(xa) { StartCase(); }
 
 gen STARTCASE4(v32)
 {
-    E("\t;CASE4\n");
     StartCase();
 
     var e := GetHelper("_when4");
@@ -2315,9 +2260,7 @@ gen STARTCASE4(v32)
     E_nl();
 
     E_sta();
-    EmitByte(COO_ESCAPE_WSREF);
-    E_h16(e.id);
-    E("010000\n");
+    E_wsref(e.id, PTRMEM_WS, 0);
     E_nl();
     
     E_lda();
@@ -2326,9 +2269,7 @@ gen STARTCASE4(v32)
     E_nl();
 
     E_sta();
-    EmitByte(COO_ESCAPE_WSREF);
-    E_h16(e.id);
-    E("010001\n");
+    E_wsref(e.id, PTRMEM_WS, 1);
     E_nl();
 }
 
@@ -2356,8 +2297,8 @@ gen WHENCASE2():c uses a
 gen WHENCASE4():c uses a
 {
     E_callhelper("_when4");
-    E("\t.dint ");
-    E_i32($c.value);
+    E_dl();
+    E_u32($c.value as uint32);
     E_nl();
 
     E_bne($c.falselabel);
@@ -2402,21 +2343,21 @@ gen ENDINIT()
 
 gen INIT1():c
 {
-    E("\t.byte ");
+    E_db();
     E_u8($c.value as uint8);
     E_nl();
 }
 
 gen INIT2():c
 {
-    E("\t.word ");
+    E_dw();
     E_u16($c.value as uint16);
     E_nl();
 }
 
 gen INIT4():c
 {
-    E("\t.dword ");
+    E_dl();
     E_u32($c.value as uint32);
     E_nl();
 }
@@ -2425,7 +2366,7 @@ gen INITS():s
 {
     var sid := E_string($s.text);
 
-    E("\t.word ");
+    E_dw();
     E_labelref(sid);
     E_nl();
 }

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -2332,7 +2332,38 @@ gen xa := CAST42(in4s)
 
 gen STARTCASE1(a) { StartCase(); }
 gen STARTCASE2(xa) { StartCase(); }
-gen STARTCASE4(v32) { StartCase(); }
+
+gen STARTCASE4(v32)
+{
+    E("\t;CASE4\n");
+    StartCase();
+
+    var e := GetHelper("_when4");
+    var op := PeekOp();
+    var sid := op.stk.sid;
+
+    E_lda();
+    E_constlo();
+    E_stackref(sid);
+    E_nl();
+
+    E_sta();
+    EmitByte(COO_ESCAPE_WSREF);
+    E_h16(e.id);
+    E("010000\n");
+    E_nl();
+    
+    E_lda();
+    E_consthi();
+    E_stackref(sid);
+    E_nl();
+
+    E_sta();
+    EmitByte(COO_ESCAPE_WSREF);
+    E_h16(e.id);
+    E("010001\n");
+    E_nl();
+}
 
 gen WHENCASE1():c
 {
@@ -2357,17 +2388,12 @@ gen WHENCASE2():c uses a
 
 gen WHENCASE4():c uses a
 {
-    varsp := varsp - 4;
-    var lhs := PushV32(); # overlaps the stored value
-    var op := PushConstOp($c.value);
+    E_callhelper("_when4");
+    E("\t.dint ");
+    E_i32($c.value);
+    E_nl();
 
-    var node: Node;
-    node.beq0.falselabel := $c.falselabel;
-    node.beq0.truelabel := 0;
-    node.beq0.fallthrough := 0;
-    DoCmp4EQ(&node);
-
-    varsp := varsp + 4;
+    E_bne($c.falselabel);
 }
 
 gen ENDCASE1() { EndCase(); }

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -145,6 +145,11 @@
     const OC_DEY := 43;
     const OC_INC := 44;
     const OC_DEC := 45;
+    const OC_BRA := 46;
+    const OC_BMI := 47;
+    const OC_BPL := 48;
+    const OC_ASL := 49;
+    const OC_LSR := 50;
 
     sub E_oc(oc: uint8)
         var ocs: string[] := {
@@ -153,7 +158,8 @@
             "txa", "tay", "tya", "beq", "bne", "bvs", "bcc", "bcs",
             "clc", "sec", "rts", "jsr", "jmp", "phx", "phy", "plx",
             "ply", "tsx", "txs", "rol", "stz", "cmp", "cpx", "cpy",
-            "inx", "iny", "dex", "dey", "inc", "dec"
+            "inx", "iny", "dex", "dey", "inc", "dec", "bra", "bmi",
+            "bpl", "asl", "lsr"
         };
 
         E_tab();
@@ -164,12 +170,6 @@
     sub E_ocnl(oc: uint8)
         E_oc(oc);
         E_nl();
-    end sub;
-
-    sub E_insn(insn: string)
-        E_tab();
-        E(insn);
-        E_space();
     end sub;
 
     sub E_plusone()
@@ -232,38 +232,27 @@
         E("#>");
     end sub;
 
-    sub E_jump(insn: string, label: LabelRef)
+    sub E_jump(oc: uint8, label: LabelRef)
         R_flushall();
-        E_tab();
-        E(insn);
-        E_space();
+        E_oc(oc);
         E_labelref(label);
         E_nl();
     end sub;
 
     sub E_jmp(label: LabelRef)
+        var oc: uint8;
         $ifdef ARCH_65C02
-            E_jump("bra", label);
+            oc := OC_BRA;
         $else
-            E_jump("jmp", label);
+            oc := OC_JMP;
         $endif
+        E_jump(oc, label);
     end sub;
 
-    sub E_bne(label: LabelRef)
-        E_jump("bne", label);
-    end sub;
-
-    sub E_bcs(label: LabelRef)
-        E_jump("bcs", label);
-    end sub;
-
-    sub E_bmi(label: LabelRef)
-        E_jump("bmi", label);
-    end sub;
-
-    sub E_bpl(label: LabelRef)
-        E_jump("bpl", label);
-    end sub;
+    sub E_bne(label: LabelRef) E_jump(OC_BNE, label); end sub;
+    sub E_bcs(label: LabelRef) E_jump(OC_BCS, label); end sub;
+    sub E_bmi(label: LabelRef) E_jump(OC_BMI, label); end sub;
+    sub E_bpl(label: LabelRef) E_jump(OC_BPL, label); end sub;
 
     sub E_rts() E_ocnl(OC_RTS); end sub;
     sub E_clc() E_ocnl(OC_CLC); end sub;
@@ -485,35 +474,35 @@
         EmitterPopChunk('R');
 
         R_flushall();
-        E("\tjsr ");
+        E_oc(OC_JSR);
         EmitByte(COO_ESCAPE_SUBREF);
         E_h16(e.id);
         E_nl();
     end sub;
 
-    sub E_jumps_with_fallthrough(trueinsn: string, falseinsn: string, node: [Node])
+    sub E_jumps_with_fallthrough(trueoc: uint8, falseoc: uint8, node: [Node])
         if node.beq0.truelabel != node.beq0.fallthrough then
-            E_jump(trueinsn, node.beq0.truelabel);
+            E_jump(trueoc, node.beq0.truelabel);
         end if;
         if node.beq0.falselabel != node.beq0.fallthrough then
-            E_jump(falseinsn, node.beq0.falselabel);
+            E_jump(falseoc, node.beq0.falselabel);
         end if;
     end sub;
 
     sub E_jumps_beq_bne(node: [Node])
-        E_jumps_with_fallthrough("beq", "bne", node);
+        E_jumps_with_fallthrough(OC_BEQ, OC_BNE, node);
     end sub;
 
     sub E_jumps_bcs_bcc(node: [Node])
-        E_jumps_with_fallthrough("bcs", "bcc", node);
+        E_jumps_with_fallthrough(OC_BCS, OC_BCC, node);
     end sub;
 
     sub E_jumps_bcc_bcs(node: [Node])
-        E_jumps_with_fallthrough("bcc", "bcs", node);
+        E_jumps_with_fallthrough(OC_BCC, OC_BCS, node);
     end sub;
 
     sub E_jumps_bmi_bpl(node: [Node])
-        E_jumps_with_fallthrough("bmi", "bpl", node);
+        E_jumps_with_fallthrough(OC_BMI, OC_BPL, node);
     end sub;
 
     sub AllocConst(value: Arith): (lid: uint16)
@@ -797,8 +786,8 @@ gen JUMP():j
         DerefOp(op);
     end sub;
 
-    sub DoParamIndirect(operand: [Operand], insn: string)
-        E_insn(insn);
+    sub DoParamIndirect(operand: [Operand], oc: uint8)
+        E_oc(oc);
         case operand.mode is
             when MODE_CONST:
                 E_labelref(AllocConst(operand.val));
@@ -828,19 +817,11 @@ gen JUMP():j
         E_y_nl();
     end sub;
 
-    sub DoParamIndirect_lda(operand: [Operand])
-        DoParamIndirect(operand, "lda");
-    end sub;
+    sub DoParamIndirect_lda(operand: [Operand]) DoParamIndirect(operand, OC_LDA); end sub; 
+    sub DoParamIndirect_sta(operand: [Operand]) DoParamIndirect(operand, OC_STA); end sub; 
+    sub DoParamIndirect_sbc(operand: [Operand]) DoParamIndirect(operand, OC_SBC); end sub;
 
-    sub DoParamIndirect_sta(operand: [Operand])
-        DoParamIndirect(operand, "sta");
-    end sub;
-
-    sub DoParamIndirect_sbc(operand: [Operand])
-        DoParamIndirect(operand, "sbc");
-    end sub;
-
-    sub DoParamDirect(operand: [Operand], insn: string, offset: uint8)
+    sub DoParamDirect(operand: [Operand], oc: uint8, offset: uint8)
         var m := operand.mode;
         if (m == MODE_STACKI) or (m == MODE_SYMBOLI) then
             $ifdef ARCH_65C02
@@ -852,7 +833,7 @@ gen JUMP():j
             $endif
         end if;
 
-        E_insn(insn);
+        E_oc(oc);
         case operand.mode is
             when MODE_CONST:
                 E_const((operand.val >> (8*offset)) as uint8);
@@ -903,13 +884,8 @@ gen JUMP():j
         E_nl();
     end sub;
 
-    sub DoParamDirect_lda(operand: [Operand], offset: uint8)
-        DoParamDirect(operand, "lda", offset);
-    end sub;
-
-    sub DoParamDirect_sta(operand: [Operand], offset: uint8)
-        DoParamDirect(operand, "sta", offset);
-    end sub;
+    sub DoParamDirect_lda(operand: [Operand], offset: uint8) DoParamDirect(operand, OC_LDA, offset); end sub;
+    sub DoParamDirect_sta(operand: [Operand], offset: uint8) DoParamDirect(operand, OC_STA, offset); end sub;
 
     # Note that this *destroys* the source register.
     sub ArchEmitMove(src: RegId, dest: RegId)
@@ -1469,26 +1445,28 @@ gen a := NEG1(a)
 
 $ifdef ARCH_65C02
     %{
-        sub SmallAdditionOrSubtraction(insn: string, amount: uint8)
+        sub SmallAdditionOrSubtraction(oc: uint8, amount: uint8)
             R_flush(REG_A);
             while amount != 0 loop
-                E_insn(insn);
+                E_oc(oc);
+                E_a();
+                E_nl();
                 amount := amount - 1;
             end loop;
         end sub;
     %}
 
     gen a := ADD1(a, CONSTANT(value>=0, value<=3):c)
-            { SmallAdditionOrSubtraction("inc a\n", $c.value as uint8); }
+            { SmallAdditionOrSubtraction(OC_INC, $c.value as uint8); }
     gen a := ADD1(a, CONSTANT(value<0, value>=-3):c)
-            { SmallAdditionOrSubtraction("dec a\n", -($c.value as int8) as uint8); }
+            { SmallAdditionOrSubtraction(OC_DEC, -($c.value as int8) as uint8); }
 $endif
 
-gen a := ADD1(a, in1s) uses y { paramwidth := 1; E_clc(); DoParamDirect(PopOp(), "adc", 0); }
-gen a := SUB1(a, in1s) uses y { paramwidth := 1; E_sec(); DoParamDirect(PopOp(), "sbc", 0); }
-gen a := OR1 (a, in1s) uses y { paramwidth := 1;          DoParamDirect(PopOp(), "ora", 0); }
-gen a := AND1(a, in1s) uses y { paramwidth := 1;          DoParamDirect(PopOp(), "and", 0); }
-gen a := EOR1(a, in1s) uses y { paramwidth := 1;          DoParamDirect(PopOp(), "eor", 0); }
+gen a := ADD1(a, in1s) uses y { paramwidth := 1; E_clc(); DoParamDirect(PopOp(), OC_ADC, 0); }
+gen a := SUB1(a, in1s) uses y { paramwidth := 1; E_sec(); DoParamDirect(PopOp(), OC_SBC, 0); }
+gen a := OR1 (a, in1s) uses y { paramwidth := 1;          DoParamDirect(PopOp(), OC_ORA, 0); }
+gen a := AND1(a, in1s) uses y { paramwidth := 1;          DoParamDirect(PopOp(), OC_AND, 0); }
+gen a := EOR1(a, in1s) uses y { paramwidth := 1;          DoParamDirect(PopOp(), OC_EOR, 0); }
 
 %{
     sub is_inc_or_dec(value: Arith): (result: uint8)
@@ -1528,17 +1506,16 @@ gen STORE1(ADD1(LOAD1(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS()
 }
 
 %{
-    sub Shift1(insn: string, amount: uint8)
+    sub Shift1(oc: uint8, amount: uint8)
         while amount != 0 loop
-            E_insn(insn);
-            E_nl();
+            E_ocnl(oc);
             amount := amount - 1;
         end loop;
     end sub;
 %}
 
-gen a := LSHIFT1(a, CONSTANT(value<=3):c) { Shift1("asl", $c.value as uint8); }
-gen a := RSHIFTU1(a, CONSTANT(value<=3):c) { Shift1("lsr", $c.value as uint8); }
+gen a := LSHIFT1(a, CONSTANT(value<=3):c) { Shift1(OC_ASL, $c.value as uint8); }
+gen a := RSHIFTU1(a, CONSTANT(value<=3):c) { Shift1(OC_LSR, $c.value as uint8); }
 
 gen a := RSHIFTS1(a, CONSTANT(value==1))
 {
@@ -1575,7 +1552,7 @@ gen xa := FALLBACK(a16) uses y cost -1000
     var op := PopOp();
     paramwidth := 2;
     DoParamDirect_lda(op, 0);
-    DoParamDirect(op, "ldx", 1);
+    DoParamDirect(op, OC_LDX, 1);
 }
 
 gen xa := LOAD2(ADDRESS():a)
@@ -1771,30 +1748,30 @@ gen STORE2(ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS()
 }
 
 %{
-    sub DoXA(insn: string)
+    sub DoXA(oc: uint8)
         var rhs := PopOp();
 
         paramwidth := 2;
         R_flush(REG_A|REG_X|REG_XA);
-        DoParamDirect(rhs, insn, 0);
+        DoParamDirect(rhs, oc, 0);
         E_pha();
         E_txa();
-        DoParamDirect(rhs, insn, 1);
+        DoParamDirect(rhs, oc, 1);
         E_tax();
         E_pla();
     end sub;
 
-    sub DoXADest(insn: string)
+    sub DoXADest(oc: uint8)
         var dest := PopAndDerefOp();
         var rhs := PopOp();
 
         paramwidth := 2;
         R_flush(REG_A|REG_X|REG_XA);
-        DoParamDirect(rhs, insn, 0);
-        DoParamDirect(dest, "sta", 0);
+        DoParamDirect(rhs, oc, 0);
+        DoParamDirect(dest, OC_STA, 0);
         E_txa();
-        DoParamDirect(rhs, insn, 1);
-        DoParamDirect(dest, "sta", 1);
+        DoParamDirect(rhs, oc, 1);
+        DoParamDirect(dest, OC_STA, 1);
 
         RegCacheFlushValues();
     end sub;
@@ -1807,11 +1784,11 @@ gen STORE2(ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS()
 
         E_sec();
         E_loadconst(REG_A, 0);
-        DoParamDirect(rhs, "sbc", 0);
+        DoParamDirect(rhs, OC_SBC, 0);
         E_pha();
         E_txa();
         E_loadconst(REG_A, 0);
-        DoParamDirect(rhs, "sbc", 1);
+        DoParamDirect(rhs, OC_SBC, 1);
         E_tax();
         E_pla();
     end sub;
@@ -1835,17 +1812,17 @@ gen STORE2(ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS()
 gen xa := NEG2(in2s)         uses y { DoXA_neg(); }
 gen xa := NOT2(in2s)         uses y { DoXA_not(); }
 
-gen xa := ADD2(in2s, xa) uses y { E_clc(); DoXA("adc"); }
-gen xa := SUB2(xa, in2s) uses y { E_sec(); DoXA("sbc"); }
-gen xa := AND2(in2s, xa) uses y {          DoXA("and"); }
-gen xa := OR2 (in2s, xa) uses y {          DoXA("ora"); }
-gen xa := EOR2(in2s, xa) uses y {          DoXA("eor"); }
+gen xa := ADD2(in2s, xa) uses y { E_clc(); DoXA(OC_ADC); }
+gen xa := SUB2(xa, in2s) uses y { E_sec(); DoXA(OC_SBC); }
+gen xa := AND2(in2s, xa) uses y {          DoXA(OC_AND); }
+gen xa := OR2 (in2s, xa) uses y {          DoXA(OC_ORA); }
+gen xa := EOR2(in2s, xa) uses y {          DoXA(OC_EOR); }
 
 // Because of some quirk of the way the code is generated, this rule helps
 // a lot --- but the same rule for SUB2, AND2 etc actually makes things
 // worse, I think because it prevents one of the pointer indexing rules from
 // firing.
-gen STORE2(ADD2(in2s, xa), ptrs) uses y cost 100 { E_clc(); DoXADest("adc"); }
+gen STORE2(ADD2(in2s, xa), ptrs) uses y cost 100 { E_clc(); DoXADest(OC_ADC); }
 
 gen xa := LSHIFT2(CAST12(a, sext==0), CONSTANT(value==1))
 {
@@ -1876,7 +1853,7 @@ gen xa := RSHIFTS2(xa, y) { E_callhelper("_rshifts2"); }
         var rhs := PopOp();
         paramwidth := 2;
         DoParamDirect_lda(rhs, 0);
-        DoParamDirect(rhs, "ldx", 1);
+        DoParamDirect(rhs, OC_LDX, 1);
         E_callhelper(name);
     end sub;
 
@@ -1975,14 +1952,14 @@ gen STORE4(NEG4(in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var lhs :
 gen STORE4(NOT4(in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var lhs := PopOp(); Do2Op4_not(lhs, dest); }
 
 %{
-    sub Do3Op4(insn: string, lhs: [Operand], rhs: [Operand], dest: [Operand])
+    sub Do3Op4(oc: uint8, lhs: [Operand], rhs: [Operand], dest: [Operand])
         paramwidth := 4;
         E_loadconst(REG_Y, 0);
         E_loadconst(REG_X, paramwidth);
         var lid := E_new_label();
 
         DoParamIndirect_lda(lhs);
-        DoParamIndirect(rhs, insn);
+        DoParamIndirect(rhs, oc);
         DoParamIndirect_sta(dest);
 
         E_iny();
@@ -1993,16 +1970,16 @@ gen STORE4(NOT4(in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var lhs :
     end sub;
 %}
 
-gen v32 := ADD4(in4s, in4s) uses a|x|y { var rhs := PopOp(); var lhs := PopOp(); var dest := PushV32(); E_clc(); Do3Op4("adc", lhs, rhs, dest); }
-gen v32 := SUB4(in4s, in4s) uses a|x|y { var rhs := PopOp(); var lhs := PopOp(); var dest := PushV32(); E_sec(); Do3Op4("sbc", lhs, rhs, dest); }
-gen v32 := AND4(in4s, in4s) uses a|x|y { var rhs := PopOp(); var lhs := PopOp(); var dest := PushV32();          Do3Op4("and", lhs, rhs, dest); }
-gen v32 := OR4(in4s, in4s)  uses a|x|y { var rhs := PopOp(); var lhs := PopOp(); var dest := PushV32();          Do3Op4("ora", lhs, rhs, dest); }
-gen v32 := EOR4(in4s, in4s) uses a|x|y { var rhs := PopOp(); var lhs := PopOp(); var dest := PushV32();          Do3Op4("eor", lhs, rhs, dest); }
-gen STORE4(ADD4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp(); E_clc(); Do3Op4("adc", lhs, rhs, dest); }
-gen STORE4(SUB4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp(); E_sec(); Do3Op4("sbc", lhs, rhs, dest); }
-gen STORE4(AND4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp();          Do3Op4("and", lhs, rhs, dest); }
-gen STORE4(OR4(in4s, in4s) , ptrs) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp();          Do3Op4("ora", lhs, rhs, dest); }
-gen STORE4(EOR4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp();          Do3Op4("eor", lhs, rhs, dest); }
+gen v32 := ADD4(in4s, in4s) uses a|x|y { var rhs := PopOp(); var lhs := PopOp(); var dest := PushV32(); E_clc(); Do3Op4(OC_ADC, lhs, rhs, dest); }
+gen v32 := SUB4(in4s, in4s) uses a|x|y { var rhs := PopOp(); var lhs := PopOp(); var dest := PushV32(); E_sec(); Do3Op4(OC_SBC, lhs, rhs, dest); }
+gen v32 := AND4(in4s, in4s) uses a|x|y { var rhs := PopOp(); var lhs := PopOp(); var dest := PushV32();          Do3Op4(OC_AND, lhs, rhs, dest); }
+gen v32 := OR4(in4s, in4s)  uses a|x|y { var rhs := PopOp(); var lhs := PopOp(); var dest := PushV32();          Do3Op4(OC_ORA, lhs, rhs, dest); }
+gen v32 := EOR4(in4s, in4s) uses a|x|y { var rhs := PopOp(); var lhs := PopOp(); var dest := PushV32();          Do3Op4(OC_EOR, lhs, rhs, dest); }
+gen STORE4(ADD4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp(); E_clc(); Do3Op4(OC_ADC, lhs, rhs, dest); }
+gen STORE4(SUB4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp(); E_sec(); Do3Op4(OC_SBC, lhs, rhs, dest); }
+gen STORE4(AND4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp();          Do3Op4(OC_AND, lhs, rhs, dest); }
+gen STORE4(OR4(in4s, in4s) , ptrs) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp();          Do3Op4(OC_ORA, lhs, rhs, dest); }
+gen STORE4(EOR4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp();          Do3Op4(OC_EOR, lhs, rhs, dest); }
 
 %{
     sub MulOrDivOrRem4(name: string, resultoffset: uint8, lhs: [Operand], rhs: [Operand], dest: [Operand])
@@ -2103,7 +2080,7 @@ gen BEQ1(a:lhs, in1s:rhs):b
 {
     var rhs := PopOp();
     paramwidth := 1;
-    DoParamDirect(rhs, "cmp", 0);
+    DoParamDirect(rhs, OC_CMP, 0);
     E_jumps_beq_bne(self.n[0]);
 }
 
@@ -2111,7 +2088,7 @@ gen BLTU1(a:lhs, in1s:rhs):b
 {
     var rhs := PopOp();
     paramwidth := 1;
-    DoParamDirect(rhs, "cmp", 0);
+    DoParamDirect(rhs, OC_CMP, 0);
     E_jumps_bcc_bcs(self.n[0]);
 }
 
@@ -2120,7 +2097,7 @@ gen BLTS1(a:lhs, in1s:rhs):b
     var rhs := PopOp();
     paramwidth := 1;
     E_sec();
-    DoParamDirect(rhs, "sbc", 0);
+    DoParamDirect(rhs, OC_SBC, 0);
     E("\tbvc *+4\n");
     E("\teor #$80\n");
     E_jumps_bmi_bpl(self.n[0]);
@@ -2130,15 +2107,15 @@ gen BEQ2(xa:lhs, in2s:rhs):b
 {
     var rhs := PopOp();
     paramwidth := 2;
-    DoParamDirect(rhs, "cmp", 0);
+    DoParamDirect(rhs, OC_CMP, 0);
     E_bne($b.falselabel);
 
     paramwidth := 1;
     if ($rhs & REGCLASS_DEREFS) != 0 then
         E_txa();
-        DoParamDirect(rhs, "cmp", 1);
+        DoParamDirect(rhs, OC_CMP, 1);
     else
-        DoParamDirect(rhs, "cpx", 1);
+        DoParamDirect(rhs, OC_CPX, 1);
     end if;
     E_jumps_beq_bne(self.n[0]);
 }
@@ -2148,11 +2125,11 @@ gen BLTU2(xa:lhs, in2s:rhs):c
     var rhs := PopOp();
     paramwidth := 2;
     E_sec();
-    DoParamDirect(rhs, "sbc", 0);
+    DoParamDirect(rhs, OC_SBC, 0);
 
     paramwidth := 1;
     E_txa();
-    DoParamDirect(rhs, "sbc", 1);
+    DoParamDirect(rhs, OC_SBC, 1);
     E_jumps_bcc_bcs(self.n[0]);
 }
 
@@ -2161,11 +2138,11 @@ gen BLTS2(xa:lhs, in2s:rhs):c
     var rhs := PopOp();
     paramwidth := 2;
     E_sec();
-    DoParamDirect(rhs, "sbc", 0);
+    DoParamDirect(rhs, OC_SBC, 0);
 
     paramwidth := 1;
     E_txa();
-    DoParamDirect(rhs, "sbc", 1);
+    DoParamDirect(rhs, OC_SBC, 1);
     E("\tbvc *+4\n");
     E("\teor #$80\n");
     E_jumps_bmi_bpl(self.n[0]);
@@ -2181,7 +2158,7 @@ gen BLTS2(xa:lhs, in2s:rhs):c
         var lid := E_new_label();
 
         DoParamIndirect_lda(lhs);
-        DoParamIndirect(rhs, "cmp");
+        DoParamIndirect(rhs, OC_CMP);
         E_bne(node.beq0.falselabel);
 
         E_dey();
@@ -2264,7 +2241,7 @@ gen STORE4(CAST14(a):c, ptrs) uses y { var dest := PopAndDerefOp(); Cast14(dest,
             E_txa();
             DoParamDirect_sta(dest, 1);
         else
-            DoParamDirect(dest, "stx", 1);
+            DoParamDirect(dest, OC_STX, 1);
         end if;
 
         if sext != 0 then

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -177,65 +177,14 @@
     end sub;
 
     sub E_label(label: LabelRef)
+        R_flushall();
         E_labelref(label);
         E(":\n");
     end sub;
 
-    var labelid: uint16 := 0;
-    sub E_plabelref(lid: uint16)
-        EmitByte(COO_ESCAPE_THISCOO);
-        EmitByte('c');
-        E_u16(lid);
-    end sub;
-
-    sub AllocPlabel(): (lid: uint16)
-        lid := labelid;
-        labelid := labelid + 1;
-    end sub;
-
-    sub E_plabel(lid: uint16)
-        R_flushall();
-        E_plabelref(lid);
-        E(":\n");
-    end sub;
-
-    sub E_new_plabel(): (lid: uint16)
-        lid := AllocPlabel();
-        E_plabel(lid);
-    end sub;
-
-    sub E_jmp_p(label: LabelRef)
-        $ifdef ARCH_65C02
-            E_insn("bra");
-        $else
-            E_insn("jmp");
-        $endif
-        E_plabelref(label);
-        E_nl();
-    end sub;
-
-    sub E_bne_p(label: LabelRef)
-        E_oc(OC_BNE);
-        E_plabelref(label);
-        E_nl();
-    end sub;
-
-    sub E_bcs_p(label: LabelRef)
-        E_oc(OC_BCS);
-        E_plabelref(label);
-        E_nl();
-    end sub;
-
-    sub E_bmi_p(label: LabelRef)
-        E_insn("bmi");
-        E_plabelref(label);
-        E_nl();
-    end sub;
-
-    sub E_bpl_p(label: LabelRef)
-        E_insn("bpl");
-        E_plabelref(label);
-        E_nl();
+    sub E_new_label(): (lid: uint16)
+        lid := AllocLabel();
+        E_label(lid);
     end sub;
 
     sub E_stackref(sid: uint16)
@@ -310,6 +259,10 @@
 
     sub E_bmi(label: LabelRef)
         E_jump("bmi", label);
+    end sub;
+
+    sub E_bpl(label: LabelRef)
+        E_jump("bpl", label);
     end sub;
 
     sub E_rts() E_ocnl(OC_RTS); end sub;
@@ -573,7 +526,7 @@
         end loop;
         if c == (0 as [Constant]) then
             c := Alloc(@bytesof Constant) as [Constant];
-            c.lid := AllocPlabel();
+            c.lid := AllocLabel();
             c.value := value;
             c.next := constants;
             constants := c;
@@ -582,12 +535,12 @@
     end sub;
 
     sub E_string(data: string): (lid: uint16)
-        lid := AllocPlabel();
+        lid := AllocLabel();
 
         EmitterPushChunk();
         E_h16(current_subr.id);
 
-        E_plabel(lid);
+        E_label(lid);
         E("\t.byte ");
 
         loop
@@ -848,7 +801,7 @@ gen JUMP():j
         E_insn(insn);
         case operand.mode is
             when MODE_CONST:
-                E_plabelref(AllocConst(operand.val));
+                E_labelref(AllocConst(operand.val));
 
             when MODE_STACK:
                 E_stackref(operand.stk.sid);
@@ -1165,7 +1118,7 @@ gen STARTSUB():s
                 PopReturnAddress();
                 E_loadconst(REG_Y, 0);
                 E_loadconst(REG_X, 4);
-                var lid := E_new_plabel();
+                var lid := E_new_label();
                 E_pla();
                 E_st(REG_A);
                 E_symref(param, 0);
@@ -1173,7 +1126,7 @@ gen STARTSUB():s
                 E_iny();
                 E_dex();
 
-                E_bne_p(lid);
+                E_bne(lid);
         end case;
     end loop;
 
@@ -1237,7 +1190,7 @@ gen ENDSUB():s
                 # using smaller code.
                 E_loadconst(REG_Y, 0);
                 E_loadconst(REG_X, 3);
-                var lid := E_new_plabel();
+                var lid := E_new_label();
 
                 E_ld(REG_A);
                 E_symref(param, 0);
@@ -1245,7 +1198,7 @@ gen ENDSUB():s
                 E_pha();
                 E_iny();
                 E_dex();
-                E_bpl_p(lid);
+                E_bpl(lid);
         end case;
         i := i + 1;
     end loop;
@@ -1262,7 +1215,7 @@ gen ENDSUB():s
         var c := constants;
         constants := constants.next;
 
-        E_plabel(c.lid);
+        E_label(c.lid);
         E("\t.dword ");
         E_u32(c.value as uint32);
         E_nl();
@@ -1302,12 +1255,12 @@ gen xa := CALLE2(param):s uses y
 %{
     sub PopArg4(dest: [Operand])
         E_loadconst(REG_Y, 3);
-        var lid := E_new_plabel();
+        var lid := E_new_label();
 
         E_pla();
         DoParamIndirect_sta(dest);
         E_dey();
-        E_bpl_p(lid);
+        E_bpl(lid);
     end sub;
 %}
 
@@ -1339,12 +1292,12 @@ gen param := ARG4(param, in4s) uses y|a
 
     # WARNING: little endian on stack!
     E_loadconst(REG_Y, 3);
-    var lid := E_new_plabel();
+    var lid := E_new_label();
 
     DoParamIndirect_lda(op);
     E_pha();
     E_dey();
-    E_bpl_p(lid);
+    E_bpl(lid);
 }
 
 gen a := POPARG1(remaining==0);
@@ -1733,20 +1686,20 @@ gen STORE2(xa, ADD2(ptrs, CONSTANT(value>=0, value<=254):c)) uses y
 
 gen STORE2(ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS():a2) uses x|y|a cost 100
 {
-    var lid := AllocPlabel();
+    var lid := AllocLabel();
     if ($a1.sym == $a2.sym) and ($a1.off == $a2.off) then
         if $c.value < 0 then
             E_lda();
             E_symref($a1.sym, $a1.off);
             E_nl();
 
-            E_bne_p(lid);
+            E_bne(lid);
 
             E_dec();
             E_symref($a1.sym, $a1.off+1);
             E_nl();
 
-            E_plabel(lid);
+            E_label(lid);
             
             E_dec();
             E_symref($a1.sym, $a1.off);
@@ -1756,13 +1709,13 @@ gen STORE2(ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS()
             E_symref($a1.sym, $a1.off);
             E_nl();
 
-            E_bne_p(lid);
+            E_bne(lid);
 
             E_inc();
             E_symref($a1.sym, $a1.off+1);
             E_nl();
 
-            E_plabel(lid);
+            E_label(lid);
         end if;
 
         RegCacheFlushValues();
@@ -1791,15 +1744,15 @@ gen STORE2(ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS()
         end if;
 
         if $c.value < 0 then
-            E_bne_p(lid);
+            E_bne(lid);
             E_dex();
-            E_plabel(lid);
+            E_label(lid);
             E_decrement(LOWREG);
         else
             E_increment(LOWREG);
-            E_bne_p(lid);
+            E_bne(lid);
             E_inx();
-            E_plabel(lid);
+            E_label(lid);
         end if;
 
         E_stx();
@@ -1955,13 +1908,13 @@ gen xa := REMS2(xa, in2s) uses y { Rem2("_divs2r"); }
 %{
     sub DoCopy4(dest: [Operand], lhs: [Operand])
         E_loadconst(REG_Y, 3);
-        var lid := E_new_plabel();
+        var lid := E_new_label();
 
         DoParamIndirect_lda(lhs);
         DoParamIndirect_sta(dest);
 
         E_dey();
-        E_bpl_p(lid);
+        E_bpl(lid);
 
         RegCacheFlushValues();
     end sub;
@@ -1985,14 +1938,14 @@ gen v32 := LOAD4(ptrs) uses a|x|y
     sub Do2Op4_not(lhs: [Operand], dest: [Operand])
         paramwidth := 4;
         E_loadconst(REG_Y, 3);
-        var lid := E_new_plabel();
+        var lid := E_new_label();
 
         DoParamIndirect_lda(lhs);
         E_not();
         DoParamIndirect_sta(dest);
 
         E_dey();
-        E_bpl_p(lid);
+        E_bpl(lid);
 
         RegCacheFlushValues();
     end sub;
@@ -2002,7 +1955,7 @@ gen v32 := LOAD4(ptrs) uses a|x|y
         E_loadconst(REG_X, 4);
         E_loadconst(REG_Y, 0);
         E_sec();
-        var lid := E_new_plabel();
+        var lid := E_new_label();
 
         E_loadconst(REG_A, 0);
         DoParamIndirect_sbc(lhs);
@@ -2010,7 +1963,7 @@ gen v32 := LOAD4(ptrs) uses a|x|y
 
         E_iny();
         E_dex();
-        E_bne_p(lid);
+        E_bne(lid);
 
         RegCacheFlushValues();
     end sub;
@@ -2026,7 +1979,7 @@ gen STORE4(NOT4(in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var lhs :
         paramwidth := 4;
         E_loadconst(REG_Y, 0);
         E_loadconst(REG_X, paramwidth);
-        var lid := E_new_plabel();
+        var lid := E_new_label();
 
         DoParamIndirect_lda(lhs);
         DoParamIndirect(rhs, insn);
@@ -2034,7 +1987,7 @@ gen STORE4(NOT4(in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var lhs :
 
         E_iny();
         E_dex();
-        E_bne_p(lid);
+        E_bne(lid);
 
         RegCacheFlushValues();
     end sub;
@@ -2057,7 +2010,7 @@ gen STORE4(EOR4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var
 
         paramwidth := 4;
         E_loadconst(REG_Y, 3);
-        var lid := E_new_plabel();
+        var lid := E_new_label();
 
         DoParamIndirect_lda(lhs);
         E("\tsta ");
@@ -2072,13 +2025,13 @@ gen STORE4(EOR4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var
         E("010008, y\n");
 
         E_dey();
-        E_bpl_p(lid);
+        E_bpl(lid);
 
         E_callhelper(name);
 
         paramwidth := 4;
         E_loadconst(REG_Y, 3);
-        lid := E_new_plabel();
+        lid := E_new_label();
 
         E("\tlda ");
         EmitByte(COO_ESCAPE_WSREF);
@@ -2089,7 +2042,7 @@ gen STORE4(EOR4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var
         DoParamIndirect_sta(dest);
 
         E_dey();
-        E_bpl_p(lid);
+        E_bpl(lid);
 
         RegCacheFlushValues();
     end sub;
@@ -2225,14 +2178,14 @@ gen BLTS2(xa:lhs, in2s:rhs):c
         var lhs := PopOp();
 
         E_loadconst(REG_Y, paramwidth-1);
-        var lid := E_new_plabel();
+        var lid := E_new_label();
 
         DoParamIndirect_lda(lhs);
         DoParamIndirect(rhs, "cmp");
         E_bne(node.beq0.falselabel);
 
         E_dey();
-        E_bpl_p(lid);
+        E_bpl(lid);
 
         if node.beq0.fallthrough != node.beq0.truelabel then
             E_jmp(node.beq0.truelabel);
@@ -2247,14 +2200,14 @@ gen BLTS2(xa:lhs, in2s:rhs):c
         E_loadconst(REG_X, 4);
         E_loadconst(REG_Y, 0);
         E_sec();
-        var lid := E_new_plabel();
+        var lid := E_new_label();
 
         DoParamIndirect_lda(lhs);
         DoParamIndirect_sbc(rhs);
 
         E_iny();
         E_dex();
-        E_bne_p(lid);
+        E_bne(lid);
 
         if sext != 0 then
             E_tay(); # set flags from A
@@ -2446,16 +2399,12 @@ gen xa := STRING():s
 
     E_lda();
     E_constlo();
-    EmitByte(COO_ESCAPE_THISCOO);
-    EmitByte('c');
-    E_u16(sid);
+    E_labelref(sid);
     E_nl();
 
     E_ldx();
     E_consthi();
-    EmitByte(COO_ESCAPE_THISCOO);
-    EmitByte('c');
-    E_u16(sid);
+    E_labelref(sid);
     E_nl();
 }
 
@@ -2500,9 +2449,7 @@ gen INITS():s
     var sid := E_string($s.text);
 
     E("\t.word ");
-    EmitByte(COO_ESCAPE_THISCOO);
-    EmitByte('c');
-    E_u16(sid);
+    E_labelref(sid);
     E_nl();
 }
 

--- a/src/cowcom/arch8080.cow.ng
+++ b/src/cowcom/arch8080.cow.ng
@@ -434,29 +434,24 @@
 	end sub;
 
 	sub E_storem(reg: RegId)
-		RegCacheFlushValues();
 		E("\tmov m,");
 		E_reg(reg);
 		E_nl();
 	end sub;
 
 	sub E_storemc(value: uint8)
-		RegCacheFlushValues();
 		E("\tmvi m,");
 		E_u8(value);
 		E_nl();
 	end sub;
 
 	sub E_stax(ptr: RegId)
-		RegCacheFlushValues();
 		E("\tstax ");
 		E_reg(ptr);
 		E_nl();
-		RegCacheFlushValues();
 	end sub;
 
 	sub E_ldax(ptr: RegId)
-		RegCacheFlushValues();
 		R_flush(REG_A);
 		E("\tldax ");
 		E_reg(ptr);

--- a/src/cowcom/archz80.cow.ng
+++ b/src/cowcom/archz80.cow.ng
@@ -288,22 +288,18 @@
 	end sub;
 
 	sub E_storem(reg: RegId)
-		RegCacheFlushValues();
 		E("\tld (hl),");
 		E_reg(reg);
 		E_nl();
 	end sub;
 
 	sub E_stax(ptr: RegId)
-		RegCacheFlushValues();
 		E("\tld a, (");
 		E_reg(ptr);
 		E(")\n");
-		RegCacheFlushValues();
 	end sub;
 
 	sub E_ldax(ptr: RegId)
-		RegCacheFlushValues();
 		R_flush(REG_A);
 		E("\tld (");
 		E_reg(ptr);
@@ -343,7 +339,6 @@
 	end sub;
 
 	sub E_store8i(src: RegId, index: RegId, off: int8)
-		RegCacheFlushValues();
 		E("\tld (");
 		E_reg(index);
 		E_i8(off);
@@ -353,7 +348,6 @@
 	end sub;
 
 	sub E_store8ic(val: uint8, index: RegId, off: int8)
-		RegCacheFlushValues();
 		E("\tld (");
 		E_reg(index);
 		E_i8(off);

--- a/src/cowcom/emitter.coh
+++ b/src/cowcom/emitter.coh
@@ -157,6 +157,13 @@ sub E_subref(subr: [Subroutine])
 	end if;
 end sub;
 
+sub E_wsref(id: uint16, wsid: uint8, off: uint16)
+	EmitByte(COO_ESCAPE_WSREF);
+	E_h16(id);
+	E_h8(wsid);
+	E_h16(off);
+end sub;
+
 sub EmitterPushChunk()
 	var chunk := Alloc(@bytesof EmitterChunk) as [EmitterChunk];
 	chunk.current_record := Alloc(@bytesof EmitterRecord) as [EmitterRecord];

--- a/src/cowcom/lexer.coh
+++ b/src/cowcom/lexer.coh
@@ -123,6 +123,7 @@ var lexer_ctype: uint8[] := {
 };
 
 var keyword_names: string[] := {
+	"@alias",
 	"@asm",
 	"@at",
 	"@bytesof",
@@ -160,6 +161,7 @@ var keyword_names: string[] := {
 const INCLUDE := 0xff; # This is special
 
 var keyword_ids: uint8[] := {
+	ALIAS,
 	ASM,
 	AT,
 	BYTESOF,

--- a/src/cowcom/parser.y
+++ b/src/cowcom/parser.y
@@ -411,6 +411,17 @@ expression(E) ::= expression(E1) AS typeref(T).
 expression(E) ::= AMPERSAND expression(E1).
 {
 	E := UndoLValue(E1);
+	if E.op == MIDCODE_ADDRESS then
+		var sym := E.address.sym;
+		if IsScalar(sym.vardata.type) != 0 then
+			SimpleError("you cannot take the address of scalar variables");
+		end if;
+	end if;
+}
+
+expression(E) ::= ALIAS AMPERSAND expression(E1).
+{
+	E := UndoLValue(E1);
 }
 
 %include

--- a/src/cowcom/regcache.coh
+++ b/src/cowcom/regcache.coh
@@ -28,16 +28,6 @@ sub RegCacheFlush(reg: RegId)
 	end loop;
 end sub;
 
-sub RegCacheFlushValues()
-	var p := &register_cache[0];
-	while p != &register_cache[@sizeof register_cache] loop
-		if (p.state == CACHE_SLOT_VALUE) then
-			p.state := CACHE_SLOT_EMPTY;
-		end if;
-		p := @next p;
-	end loop;
-end sub;
-
 sub reg_i_find_empty_slot(): (slot: [CacheSlot])
 	slot := &register_cache[0];
 	while slot != &register_cache[@sizeof register_cache] loop

--- a/src/cowlink/archbbct.coh
+++ b/src/cowlink/archbbct.coh
@@ -18,8 +18,7 @@ end sub;
 sub ArchEmitWSRef(wid: uint8, address: Size)
 	E("ws");
 	EmitByte(wid + '0');
-	EmitByte('+');
-	E_u16(address);
+	E_i16(address as int16);
 end sub;
 
 sub ArchEmitHeader(coo: [Coo])

--- a/src/cowlink/emitter.coh
+++ b/src/cowlink/emitter.coh
@@ -38,6 +38,16 @@ sub E_u8(value: uint8)
 	E_u32(value as uint32);
 end sub;
 
+sub E_i16(value: int16)
+	if value < 0 then
+		EmitByte('-');
+		value := -value;
+	else
+		EmitByte('+');
+	end if;
+	E_u16(value as uint16);
+end sub;
+
 sub E_h(value: uint32, width: uint8)
 	var buffer: uint8[5];
 	var pe := UIToA(value as uint32, 16, &buffer[0]);

--- a/tests/addsub-32bit.good
+++ b/tests/addsub-32bit.good
@@ -34,9 +34,3 @@ TWO-mone==three: yes
 -zero == zero: yes
 -mone == one: yes
 -mtwo == two: yes
-deadbeef+deadbeef=0xbd5b7dde: yes
-deadbeef-deadbeef=0x00000000: yes
-[pdeadbeef]+deadbeef=0xbd5b7dde: yes
-deadbeef+[pdeadbeef]=0xbd5b7dde: yes
-presult test: yes
-complex backwards sub: yes

--- a/tests/addsub-32bit.test.cow
+++ b/tests/addsub-32bit.test.cow
@@ -71,30 +71,3 @@ sub neg_test()
 end sub;
 neg_test();
 
-sub extra_test()
-	var deadbeef: int32 := 0xdeadbeef;
-	var pdeadbeef: [int32] := &deadbeef;
-	var mdeadbeef: int32 := -0xdeadbeef;
-
-    print("deadbeef+deadbeef=0xbd5b7dde");
-    if (deadbeef+deadbeef)==0xbd5b7dde then yes(); else no(); end if;
-    print("deadbeef-deadbeef=0x00000000");
-    if (deadbeef-deadbeef)==0x00000000 then yes(); else no(); end if;
-
-    print("[pdeadbeef]+deadbeef=0xbd5b7dde");
-    if ([pdeadbeef]+deadbeef)==0xbd5b7dde then yes(); else no(); end if;
-    print("deadbeef+[pdeadbeef]=0xbd5b7dde");
-    if (deadbeef+[pdeadbeef])==0xbd5b7dde then yes(); else no(); end if;
-
-    print("presult test");
-    var result: int32;
-    var presult: [int32] := &result;
-    [presult] := [pdeadbeef] + [pdeadbeef];
-    if result==0xbd5b7dde then yes(); else no(); end if;
-
-    print("complex backwards sub");
-    result := -1;
-    if (-[presult]) == 1 then yes(); else no(); end if;
-end sub;
-extra_test();
-

--- a/tests/case.good
+++ b/tests/case.good
@@ -14,3 +14,13 @@ uint32 of 2 == 2: yes
 uint32 of 9 == 4: yes
 int32 of -2 == -2: yes
 int32 of 9 == 4: yes
+0 of many bytes == 100: yes
+13 of many bytes == 113: yes
+19 of many bytes == 119: yes
+39 of many bytes == 139: yes
+40 of many bytes == 0: yes
+0 of many int16s == 100: yes
+13 of many int16s == 113: yes
+19 of many int16s == 119: yes
+39 of many int16s == 139: yes
+40 of many int16s == 0: yes

--- a/tests/case.test.cow
+++ b/tests/case.test.cow
@@ -81,6 +81,98 @@ sub case_int32(i: uint32): (out: int8)
 	end case;
 end sub;
 
+sub case_many_bytes(i: uint8): (out: uint8)
+	case i is
+		when  0: out := 100;
+		when  1: out := 101;
+		when  2: out := 102;
+		when  3: out := 103;
+		when  4: out := 104;
+		when  5: out := 105;
+		when  6: out := 106;
+		when  7: out := 107;
+		when  8: out := 108;
+		when  9: out := 109;
+		when 10: out := 110;
+		when 11: out := 111;
+		when 12: out := 112;
+		when 13: out := 113;
+		when 14: out := 114;
+		when 15: out := 115;
+		when 16: out := 116;
+		when 17: out := 117;
+		when 18: out := 118;
+		when 19: out := 119;
+		when 20: out := 120;
+		when 21: out := 121;
+		when 22: out := 122;
+		when 23: out := 123;
+		when 24: out := 124;
+		when 25: out := 125;
+		when 26: out := 126;
+		when 27: out := 127;
+		when 28: out := 128;
+		when 29: out := 129;
+		when 30: out := 130;
+		when 31: out := 131;
+		when 32: out := 132;
+		when 33: out := 133;
+		when 34: out := 134;
+		when 35: out := 135;
+		when 36: out := 136;
+		when 37: out := 137;
+		when 38: out := 138;
+		when 39: out := 139;
+		when else: out := 0;
+	end case;
+end sub;
+
+sub case_many_int16s(i: uint16): (out: uint8)
+	case i is
+		when  0: out := 100;
+		when  1: out := 101;
+		when  2: out := 102;
+		when  3: out := 103;
+		when  4: out := 104;
+		when  5: out := 105;
+		when  6: out := 106;
+		when  7: out := 107;
+		when  8: out := 108;
+		when  9: out := 109;
+		when 10: out := 110;
+		when 11: out := 111;
+		when 12: out := 112;
+		when 13: out := 113;
+		when 14: out := 114;
+		when 15: out := 115;
+		when 16: out := 116;
+		when 17: out := 117;
+		when 18: out := 118;
+		when 19: out := 119;
+		when 20: out := 120;
+		when 21: out := 121;
+		when 22: out := 122;
+		when 23: out := 123;
+		when 24: out := 124;
+		when 25: out := 125;
+		when 26: out := 126;
+		when 27: out := 127;
+		when 28: out := 128;
+		when 29: out := 129;
+		when 30: out := 130;
+		when 31: out := 131;
+		when 32: out := 132;
+		when 33: out := 133;
+		when 34: out := 134;
+		when 35: out := 135;
+		when 36: out := 136;
+		when 37: out := 137;
+		when 38: out := 138;
+		when 39: out := 139;
+		when else: out := 0;
+	end case;
+end sub;
+
 sub test_case_bytes()
 	print("uint8 of 2 == 2"); if case_uint8(2) == 2 then yes(); else no(); end if;
 	print("uint8 of 9 == 4"); if case_uint8(9) == 4 then yes(); else no(); end if;
@@ -119,4 +211,22 @@ sub test_case_longs()
 	print("int32 of 9 == 4"); if case_int32(9) == 4 then yes(); else no(); end if;
 end sub;
 test_case_longs();
+
+sub test_case_many_bytes()
+	print("0 of many bytes == 100"); if case_many_bytes(0) == 100 then yes(); else no(); end if;
+	print("13 of many bytes == 113"); if case_many_bytes(13) == 113 then yes(); else no(); end if;
+	print("19 of many bytes == 119"); if case_many_bytes(19) == 119 then yes(); else no(); end if;
+	print("39 of many bytes == 139"); if case_many_bytes(39) == 139 then yes(); else no(); end if;
+	print("40 of many bytes == 0"); if case_many_bytes(40) == 0 then yes(); else no(); end if;
+end sub;
+test_case_many_bytes();
+
+sub test_case_many_int16s()
+	print("0 of many int16s == 100"); if case_many_int16s(0) == 100 then yes(); else no(); end if;
+	print("13 of many int16s == 113"); if case_many_int16s(13) == 113 then yes(); else no(); end if;
+	print("19 of many int16s == 119"); if case_many_int16s(19) == 119 then yes(); else no(); end if;
+	print("39 of many int16s == 139"); if case_many_int16s(39) == 139 then yes(); else no(); end if;
+	print("40 of many int16s == 0"); if case_many_int16s(40) == 0 then yes(); else no(); end if;
+end sub;
+test_case_many_int16s();
 


### PR DESCRIPTION
I went through the 6502 backend and cleaned up a lot --- there was a lot of stray code which served no purpose. The 65c02 compiler, compiled with the 8080 compiler, went from 58828 bytes to 58639 bytes. I also found some places where I could actually improve the 6502 generated code: cowcom.cgen, compiled for the 6502, went from 52451 bytes to 52361 bytes.

...and _then_ I realised I can make my aliasing problems go away by modifying the language to forbid it --- the only time it's a problem is when taking the address of a simple variable, as that's the only time it's a problem. (Taking the address of a record isn't a problem as it cannot change, and values of members are never cached.) Turns out there's only two places in the code base which do this, one of which is some evil in the bbct runtime, and the other is a test!

This allows us to be way more aggressive with value caching, preventing e.g. the Z80 backend constantly reloading ix. The saving is, sadly, offset by the extra parser rules, but cowlink.ncpmz goes from 5089 to 5056 bytes, and cowcom.65c02.ncpmz will now fit in the Z80 address space: 60236 bytes (plus 50128 bytes of workspace and stack). cowcom.cgen for the 65c02 is now 52715 bytes, though --- aliasing isn't a problem on the 6502 which means the extra compiler code is dead weight.