### PR TITLE
Add some more optimisations

### DIFF
--- a/rt/bbct/cowgol.cos
+++ b/rt/bbct/cowgol.cos
@@ -37,7 +37,7 @@
 
 &X _lshift2
 &W _lshift2 1 2
-; Shifts AX left Y bits.
+; Shifts XA left Y bits.
 ``:
     sta `$_lshift2.1.0
     stx `$_lshift2.1.1
@@ -54,7 +54,7 @@
 
 &X _rshiftu2
 &W _rshiftu2 1 2
-; Logical shifts AX right Y bits.
+; Logical shifts XA right Y bits.
 ``:
     sta `$_lshift2.1.0
     stx `$_lshift2.1.1
@@ -71,7 +71,7 @@
 
 &X _rshifts2
 &W _rshifts2 1 2
-; Arithmetic shifts AX right Y bits.
+; Arithmetic shifts XA right Y bits.
 ``:
     sta `$_lshift2.1.0
     stx `$_lshift2.1.1

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -2075,6 +2075,21 @@ gen BEQ2(xa, CONSTANT(value==0)):b uses a|y
     E_jumps_beq_bne(self.n[0]);
 }
 
+gen BEQ2(LOAD2(ADDRESS():a), CONSTANT(value==0)):b uses a
+{
+    E_lda();
+    E_symref($a.sym, $a.off);
+    E_nl();
+
+    E_bne($b.falselabel);
+
+    E_lda();
+    E_symref($a.sym, $a.off+1);
+    E_nl();
+
+    E_jumps_beq_bne(self.n[0]);
+}
+
 gen BEQ2(xa:lhs, in2s:rhs):b
 {
     var rhs := PopOp();

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -2031,6 +2031,12 @@ gen BEQ0(CONSTANT():lhs, CONSTANT():rhs):b
     end if;
 }
 
+gen BEQ1(a:lhs, CONSTANT(value==0)):b uses a|x
+{
+    E_tax();
+    E_jumps_beq_bne(self.n[0]);
+}
+
 gen BEQ1(a:lhs, in1s:rhs):b
 {
     var rhs := PopOp();
@@ -2045,6 +2051,12 @@ gen BLTU1(a:lhs, in1s:rhs):b
     E_jumps_bcc_bcs(self.n[0]);
 }
 
+gen BLTS1(a, CONSTANT(value==0)):b uses x
+{
+    E_tax();
+    E_jumps_beq_bne(self.n[0]);
+}
+
 gen BLTS1(a:lhs, in1s:rhs):b
 {
     var rhs := PopOp();
@@ -2053,6 +2065,14 @@ gen BLTS1(a:lhs, in1s:rhs):b
     E("\tbvc *+4\n");
     E("\teor #$80\n");
     E_jumps_bmi_bpl(self.n[0]);
+}
+
+gen BEQ2(xa, CONSTANT(value==0)):b uses a|y
+{
+    E_tay();
+    E_bne($b.falselabel);
+    E_txa();
+    E_jumps_beq_bne(self.n[0]);
 }
 
 gen BEQ2(xa:lhs, in2s:rhs):b
@@ -2091,6 +2111,12 @@ gen BLTS2(xa:lhs, in2s:rhs):c
     DoParamDirect(rhs, OC_SBC, 1);
     E("\tbvc *+4\n");
     E("\teor #$80\n");
+    E_jumps_bmi_bpl(self.n[0]);
+}
+
+gen BLTS2(xa, CONSTANT(value==0)):b
+{
+    E_txa();
     E_jumps_bmi_bpl(self.n[0]);
 }
 
@@ -2141,9 +2167,35 @@ gen BLTS2(xa:lhs, in2s:rhs):c
     end sub;
 %}
 
+gen BEQ4(in4s, CONSTANT(value==0)):b uses a|x|y
+{
+    var lhs := PopOp();
+
+    E_loadconst(REG_Y, 3);
+    var lid := E_new_label();
+
+    DoParamIndirect_lda(lhs);
+    E_bne($b.falselabel);
+
+    E_dey();
+    E_bpl(lid);
+
+    if $b.fallthrough != $b.truelabel then
+        E_jmp($b.truelabel);
+    end if;
+}
+
 gen BEQ4(in4s, in4s):b uses a|x|y { DoCmp4EQ(self.n[0]); }
 gen BLTU4(in4s, in4s):b uses a|x|y { DoCmp4LT(self.n[0], 0); }
 gen BLTS4(in4s, in4s):b uses a|x|y { DoCmp4LT(self.n[0], 1); }
+
+gen BLTS4(in4s, CONSTANT(value==0)):b uses a|x|y
+{
+    var lhs := PopOp();
+
+    DoParamDirect_lda(lhs, 3);
+    E_jumps_bmi_bpl(self.n[0]);
+}
 
 // --- Casts ----------------------------------------------------------------
 

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -291,6 +291,17 @@
     sub E_sty() E_st(REG_Y); end sub;
     sub E_stz() E_oc(OC_STZ); end sub;
 
+    sub E_ldst_ws(oc: uint8, id: uint16, off: Size)
+        E_oc(oc);
+        E_wsref(id, PTRMEM_WS, off);
+        E_nl();
+    end sub;
+
+    sub E_sta_ws(id: uint16, off: Size) E_ldst_ws(OC_STA, id, off); end sub;
+    sub E_stx_ws(id: uint16, off: Size) E_ldst_ws(OC_STX, id, off); end sub;
+    sub E_lda_ws(id: uint16, off: Size) E_ldst_ws(OC_LDA, id, off); end sub;
+    sub E_ldx_ws(id: uint16, off: Size) E_ldst_ws(OC_LDX, id, off); end sub;
+
     sub E_cp(reg: RegId)
         case reg is
             when REG_A: E_oc(OC_CMP);
@@ -1805,13 +1816,9 @@ gen a := CAST21(RSHIFTS2(xa, CONSTANT(value==8))) { E_txa(); }
     sub MulOrDiv2(name: string)
         var e := GetHelper("_mathpad");
 
-        E_sta();
-        E_wsref(e.id, PTRMEM_WS, 0);
-        E_nl();
-
-        E_stx();
-        E_wsref(e.id, PTRMEM_WS, 1);
-        E_nl();
+        var subid := e.id;
+        E_sta_ws(subid, 0);
+        E_stx_ws(subid, 1);
 
         var rhs := PopOp();
         DoParamDirect_lda(rhs, 0);
@@ -1824,13 +1831,9 @@ gen a := CAST21(RSHIFTS2(xa, CONSTANT(value==8))) { E_txa(); }
 
         var e := GetHelper("_mathpad");
 
-        E_lda();
-        E_wsref(e.id, PTRMEM_WS, 4);
-        E_nl();
-
-        E_ldx();
-        E_wsref(e.id, PTRMEM_WS, 5);
-        E_nl();
+        var subid := e.id;
+        E_lda_ws(subid, 4);
+        E_ldx_ws(subid, 5);
     end sub;
 %}
 
@@ -1952,15 +1955,18 @@ gen STORE4(EOR4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var
         E_loadconst(REG_Y, 3);
         var lid := E_new_label();
 
+        var subid := e.id;
+        sub ldst(oc: uint8, off: Size)
+            E_oc(oc);
+            E_wsref(subid, PTRMEM_WS, off);
+            E_y_nl();
+        end sub;
+
         DoParamIndirect_lda(lhs);
-        E_sta();
-        E_wsref(e.id, PTRMEM_WS, 0);
-        E_y_nl();
+        ldst(OC_STA, 0);
 
         DoParamIndirect_lda(rhs);
-        E_sta();
-        E_wsref(e.id, PTRMEM_WS, 8);
-        E_y_nl();
+        ldst(OC_STA, 8);
 
         E_dey();
         E_bpl(lid);
@@ -1970,9 +1976,7 @@ gen STORE4(EOR4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var
         E_loadconst(REG_Y, 3);
         lid := E_new_label();
 
-        E_lda();
-        E_wsref(e.id, PTRMEM_WS, resultoffset as uint16);
-        E_y_nl();
+        ldst(OC_LDA, resultoffset as uint16);
         DoParamIndirect_sta(dest);
 
         E_dey();
@@ -2318,18 +2322,15 @@ gen STARTCASE4(v32)
     E_stackref(sid);
     E_nl();
 
-    E_sta();
-    E_wsref(e.id, PTRMEM_WS, 0);
-    E_nl();
+    var subid := e.id;
+    E_sta_ws(subid, 0);
     
     E_lda();
     E_consthi();
     E_stackref(sid);
     E_nl();
 
-    E_sta();
-    E_wsref(e.id, PTRMEM_WS, 1);
-    E_nl();
+    E_sta_ws(subid, 1);
 }
 
 gen WHENCASE1():c

--- a/src/cowcom/arch8080.cow.ng
+++ b/src/cowcom/arch8080.cow.ng
@@ -1345,11 +1345,7 @@ gen BLTU1(a, b|d|h:rhs):b
 gen BLTU1(a, CONSTANT():c):b
 {
 	var v := $c.value as uint8;
-	if v == 0 then
-		E_ora(REG_A);
-	else
-		E_cpi(v);
-	end if;
+	E_cpi(v);
 	E_jumps_jc_jnc(self.n[0]);
 }
 

--- a/src/cowcom/archz80.cow.ng
+++ b/src/cowcom/archz80.cow.ng
@@ -1766,6 +1766,12 @@ gen BLTS1(a, CONSTANT():c):b
 	E_jumps_jm_jp(self.n[0]);
 }
 
+gen BLTS1(a, CONSTANT(value==0)):b
+{
+	E_or(REG_A);
+	E_jumps_jm_jp(self.n[0]);
+}
+
 gen BEQ2(bc|de:lhs, hl):a
 		{ bequ2(self.n[0], $lhs); }
 

--- a/src/cowcom/archz80.cow.ng
+++ b/src/cowcom/archz80.cow.ng
@@ -98,11 +98,11 @@
 	end sub;
 
 	sub E_jp(label: LabelRef)
-		E_jump("jp", label);
+		E_jump("jr", label);
 	end sub;
 
 	sub E_jnz(label: LabelRef)
-		E_jump("jp nz,", label);
+		E_jump("jr nz,", label);
 	end sub;
 
 	sub E_ret()
@@ -979,7 +979,7 @@ gen RETURN()
     if current_subr.num_output_parameters == 0 then
 		E_ret();
 	else
-		E("\tjp end_");
+		E("\tjr end_");
 		E_subref(current_subr);
 		E("\n");
 	end if;
@@ -1641,15 +1641,15 @@ gen hlhl := RSHIFTS4(hlhl, a)
 	end sub;
 
 	sub E_jumps_jz_jnz(node: [Node])
-		E_jumps_with_fallthrough("jp z,", "jp nz,", node);
+		E_jumps_with_fallthrough("jr z,", "jr nz,", node);
 	end sub;
 
 	sub E_jumps_jnz_jz(node: [Node])
-		E_jumps_with_fallthrough("jp nz,", "jp z,", node);
+		E_jumps_with_fallthrough("jr nz,", "jr z,", node);
 	end sub;
 
 	sub E_jumps_jc_jnc(node: [Node])
-		E_jumps_with_fallthrough("jp c,", "jp nc,", node);
+		E_jumps_with_fallthrough("jr c,", "jr nc,", node);
 	end sub;
 
 	sub E_jumps_jm_jp(node: [Node])
@@ -1705,7 +1705,7 @@ gen hlhl := RSHIFTS4(hlhl, a)
 		else
 			E_rcf();
 			cmpeq2(value as uint16);
-			E_jump("jp nz,", node.beq0.falselabel);
+			E_jump("jr nz,", node.beq0.falselabel);
 			E_exx();
 			cmpeq2((value>>16) as uint16);
 		end if;

--- a/third_party/zmac/build.lua
+++ b/third_party/zmac/build.lua
@@ -34,7 +34,7 @@ function zmac(e)
 			e.ins
 		),
 		outs = e.outs,
-		cmd = "@1 -m "..archflag.." -o &1 "..table.concat(hdrpaths, " ").." @2"
+		cmd = "@1 -j -m "..archflag.." -o &1 "..table.concat(hdrpaths, " ").." @2"
 	}
 end
 


### PR DESCRIPTION
Turns out I completely forgot some easy wins! cowcom-8080.bbct goes from 57165 to 56588 bytes, which is a drop of about 1%, which is really nice. cowlink-bbct goes down from 8784 to 8647 bytes.

The extra rules caused cowcom-65c02.ncpmz to go over the limit and it stopped compiling, but I figured out how to enable automatic relative jumps, which I wanted anyway. That knocked a kilobyte off the compiler size. cowcom-65c02.ncpmz has gone from 60236 to 60062 bytes.