### PR TITLE
Produce a new, smaller variant of bbct

### DIFF
--- a/bootstrap/cowlink-cgen.bootstrap.c
+++ b/bootstrap/cowlink-cgen.bootstrap.c
@@ -1,23 +1,8 @@
 #include "cowgol.h"
-static i8 workspace[0x018e];
+static i8 workspace[0x018d];
 static i1* ws = (i1*)workspace;
 
-// AlignUp workspace at ws+848 length ws+16
-void f4(i8* p1 /* out */, i8 p2 /* in */) {
-	*(i8*)(intptr_t)(ws+848) = p2; /*in */
-
-	i8 v3 = (i8)(intptr_t)(ws+848);
-	i8 v4 = *(i8*)(intptr_t)v3;
-	i8 v5 = v4+(+7);
-	i8 v6 = v5&(-8);
-	i8 v7 = (i8)(intptr_t)(ws+856);
-	*(i8*)(intptr_t)v7 = v6;
-
-endsub:;
-	*p1 = *(i8*)(intptr_t)(ws+856);
-}
-
-// ExitWithError workspace at ws+3112 length ws+0
+// ExitWithError workspace at ws+3104 length ws+0
 void f6(void) {
 
 	
@@ -27,51 +12,51 @@ exit(1);
 endsub:;
 }
 
-// MemSet workspace at ws+856 length ws+24
+// MemSet workspace at ws+848 length ws+24
 void f7(i8 p8 /* len */, i1 p9 /* byte */, i8 p10 /* buf */) {
-	*(i8*)(intptr_t)(ws+856) = p10; /*buf */
-	*(i1*)(intptr_t)(ws+864) = p9; /*byte */
-	*(i8*)(intptr_t)(ws+872) = p8; /*len */
+	*(i8*)(intptr_t)(ws+848) = p10; /*buf */
+	*(i1*)(intptr_t)(ws+856) = p9; /*byte */
+	*(i8*)(intptr_t)(ws+864) = p8; /*len */
 
 	
 memset((void*)(intptr_t) 
-*(i8*)(intptr_t)(ws+856) 
+*(i8*)(intptr_t)(ws+848) 
 ,  
-*(i1*)(intptr_t)(ws+864) 
+*(i1*)(intptr_t)(ws+856) 
 ,  
-*(i8*)(intptr_t)(ws+872) 
+*(i8*)(intptr_t)(ws+864) 
 ); 
 
 
 endsub:;
 }
 
-// print_char workspace at ws+3144 length ws+1
+// print_char workspace at ws+3136 length ws+1
 void f8(i1 p11 /* c */) {
-	*(i1*)(intptr_t)(ws+3144) = p11; /*c */
+	*(i1*)(intptr_t)(ws+3136) = p11; /*c */
 
 	
 putchar( 
-*(i1*)(intptr_t)(ws+3144) 
+*(i1*)(intptr_t)(ws+3136) 
 ); 
 
 
 endsub:;
 }
 
-// print workspace at ws+3128 length ws+9
+// print workspace at ws+3120 length ws+9
 void f11(i8 p20 /* ptr */) {
-	*(i8*)(intptr_t)(ws+3128) = p20; /*ptr */
+	*(i8*)(intptr_t)(ws+3120) = p20; /*ptr */
 
 c02_0001:;
 
-	i8 v21 = (i8)(intptr_t)(ws+3128);
+	i8 v21 = (i8)(intptr_t)(ws+3120);
 	i8 v22 = *(i8*)(intptr_t)v21;
 	i1 v23 = *(i1*)(intptr_t)v22;
-	i8 v24 = (i8)(intptr_t)(ws+3136);
+	i8 v24 = (i8)(intptr_t)(ws+3128);
 	*(i1*)(intptr_t)v24 = v23;
 
-	i8 v25 = (i8)(intptr_t)(ws+3136);
+	i8 v25 = (i8)(intptr_t)(ws+3128);
 	i1 v26 = *(i1*)(intptr_t)v25;
 	i1 v27 = (i1)+0;
 	if (v26==v27) goto c02_0006; else goto c02_0007;
@@ -86,14 +71,14 @@ c02_0007:;
 
 c02_0003:;
 
-	i8 v28 = (i8)(intptr_t)(ws+3136);
+	i8 v28 = (i8)(intptr_t)(ws+3128);
 	i1 v29 = *(i1*)(intptr_t)v28;
 	f8(v29);
 
-	i8 v30 = (i8)(intptr_t)(ws+3128);
+	i8 v30 = (i8)(intptr_t)(ws+3120);
 	i8 v31 = *(i8*)(intptr_t)v30;
 	i8 v32 = v31+(+1);
-	i8 v33 = (i8)(intptr_t)(ws+3128);
+	i8 v33 = (i8)(intptr_t)(ws+3120);
 	*(i8*)(intptr_t)v33 = v32;
 
 	goto c02_0001;
@@ -103,7 +88,7 @@ c02_0002:;
 endsub:;
 }
 
-// print_nl workspace at ws+768 length ws+0
+// print_nl workspace at ws+760 length ws+0
 void f12(void) {
 
 	i1 v34 = (i1)+10;
@@ -112,76 +97,76 @@ void f12(void) {
 endsub:;
 }
 
-// UIToA workspace at ws+3128 length ws+49
+// UIToA workspace at ws+3120 length ws+49
 void f13(i8* p35 /* ptr */, i8 p36 /* buffer */, i1 p37 /* base */, i4 p38 /* value */) {
-	*(i4*)(intptr_t)(ws+3128) = p38; /*value */
-	*(i1*)(intptr_t)(ws+3132) = p37; /*base */
-	*(i8*)(intptr_t)(ws+3136) = p36; /*buffer */
+	*(i4*)(intptr_t)(ws+3120) = p38; /*value */
+	*(i1*)(intptr_t)(ws+3124) = p37; /*base */
+	*(i8*)(intptr_t)(ws+3128) = p36; /*buffer */
 
-	i8 v39 = (i8)(intptr_t)(ws+3136);
+	i8 v39 = (i8)(intptr_t)(ws+3128);
 	i8 v40 = *(i8*)(intptr_t)v39;
-	i8 v41 = (i8)(intptr_t)(ws+3144);
+	i8 v41 = (i8)(intptr_t)(ws+3136);
 	*(i8*)(intptr_t)v41 = v40;
 
 c02_0008:;
 
-	i8 v42 = (i8)(intptr_t)(ws+3128);
+	i8 v42 = (i8)(intptr_t)(ws+3120);
 	i4 v43 = *(i4*)(intptr_t)v42;
-	i8 v44 = (i8)(intptr_t)(ws+3132);
+	i8 v44 = (i8)(intptr_t)(ws+3124);
 	i1 v45 = *(i1*)(intptr_t)v44;
 	i4 v46 = v45;
 	i4 v47 = v43%v46;
-	i8 v48 = (i8)(intptr_t)(ws+3152);
+	i8 v48 = (i8)(intptr_t)(ws+3144);
 	*(i4*)(intptr_t)v48 = v47;
 
-	i8 v49 = (i8)(intptr_t)(ws+3128);
+	i8 v49 = (i8)(intptr_t)(ws+3120);
 	i4 v50 = *(i4*)(intptr_t)v49;
-	i8 v51 = (i8)(intptr_t)(ws+3132);
+	i8 v51 = (i8)(intptr_t)(ws+3124);
 	i1 v52 = *(i1*)(intptr_t)v51;
 	i4 v53 = v52;
 	i4 v54 = v50/v53;
-	i8 v55 = (i8)(intptr_t)(ws+3128);
+	i8 v55 = (i8)(intptr_t)(ws+3120);
 	*(i4*)(intptr_t)v55 = v54;
 
-	i8 v56 = (i8)(intptr_t)(ws+3152);
+	i8 v56 = (i8)(intptr_t)(ws+3144);
 	i4 v57 = *(i4*)(intptr_t)v56;
 	i4 v58 = (i4)+10;
 	if (v57<v58) goto c02_000d; else goto c02_000e;
 
 c02_000d:;
 
-	i8 v59 = (i8)(intptr_t)(ws+3152);
+	i8 v59 = (i8)(intptr_t)(ws+3144);
 	i4 v60 = *(i4*)(intptr_t)v59;
 	i4 v61 = v60+(+48);
-	i8 v62 = (i8)(intptr_t)(ws+3152);
+	i8 v62 = (i8)(intptr_t)(ws+3144);
 	*(i4*)(intptr_t)v62 = v61;
 
 	goto c02_000a;
 
 c02_000e:;
 
-	i8 v63 = (i8)(intptr_t)(ws+3152);
+	i8 v63 = (i8)(intptr_t)(ws+3144);
 	i4 v64 = *(i4*)(intptr_t)v63;
 	i4 v65 = v64+(+87);
-	i8 v66 = (i8)(intptr_t)(ws+3152);
+	i8 v66 = (i8)(intptr_t)(ws+3144);
 	*(i4*)(intptr_t)v66 = v65;
 
 c02_000a:;
 
-	i8 v67 = (i8)(intptr_t)(ws+3152);
+	i8 v67 = (i8)(intptr_t)(ws+3144);
 	i4 v68 = *(i4*)(intptr_t)v67;
 	i1 v69 = v68;
-	i8 v70 = (i8)(intptr_t)(ws+3144);
+	i8 v70 = (i8)(intptr_t)(ws+3136);
 	i8 v71 = *(i8*)(intptr_t)v70;
 	*(i1*)(intptr_t)v71 = v69;
 
-	i8 v72 = (i8)(intptr_t)(ws+3144);
+	i8 v72 = (i8)(intptr_t)(ws+3136);
 	i8 v73 = *(i8*)(intptr_t)v72;
 	i8 v74 = v73+(+1);
-	i8 v75 = (i8)(intptr_t)(ws+3144);
+	i8 v75 = (i8)(intptr_t)(ws+3136);
 	*(i8*)(intptr_t)v75 = v74;
 
-	i8 v76 = (i8)(intptr_t)(ws+3128);
+	i8 v76 = (i8)(intptr_t)(ws+3120);
 	i4 v77 = *(i4*)(intptr_t)v76;
 	i4 v78 = (i4)+0;
 	if (v77==v78) goto c02_0012; else goto c02_0013;
@@ -200,56 +185,56 @@ c02_000f:;
 
 c02_0009:;
 
-	i8 v79 = (i8)(intptr_t)(ws+3136);
+	i8 v79 = (i8)(intptr_t)(ws+3128);
 	i8 v80 = *(i8*)(intptr_t)v79;
-	i8 v81 = (i8)(intptr_t)(ws+3160);
+	i8 v81 = (i8)(intptr_t)(ws+3152);
 	*(i8*)(intptr_t)v81 = v80;
 
-	i8 v82 = (i8)(intptr_t)(ws+3144);
+	i8 v82 = (i8)(intptr_t)(ws+3136);
 	i8 v83 = *(i8*)(intptr_t)v82;
 	i8 v84 = v83+(-1);
-	i8 v85 = (i8)(intptr_t)(ws+3168);
+	i8 v85 = (i8)(intptr_t)(ws+3160);
 	*(i8*)(intptr_t)v85 = v84;
 
 c02_0016:;
 
-	i8 v86 = (i8)(intptr_t)(ws+3160);
+	i8 v86 = (i8)(intptr_t)(ws+3152);
 	i8 v87 = *(i8*)(intptr_t)v86;
-	i8 v88 = (i8)(intptr_t)(ws+3168);
+	i8 v88 = (i8)(intptr_t)(ws+3160);
 	i8 v89 = *(i8*)(intptr_t)v88;
 	if (v87<v89) goto c02_0018; else goto c02_0019;
 
 c02_0018:;
 
-	i8 v90 = (i8)(intptr_t)(ws+3160);
+	i8 v90 = (i8)(intptr_t)(ws+3152);
 	i8 v91 = *(i8*)(intptr_t)v90;
 	i1 v92 = *(i1*)(intptr_t)v91;
-	i8 v93 = (i8)(intptr_t)(ws+3176);
+	i8 v93 = (i8)(intptr_t)(ws+3168);
 	*(i1*)(intptr_t)v93 = v92;
 
-	i8 v94 = (i8)(intptr_t)(ws+3168);
+	i8 v94 = (i8)(intptr_t)(ws+3160);
 	i8 v95 = *(i8*)(intptr_t)v94;
 	i1 v96 = *(i1*)(intptr_t)v95;
-	i8 v97 = (i8)(intptr_t)(ws+3160);
+	i8 v97 = (i8)(intptr_t)(ws+3152);
 	i8 v98 = *(i8*)(intptr_t)v97;
 	*(i1*)(intptr_t)v98 = v96;
 
-	i8 v99 = (i8)(intptr_t)(ws+3176);
+	i8 v99 = (i8)(intptr_t)(ws+3168);
 	i1 v100 = *(i1*)(intptr_t)v99;
-	i8 v101 = (i8)(intptr_t)(ws+3168);
+	i8 v101 = (i8)(intptr_t)(ws+3160);
 	i8 v102 = *(i8*)(intptr_t)v101;
 	*(i1*)(intptr_t)v102 = v100;
 
-	i8 v103 = (i8)(intptr_t)(ws+3160);
+	i8 v103 = (i8)(intptr_t)(ws+3152);
 	i8 v104 = *(i8*)(intptr_t)v103;
 	i8 v105 = v104+(+1);
-	i8 v106 = (i8)(intptr_t)(ws+3160);
+	i8 v106 = (i8)(intptr_t)(ws+3152);
 	*(i8*)(intptr_t)v106 = v105;
 
-	i8 v107 = (i8)(intptr_t)(ws+3168);
+	i8 v107 = (i8)(intptr_t)(ws+3160);
 	i8 v108 = *(i8*)(intptr_t)v107;
 	i8 v109 = v108+(-1);
-	i8 v110 = (i8)(intptr_t)(ws+3168);
+	i8 v110 = (i8)(intptr_t)(ws+3160);
 	*(i8*)(intptr_t)v110 = v109;
 
 	goto c02_0016;
@@ -257,38 +242,38 @@ c02_0018:;
 c02_0019:;
 
 	i1 v111 = (i1)+0;
-	i8 v112 = (i8)(intptr_t)(ws+3144);
+	i8 v112 = (i8)(intptr_t)(ws+3136);
 	i8 v113 = *(i8*)(intptr_t)v112;
 	*(i1*)(intptr_t)v113 = v111;
 
 endsub:;
-	*p35 = *(i8*)(intptr_t)(ws+3144);
+	*p35 = *(i8*)(intptr_t)(ws+3136);
 }
 
-// print_i32 workspace at ws+3104 length ws+24
+// print_i32 workspace at ws+3096 length ws+24
 void f15(i4 p140 /* value */) {
-	*(i4*)(intptr_t)(ws+3104) = p140; /*value */
+	*(i4*)(intptr_t)(ws+3096) = p140; /*value */
 
-	i8 v141 = (i8)(intptr_t)(ws+3104);
+	i8 v141 = (i8)(intptr_t)(ws+3096);
 	i4 v142 = *(i4*)(intptr_t)v141;
 	i1 v143 = (i1)+10;
-	i8 v144 = (i8)(intptr_t)(ws+3108);
+	i8 v144 = (i8)(intptr_t)(ws+3100);
 	i8 v145;
 	f13(&v145, v144, v143, v142);
-	i8 v146 = (i8)(intptr_t)(ws+3120);
+	i8 v146 = (i8)(intptr_t)(ws+3112);
 	*(i8*)(intptr_t)v146 = v145;
 
-	i8 v147 = (i8)(intptr_t)(ws+3108);
+	i8 v147 = (i8)(intptr_t)(ws+3100);
 	f11(v147);
 
 endsub:;
 }
 
-// print_i16 workspace at ws+3096 length ws+2
+// print_i16 workspace at ws+3088 length ws+2
 void f16(i2 p148 /* value */) {
-	*(i2*)(intptr_t)(ws+3096) = p148; /*value */
+	*(i2*)(intptr_t)(ws+3088) = p148; /*value */
 
-	i8 v149 = (i8)(intptr_t)(ws+3096);
+	i8 v149 = (i8)(intptr_t)(ws+3088);
 	i2 v150 = *(i2*)(intptr_t)v149;
 	i4 v151 = v150;
 	f15(v151);
@@ -296,11 +281,11 @@ void f16(i2 p148 /* value */) {
 endsub:;
 }
 
-// print_i8 workspace at ws+3096 length ws+1
+// print_i8 workspace at ws+3088 length ws+1
 void f17(i1 p152 /* value */) {
-	*(i1*)(intptr_t)(ws+3096) = p152; /*value */
+	*(i1*)(intptr_t)(ws+3088) = p152; /*value */
 
-	i8 v153 = (i8)(intptr_t)(ws+3096);
+	i8 v153 = (i8)(intptr_t)(ws+3088);
 	i1 v154 = *(i1*)(intptr_t)v153;
 	i4 v155 = v154;
 	f15(v155);
@@ -308,66 +293,66 @@ void f17(i1 p152 /* value */) {
 endsub:;
 }
 
-// print_hex_i8 workspace at ws+776 length ws+3
+// print_hex_i8 workspace at ws+768 length ws+3
 void f18(i1 p156 /* value */) {
-	*(i1*)(intptr_t)(ws+776) = p156; /*value */
+	*(i1*)(intptr_t)(ws+768) = p156; /*value */
 
 	i1 v157 = (i1)+2;
-	i8 v158 = (i8)(intptr_t)(ws+777);
+	i8 v158 = (i8)(intptr_t)(ws+769);
 	*(i1*)(intptr_t)v158 = v157;
 
 c02_001f:;
 
-	i8 v159 = (i8)(intptr_t)(ws+776);
+	i8 v159 = (i8)(intptr_t)(ws+768);
 	i1 v160 = *(i1*)(intptr_t)v159;
 	i1 v161 = (i1)+4;
 	i1 v162 = ((i1)v160)>>v161;
-	i8 v163 = (i8)(intptr_t)(ws+778);
+	i8 v163 = (i8)(intptr_t)(ws+770);
 	*(i1*)(intptr_t)v163 = v162;
 
-	i8 v164 = (i8)(intptr_t)(ws+778);
+	i8 v164 = (i8)(intptr_t)(ws+770);
 	i1 v165 = *(i1*)(intptr_t)v164;
 	i1 v166 = (i1)+10;
 	if (v165<v166) goto c02_0024; else goto c02_0025;
 
 c02_0024:;
 
-	i8 v167 = (i8)(intptr_t)(ws+778);
+	i8 v167 = (i8)(intptr_t)(ws+770);
 	i1 v168 = *(i1*)(intptr_t)v167;
 	i1 v169 = v168+(+48);
-	i8 v170 = (i8)(intptr_t)(ws+778);
+	i8 v170 = (i8)(intptr_t)(ws+770);
 	*(i1*)(intptr_t)v170 = v169;
 
 	goto c02_0021;
 
 c02_0025:;
 
-	i8 v171 = (i8)(intptr_t)(ws+778);
+	i8 v171 = (i8)(intptr_t)(ws+770);
 	i1 v172 = *(i1*)(intptr_t)v171;
 	i1 v173 = v172+(+87);
-	i8 v174 = (i8)(intptr_t)(ws+778);
+	i8 v174 = (i8)(intptr_t)(ws+770);
 	*(i1*)(intptr_t)v174 = v173;
 
 c02_0021:;
 
-	i8 v175 = (i8)(intptr_t)(ws+778);
+	i8 v175 = (i8)(intptr_t)(ws+770);
 	i1 v176 = *(i1*)(intptr_t)v175;
 	f8(v176);
 
-	i8 v177 = (i8)(intptr_t)(ws+776);
+	i8 v177 = (i8)(intptr_t)(ws+768);
 	i1 v178 = *(i1*)(intptr_t)v177;
 	i1 v179 = (i1)+4;
 	i1 v180 = ((i1)v178)<<v179;
-	i8 v181 = (i8)(intptr_t)(ws+776);
+	i8 v181 = (i8)(intptr_t)(ws+768);
 	*(i1*)(intptr_t)v181 = v180;
 
-	i8 v182 = (i8)(intptr_t)(ws+777);
+	i8 v182 = (i8)(intptr_t)(ws+769);
 	i1 v183 = *(i1*)(intptr_t)v182;
 	i1 v184 = v183+(-1);
-	i8 v185 = (i8)(intptr_t)(ws+777);
+	i8 v185 = (i8)(intptr_t)(ws+769);
 	*(i1*)(intptr_t)v185 = v184;
 
-	i8 v186 = (i8)(intptr_t)(ws+777);
+	i8 v186 = (i8)(intptr_t)(ws+769);
 	i1 v187 = *(i1*)(intptr_t)v186;
 	i1 v188 = (i1)+0;
 	if (v187==v188) goto c02_0029; else goto c02_002a;
@@ -389,32 +374,32 @@ c02_0020:;
 endsub:;
 }
 
-// print_hex_i32 workspace at ws+768 length ws+4
+// print_hex_i32 workspace at ws+760 length ws+4
 void f20(i4 p198 /* value */) {
-	*(i4*)(intptr_t)(ws+768) = p198; /*value */
+	*(i4*)(intptr_t)(ws+760) = p198; /*value */
 
-	i8 v199 = (i8)(intptr_t)(ws+768);
+	i8 v199 = (i8)(intptr_t)(ws+760);
 	i4 v200 = *(i4*)(intptr_t)v199;
 	i1 v201 = (i1)+24;
 	i4 v202 = ((i4)v200)>>v201;
 	i1 v203 = v202;
 	f18(v203);
 
-	i8 v204 = (i8)(intptr_t)(ws+768);
+	i8 v204 = (i8)(intptr_t)(ws+760);
 	i4 v205 = *(i4*)(intptr_t)v204;
 	i1 v206 = (i1)+16;
 	i4 v207 = ((i4)v205)>>v206;
 	i1 v208 = v207;
 	f18(v208);
 
-	i8 v209 = (i8)(intptr_t)(ws+768);
+	i8 v209 = (i8)(intptr_t)(ws+760);
 	i4 v210 = *(i4*)(intptr_t)v209;
 	i1 v211 = (i1)+8;
 	i4 v212 = ((i4)v210)>>v211;
 	i1 v213 = v212;
 	f18(v213);
 
-	i8 v214 = (i8)(intptr_t)(ws+768);
+	i8 v214 = (i8)(intptr_t)(ws+760);
 	i4 v215 = *(i4*)(intptr_t)v214;
 	i1 v216 = v215;
 	f18(v216);
@@ -422,7 +407,7 @@ void f20(i4 p198 /* value */) {
 endsub:;
 }
 
-// ArgvInit workspace at ws+640 length ws+0
+// ArgvInit workspace at ws+632 length ws+0
 void f23(void) {
 
 	
@@ -439,7 +424,7 @@ void f23(void) {
 endsub:;
 }
 
-// ArgvNext workspace at ws+640 length ws+8
+// ArgvNext workspace at ws+632 length ws+8
 void f24(i8* p332 /* arg */) {
 
 	i8 v333 = (i8)(intptr_t)(ws+16);
@@ -450,7 +435,7 @@ void f24(i8* p332 /* arg */) {
 c02_0052:;
 
 	i8 v336 = (i8)+0;
-	i8 v337 = (i8)(intptr_t)(ws+640);
+	i8 v337 = (i8)(intptr_t)(ws+632);
 	*(i8*)(intptr_t)v337 = v336;
 
 	goto endsub;
@@ -464,10 +449,10 @@ c02_004f:;
 	i8 v338 = (i8)(intptr_t)(ws+16);
 	i8 v339 = *(i8*)(intptr_t)v338;
 	i8 v340 = *(i8*)(intptr_t)v339;
-	i8 v341 = (i8)(intptr_t)(ws+640);
+	i8 v341 = (i8)(intptr_t)(ws+632);
 	*(i8*)(intptr_t)v341 = v340;
 
-	i8 v342 = (i8)(intptr_t)(ws+640);
+	i8 v342 = (i8)(intptr_t)(ws+632);
 	i8 v343 = *(i8*)(intptr_t)v342;
 	i8 v344 = (i8)+0;
 	if (v343==v344) goto c02_0057; else goto c02_0058;
@@ -491,34 +476,34 @@ c02_0058:;
 c02_0054:;
 
 endsub:;
-	*p332 = *(i8*)(intptr_t)(ws+640);
+	*p332 = *(i8*)(intptr_t)(ws+632);
 }
 
-// StrCmp workspace at ws+744 length ws+17
+// StrCmp workspace at ws+736 length ws+17
 void f25(i1* p351 /* res */, i8 p352 /* s2 */, i8 p353 /* s1 */) {
-	*(i8*)(intptr_t)(ws+744) = p353; /*s1 */
-	*(i8*)(intptr_t)(ws+752) = p352; /*s2 */
+	*(i8*)(intptr_t)(ws+736) = p353; /*s1 */
+	*(i8*)(intptr_t)(ws+744) = p352; /*s2 */
 
 c02_0059:;
 
-	i8 v354 = (i8)(intptr_t)(ws+744);
+	i8 v354 = (i8)(intptr_t)(ws+736);
 	i8 v355 = *(i8*)(intptr_t)v354;
 	i1 v356 = *(i1*)(intptr_t)v355;
-	i8 v357 = (i8)(intptr_t)(ws+752);
+	i8 v357 = (i8)(intptr_t)(ws+744);
 	i8 v358 = *(i8*)(intptr_t)v357;
 	i1 v359 = *(i1*)(intptr_t)v358;
 	i1 v360 = v356-v359;
-	i8 v361 = (i8)(intptr_t)(ws+760);
+	i8 v361 = (i8)(intptr_t)(ws+752);
 	*(i1*)(intptr_t)v361 = v360;
 
-	i8 v362 = (i8)(intptr_t)(ws+760);
+	i8 v362 = (i8)(intptr_t)(ws+752);
 	i1 v363 = *(i1*)(intptr_t)v362;
 	i1 v364 = (i1)+0;
 	if (v363==v364) goto c02_0062; else goto c02_0060;
 
 c02_0062:;
 
-	i8 v365 = (i8)(intptr_t)(ws+744);
+	i8 v365 = (i8)(intptr_t)(ws+736);
 	i8 v366 = *(i8*)(intptr_t)v365;
 	i1 v367 = *(i1*)(intptr_t)v366;
 	i1 v368 = (i1)+0;
@@ -534,16 +519,16 @@ c02_0061:;
 
 c02_005b:;
 
-	i8 v369 = (i8)(intptr_t)(ws+744);
+	i8 v369 = (i8)(intptr_t)(ws+736);
 	i8 v370 = *(i8*)(intptr_t)v369;
 	i8 v371 = v370+(+1);
-	i8 v372 = (i8)(intptr_t)(ws+744);
+	i8 v372 = (i8)(intptr_t)(ws+736);
 	*(i8*)(intptr_t)v372 = v371;
 
-	i8 v373 = (i8)(intptr_t)(ws+752);
+	i8 v373 = (i8)(intptr_t)(ws+744);
 	i8 v374 = *(i8*)(intptr_t)v373;
 	i8 v375 = v374+(+1);
-	i8 v376 = (i8)(intptr_t)(ws+752);
+	i8 v376 = (i8)(intptr_t)(ws+744);
 	*(i8*)(intptr_t)v376 = v375;
 
 	goto c02_0059;
@@ -551,14 +536,14 @@ c02_005b:;
 c02_005a:;
 
 endsub:;
-	*p351 = *(i1*)(intptr_t)(ws+760);
+	*p351 = *(i1*)(intptr_t)(ws+752);
 }
 
-// ToLower workspace at ws+664 length ws+2
+// ToLower workspace at ws+656 length ws+2
 void f26(i1* p377 /* cc */, i1 p378 /* c */) {
-	*(i1*)(intptr_t)(ws+664) = p378; /*c */
+	*(i1*)(intptr_t)(ws+656) = p378; /*c */
 
-	i8 v379 = (i8)(intptr_t)(ws+664);
+	i8 v379 = (i8)(intptr_t)(ws+656);
 	i1 v380 = *(i1*)(intptr_t)v379;
 	i1 v381 = (i1)+65;
 	if (v380<v381) goto c02_0069; else goto c02_006a;
@@ -566,62 +551,62 @@ void f26(i1* p377 /* cc */, i1 p378 /* c */) {
 c02_006a:;
 
 	i1 v382 = (i1)+90;
-	i8 v383 = (i8)(intptr_t)(ws+664);
+	i8 v383 = (i8)(intptr_t)(ws+656);
 	i1 v384 = *(i1*)(intptr_t)v383;
 	if (v382<v384) goto c02_0069; else goto c02_0068;
 
 c02_0068:;
 
-	i8 v385 = (i8)(intptr_t)(ws+664);
+	i8 v385 = (i8)(intptr_t)(ws+656);
 	i1 v386 = *(i1*)(intptr_t)v385;
 	i1 v387 = v386|(+32);
-	i8 v388 = (i8)(intptr_t)(ws+665);
+	i8 v388 = (i8)(intptr_t)(ws+657);
 	*(i1*)(intptr_t)v388 = v387;
 
 	goto c02_0063;
 
 c02_0069:;
 
-	i8 v389 = (i8)(intptr_t)(ws+664);
+	i8 v389 = (i8)(intptr_t)(ws+656);
 	i1 v390 = *(i1*)(intptr_t)v389;
-	i8 v391 = (i8)(intptr_t)(ws+665);
+	i8 v391 = (i8)(intptr_t)(ws+657);
 	*(i1*)(intptr_t)v391 = v390;
 
 c02_0063:;
 
 endsub:;
-	*p377 = *(i1*)(intptr_t)(ws+665);
+	*p377 = *(i1*)(intptr_t)(ws+657);
 }
 
-// StrICmp workspace at ws+640 length ws+17
+// StrICmp workspace at ws+632 length ws+17
 void f27(i1* p392 /* res */, i8 p393 /* s2 */, i8 p394 /* s1 */) {
-	*(i8*)(intptr_t)(ws+640) = p394; /*s1 */
-	*(i8*)(intptr_t)(ws+648) = p393; /*s2 */
+	*(i8*)(intptr_t)(ws+632) = p394; /*s1 */
+	*(i8*)(intptr_t)(ws+640) = p393; /*s2 */
 
 c02_006b:;
 
-	i8 v395 = (i8)(intptr_t)(ws+640);
+	i8 v395 = (i8)(intptr_t)(ws+632);
 	i8 v396 = *(i8*)(intptr_t)v395;
 	i1 v397 = *(i1*)(intptr_t)v396;
 	i1 v398;
 	f26(&v398, v397);
-	i8 v399 = (i8)(intptr_t)(ws+648);
+	i8 v399 = (i8)(intptr_t)(ws+640);
 	i8 v400 = *(i8*)(intptr_t)v399;
 	i1 v401 = *(i1*)(intptr_t)v400;
 	i1 v402;
 	f26(&v402, v401);
 	i1 v403 = v398-v402;
-	i8 v404 = (i8)(intptr_t)(ws+656);
+	i8 v404 = (i8)(intptr_t)(ws+648);
 	*(i1*)(intptr_t)v404 = v403;
 
-	i8 v405 = (i8)(intptr_t)(ws+656);
+	i8 v405 = (i8)(intptr_t)(ws+648);
 	i1 v406 = *(i1*)(intptr_t)v405;
 	i1 v407 = (i1)+0;
 	if (v406==v407) goto c02_0074; else goto c02_0072;
 
 c02_0074:;
 
-	i8 v408 = (i8)(intptr_t)(ws+640);
+	i8 v408 = (i8)(intptr_t)(ws+632);
 	i8 v409 = *(i8*)(intptr_t)v408;
 	i1 v410 = *(i1*)(intptr_t)v409;
 	i1 v411 = (i1)+0;
@@ -637,16 +622,16 @@ c02_0073:;
 
 c02_006d:;
 
-	i8 v412 = (i8)(intptr_t)(ws+640);
+	i8 v412 = (i8)(intptr_t)(ws+632);
 	i8 v413 = *(i8*)(intptr_t)v412;
 	i8 v414 = v413+(+1);
-	i8 v415 = (i8)(intptr_t)(ws+640);
+	i8 v415 = (i8)(intptr_t)(ws+632);
 	*(i8*)(intptr_t)v415 = v414;
 
-	i8 v416 = (i8)(intptr_t)(ws+648);
+	i8 v416 = (i8)(intptr_t)(ws+640);
 	i8 v417 = *(i8*)(intptr_t)v416;
 	i8 v418 = v417+(+1);
-	i8 v419 = (i8)(intptr_t)(ws+648);
+	i8 v419 = (i8)(intptr_t)(ws+640);
 	*(i8*)(intptr_t)v419 = v418;
 
 	goto c02_006b;
@@ -654,636 +639,325 @@ c02_006d:;
 c02_006c:;
 
 endsub:;
-	*p392 = *(i1*)(intptr_t)(ws+656);
+	*p392 = *(i1*)(intptr_t)(ws+648);
 }
 
-// StrLen workspace at ws+768 length ws+25
-void f28(i8* p420 /* size */, i8 p421 /* s */) {
-	*(i8*)(intptr_t)(ws+768) = p421; /*s */
+// Alloc workspace at ws+784 length ws+16
+void f31(i8* p486 /* block */, i8 p487 /* length */) {
+	*(i8*)(intptr_t)(ws+784) = p487; /*length */
 
-	i8 v422 = (i8)(intptr_t)(ws+768);
-	i8 v423 = *(i8*)(intptr_t)v422;
-	i8 v424 = (i8)(intptr_t)(ws+784);
-	*(i8*)(intptr_t)v424 = v423;
+	
+*(i8*)(intptr_t)(ws+792) 
+=(i8)calloc(1, (size_t) 
+*(i8*)(intptr_t)(ws+784) 
+); 
 
-c02_0075:;
-
-	i8 v425 = (i8)(intptr_t)(ws+784);
-	i8 v426 = *(i8*)(intptr_t)v425;
-	i1 v427 = *(i1*)(intptr_t)v426;
-	i8 v428 = (i8)(intptr_t)(ws+792);
-	*(i1*)(intptr_t)v428 = v427;
-
-	i8 v429 = (i8)(intptr_t)(ws+792);
-	i1 v430 = *(i1*)(intptr_t)v429;
-	i1 v431 = (i1)+0;
-	if (v430==v431) goto c02_007a; else goto c02_007b;
-
-c02_007a:;
-
-	goto c02_0076;
-
-	goto c02_0077;
-
-c02_007b:;
-
-c02_0077:;
-
-	i8 v432 = (i8)(intptr_t)(ws+784);
-	i8 v433 = *(i8*)(intptr_t)v432;
-	i8 v434 = v433+(+1);
-	i8 v435 = (i8)(intptr_t)(ws+784);
-	*(i8*)(intptr_t)v435 = v434;
-
-	goto c02_0075;
-
-c02_0076:;
-
-	i8 v436 = (i8)(intptr_t)(ws+784);
-	i8 v437 = *(i8*)(intptr_t)v436;
-	i8 v438 = (i8)(intptr_t)(ws+768);
-	i8 v439 = *(i8*)(intptr_t)v438;
-	i8 v440 = v437-v439;
-	i8 v441 = (i8)(intptr_t)(ws+776);
-	*(i8*)(intptr_t)v441 = v440;
 
 endsub:;
-	*p420 = *(i8*)(intptr_t)(ws+776);
+	*p486 = *(i8*)(intptr_t)(ws+792);
 }
 
-// MemCopy workspace at ws+768 length ws+24
-void f30(i8 p463 /* dest */, i8 p464 /* size */, i8 p465 /* src */) {
-	*(i8*)(intptr_t)(ws+768) = p465; /*src */
-	*(i8*)(intptr_t)(ws+776) = p464; /*size */
-	*(i8*)(intptr_t)(ws+784) = p463; /*dest */
+// StrDup workspace at ws+736 length ws+16
+void f33(i8* p489 /* sout */, i8 p490 /* s */) {
+	*(i8*)(intptr_t)(ws+736) = p490; /*s */
 
-c02_0085:;
+	
+*(i8*)(intptr_t)(ws+744) 
+=(i8)strdup((const char*) 
+*(i8*)(intptr_t)(ws+736) 
+); 
 
-	i8 v466 = (i8)(intptr_t)(ws+776);
-	i8 v467 = *(i8*)(intptr_t)v466;
-	i8 v468 = (i8)+0;
-	if (v467==v468) goto c02_0088; else goto c02_0087;
-
-c02_0087:;
-
-	i8 v469 = (i8)(intptr_t)(ws+768);
-	i8 v470 = *(i8*)(intptr_t)v469;
-	i1 v471 = *(i1*)(intptr_t)v470;
-	i8 v472 = (i8)(intptr_t)(ws+784);
-	i8 v473 = *(i8*)(intptr_t)v472;
-	*(i1*)(intptr_t)v473 = v471;
-
-	i8 v474 = (i8)(intptr_t)(ws+784);
-	i8 v475 = *(i8*)(intptr_t)v474;
-	i8 v476 = v475+(+1);
-	i8 v477 = (i8)(intptr_t)(ws+784);
-	*(i8*)(intptr_t)v477 = v476;
-
-	i8 v478 = (i8)(intptr_t)(ws+768);
-	i8 v479 = *(i8*)(intptr_t)v478;
-	i8 v480 = v479+(+1);
-	i8 v481 = (i8)(intptr_t)(ws+768);
-	*(i8*)(intptr_t)v481 = v480;
-
-	i8 v482 = (i8)(intptr_t)(ws+776);
-	i8 v483 = *(i8*)(intptr_t)v482;
-	i8 v484 = v483+(-1);
-	i8 v485 = (i8)(intptr_t)(ws+776);
-	*(i8*)(intptr_t)v485 = v484;
-
-	goto c02_0085;
-
-c02_0088:;
 
 endsub:;
+	*p489 = *(i8*)(intptr_t)(ws+744);
 }
-const i1 c02_s0008[] = { 0x4f,0x75,0x74,0x20,0x6f,0x66,0x20,0x6d,0x65,0x6d,0x6f,0x72,0x79,0x0a,0 };
 
-// Alloc workspace at ws+792 length ws+56
-void f33(i8* p581 /* block */, i8 p582 /* length */) {
-	*(i8*)(intptr_t)(ws+792) = p582; /*length */
+// GetFreeMemory workspace at ws+632 length ws+8
+void f35(i8* p491 /* i */) {
 
-	i8 v583 = (i8)(intptr_t)(ws+792);
-	i8 v584 = *(i8*)(intptr_t)v583;
-	i8 v585 = v584+(+8);
-	i8 v586;
-	f4(&v586, v585);
-	i8 v587 = (i8)(intptr_t)(ws+808);
-	*(i8*)(intptr_t)v587 = v586;
-
-	i8 v588 = (i8)+0;
-	i8 v589 = (i8)(intptr_t)(ws+816);
-	*(i8*)(intptr_t)v589 = v588;
-
-	i8 v590 = (i8)(intptr_t)(ws+24);
-	i8 v591 = *(i8*)(intptr_t)v590;
-	i8 v592 = (i8)(intptr_t)(ws+824);
-	*(i8*)(intptr_t)v592 = v591;
-
-c02_009f:;
-
-	i8 v593 = (i8)(intptr_t)(ws+824);
-	i8 v594 = *(i8*)(intptr_t)v593;
-	i8 v595 = (i8)+0;
-	if (v594==v595) goto c02_00a4; else goto c02_00a5;
-
-c02_00a4:;
-
-	i8 v596 = (i8)+0;
-	i8 v597 = (i8)(intptr_t)(ws+824);
-	*(i8*)(intptr_t)v597 = v596;
-
-	i8 v598 = (i8)(intptr_t)c02_s0008;
-	f11(v598);
-
-	f6();
-
-	goto c02_00a0;
-
-	goto c02_00a1;
-
-c02_00a5:;
-
-c02_00a1:;
-
-	i8 v599 = (i8)(intptr_t)(ws+824);
-	i8 v600 = *(i8*)(intptr_t)v599;
-	i8 v601 = v600+(+8);
-	i8 v602 = *(i8*)(intptr_t)v601;
-	i8 v603 = (i8)(intptr_t)(ws+832);
-	*(i8*)(intptr_t)v603 = v602;
-
-	i8 v604 = (i8)(intptr_t)(ws+832);
-	i8 v605 = *(i8*)(intptr_t)v604;
-	i8 v606 = (i8)(intptr_t)(ws+808);
-	i8 v607 = *(i8*)(intptr_t)v606;
-	if (v605==v607) goto c02_00a9; else goto c02_00aa;
-
-c02_00a9:;
-
-	i8 v608 = (i8)(intptr_t)(ws+816);
-	i8 v609 = *(i8*)(intptr_t)v608;
-	i8 v610 = (i8)+0;
-	if (v609==v610) goto c02_00af; else goto c02_00ae;
-
-c02_00ae:;
-
-	i8 v611 = (i8)(intptr_t)(ws+824);
-	i8 v612 = *(i8*)(intptr_t)v611;
-	i8 v613 = *(i8*)(intptr_t)v612;
-	i8 v614 = (i8)(intptr_t)(ws+816);
-	i8 v615 = *(i8*)(intptr_t)v614;
-	*(i8*)(intptr_t)v615 = v613;
-
-	goto c02_00ab;
-
-c02_00af:;
-
-	i8 v616 = (i8)(intptr_t)(ws+824);
-	i8 v617 = *(i8*)(intptr_t)v616;
-	i8 v618 = *(i8*)(intptr_t)v617;
-	i8 v619 = (i8)(intptr_t)(ws+24);
-	*(i8*)(intptr_t)v619 = v618;
-
-c02_00ab:;
-
-	goto c02_00a0;
-
-	goto c02_00a6;
-
-c02_00aa:;
-
-	i8 v620 = (i8)(intptr_t)(ws+808);
-	i8 v621 = *(i8*)(intptr_t)v620;
-	i8 v622 = (i8)(intptr_t)(ws+832);
-	i8 v623 = *(i8*)(intptr_t)v622;
-	i8 v624 = v623+(-16);
-	if (v621<v624) goto c02_00b2; else goto c02_00b3;
-
-c02_00b2:;
-
-	i8 v625 = (i8)(intptr_t)(ws+832);
-	i8 v626 = *(i8*)(intptr_t)v625;
-	i8 v627 = (i8)(intptr_t)(ws+808);
-	i8 v628 = *(i8*)(intptr_t)v627;
-	i8 v629 = v626-v628;
-	i8 v630 = (i8)(intptr_t)(ws+824);
-	i8 v631 = *(i8*)(intptr_t)v630;
-	i8 v632 = v631+(+8);
-	*(i8*)(intptr_t)v632 = v629;
-
-	i8 v633 = (i8)(intptr_t)(ws+824);
-	i8 v634 = *(i8*)(intptr_t)v633;
-	i8 v635 = (i8)(intptr_t)(ws+824);
-	i8 v636 = *(i8*)(intptr_t)v635;
-	i8 v637 = v636+(+8);
-	i8 v638 = *(i8*)(intptr_t)v637;
-	i8 v639 = v634+v638;
-	i8 v640 = (i8)(intptr_t)(ws+824);
-	*(i8*)(intptr_t)v640 = v639;
-
-	goto c02_00a0;
-
-	goto c02_00a6;
-
-c02_00b3:;
-
-c02_00a6:;
-
-	i8 v641 = (i8)(intptr_t)(ws+824);
-	i8 v642 = *(i8*)(intptr_t)v641;
-	i8 v643 = (i8)(intptr_t)(ws+816);
-	*(i8*)(intptr_t)v643 = v642;
-
-	i8 v644 = (i8)(intptr_t)(ws+824);
-	i8 v645 = *(i8*)(intptr_t)v644;
-	i8 v646 = *(i8*)(intptr_t)v645;
-	i8 v647 = (i8)(intptr_t)(ws+824);
-	*(i8*)(intptr_t)v647 = v646;
-
-	goto c02_009f;
-
-c02_00a0:;
-
-	i8 v648 = (i8)(intptr_t)(ws+824);
-	i8 v649 = *(i8*)(intptr_t)v648;
-	i8 v650 = (i8)(intptr_t)(ws+840);
-	*(i8*)(intptr_t)v650 = v649;
-
-	i8 v651 = (i8)(intptr_t)(ws+808);
-	i8 v652 = *(i8*)(intptr_t)v651;
-	i8 v653 = (i8)(intptr_t)(ws+840);
-	i8 v654 = *(i8*)(intptr_t)v653;
-	*(i8*)(intptr_t)v654 = v652;
-
-	i8 v655 = (i8)(intptr_t)(ws+840);
-	i8 v656 = *(i8*)(intptr_t)v655;
-	i8 v657 = v656+(+8);
-	i8 v658 = (i8)(intptr_t)(ws+800);
-	*(i8*)(intptr_t)v658 = v657;
-
-	i8 v659 = (i8)(intptr_t)(ws+800);
-	i8 v660 = *(i8*)(intptr_t)v659;
-	i1 v661 = (i1)+0;
-	i8 v662 = (i8)(intptr_t)(ws+792);
-	i8 v663 = *(i8*)(intptr_t)v662;
-	f7(v663, v661, v660);
+	i8 v492 = (i8)+0;
+	i8 v493 = (i8)(intptr_t)(ws+632);
+	*(i8*)(intptr_t)v493 = v492;
 
 endsub:;
-	*p581 = *(i8*)(intptr_t)(ws+800);
+	*p491 = *(i8*)(intptr_t)(ws+632);
 }
 
-// GetFreeMemory workspace at ws+640 length ws+16
-void f36(i8* p802 /* bytes */) {
+// fcb_i_blockin workspace at ws+816 length ws+28
+void f36(i8 p494 /* fcb */) {
+	*(i8*)(intptr_t)(ws+816) = p494; /*fcb */
 
-	i8 v803 = (i8)+0;
-	i8 v804 = (i8)(intptr_t)(ws+640);
-	*(i8*)(intptr_t)v804 = v803;
+	i8 v495 = (i8)(intptr_t)(ws+816);
+	i8 v496 = *(i8*)(intptr_t)v495;
+	i8 v497 = v496+(+12);
+	i1 v498 = (i1)+0;
+	i8 v499 = (i8)+512;
+	f7(v499, v498, v497);
 
-	i8 v805 = (i8)(intptr_t)(ws+24);
-	i8 v806 = *(i8*)(intptr_t)v805;
-	i8 v807 = (i8)(intptr_t)(ws+648);
-	*(i8*)(intptr_t)v807 = v806;
+	i8 v500 = (i8)(intptr_t)(ws+816);
+	i8 v501 = *(i8*)(intptr_t)v500;
+	i4 v502 = *(i4*)(intptr_t)v501;
+	i8 v503 = (i8)(intptr_t)(ws+824);
+	*(i4*)(intptr_t)v503 = v502;
 
-c02_00d6:;
+	i8 v504 = (i8)(intptr_t)(ws+816);
+	i8 v505 = *(i8*)(intptr_t)v504;
+	i8 v506 = v505+(+12);
+	i8 v507 = (i8)(intptr_t)(ws+832);
+	*(i8*)(intptr_t)v507 = v506;
 
-	i8 v808 = (i8)(intptr_t)(ws+648);
-	i8 v809 = *(i8*)(intptr_t)v808;
-	i8 v810 = (i8)+0;
-	if (v809==v810) goto c02_00d9; else goto c02_00d8;
-
-c02_00d8:;
-
-	i8 v811 = (i8)(intptr_t)(ws+640);
-	i8 v812 = *(i8*)(intptr_t)v811;
-	i8 v813 = (i8)(intptr_t)(ws+648);
-	i8 v814 = *(i8*)(intptr_t)v813;
-	i8 v815 = v814+(+8);
-	i8 v816 = *(i8*)(intptr_t)v815;
-	i8 v817 = v812+v816;
-	i8 v818 = (i8)(intptr_t)(ws+640);
-	*(i8*)(intptr_t)v818 = v817;
-
-	i8 v819 = (i8)(intptr_t)(ws+648);
-	i8 v820 = *(i8*)(intptr_t)v819;
-	i8 v821 = *(i8*)(intptr_t)v820;
-	i8 v822 = (i8)(intptr_t)(ws+648);
-	*(i8*)(intptr_t)v822 = v821;
-
-	goto c02_00d6;
-
-c02_00d9:;
-
-endsub:;
-	*p802 = *(i8*)(intptr_t)(ws+640);
-}
-
-// StrDup workspace at ws+744 length ws+24
-void f37(i8* p823 /* news */, i8 p824 /* s */) {
-	*(i8*)(intptr_t)(ws+744) = p824; /*s */
-
-	i8 v825 = (i8)(intptr_t)(ws+744);
-	i8 v826 = *(i8*)(intptr_t)v825;
-	i8 v827;
-	f28(&v827, v826);
-	i8 v828 = v827+(+1);
-	i8 v829 = (i8)(intptr_t)(ws+760);
-	*(i8*)(intptr_t)v829 = v828;
-
-	i8 v830 = (i8)(intptr_t)(ws+760);
-	i8 v831 = *(i8*)(intptr_t)v830;
-	i8 v832;
-	f33(&v832, v831);
-	i8 v833 = (i8)(intptr_t)(ws+752);
-	*(i8*)(intptr_t)v833 = v832;
-
-	i8 v834 = (i8)(intptr_t)(ws+744);
-	i8 v835 = *(i8*)(intptr_t)v834;
-	i8 v836 = (i8)(intptr_t)(ws+760);
-	i8 v837 = *(i8*)(intptr_t)v836;
-	i8 v838 = (i8)(intptr_t)(ws+752);
-	i8 v839 = *(i8*)(intptr_t)v838;
-	f30(v839, v837, v835);
-
-endsub:;
-	*p823 = *(i8*)(intptr_t)(ws+752);
-}
-
-// fcb_i_blockin workspace at ws+824 length ws+28
-void f38(i8 p840 /* fcb */) {
-	*(i8*)(intptr_t)(ws+824) = p840; /*fcb */
-
-	i8 v841 = (i8)(intptr_t)(ws+824);
-	i8 v842 = *(i8*)(intptr_t)v841;
-	i8 v843 = v842+(+12);
-	i1 v844 = (i1)+0;
-	i8 v845 = (i8)+512;
-	f7(v845, v844, v843);
-
-	i8 v846 = (i8)(intptr_t)(ws+824);
-	i8 v847 = *(i8*)(intptr_t)v846;
-	i4 v848 = *(i4*)(intptr_t)v847;
-	i8 v849 = (i8)(intptr_t)(ws+832);
-	*(i4*)(intptr_t)v849 = v848;
-
-	i8 v850 = (i8)(intptr_t)(ws+824);
-	i8 v851 = *(i8*)(intptr_t)v850;
-	i8 v852 = v851+(+12);
-	i8 v853 = (i8)(intptr_t)(ws+840);
-	*(i8*)(intptr_t)v853 = v852;
-
-	i8 v854 = (i8)(intptr_t)(ws+824);
-	i8 v855 = *(i8*)(intptr_t)v854;
-	i8 v856 = v855+(+8);
-	i4 v857 = *(i4*)(intptr_t)v856;
-	i1 v858 = (i1)+9;
-	i4 v859 = ((i4)v857)<<v858;
-	i8 v860 = (i8)(intptr_t)(ws+848);
-	*(i4*)(intptr_t)v860 = v859;
+	i8 v508 = (i8)(intptr_t)(ws+816);
+	i8 v509 = *(i8*)(intptr_t)v508;
+	i8 v510 = v509+(+8);
+	i4 v511 = *(i4*)(intptr_t)v510;
+	i1 v512 = (i1)+9;
+	i4 v513 = ((i4)v511)<<v512;
+	i8 v514 = (i8)(intptr_t)(ws+840);
+	*(i4*)(intptr_t)v514 = v513;
 
 	
 pread( 
-*(i4*)(intptr_t)(ws+832) 
+*(i4*)(intptr_t)(ws+824) 
 , (void*)(intptr_t) 
-*(i8*)(intptr_t)(ws+840) 
+*(i8*)(intptr_t)(ws+832) 
 ,  
 (+512)
 ,  
-*(i4*)(intptr_t)(ws+848) 
+*(i4*)(intptr_t)(ws+840) 
 ); 
 
 
-	i1 v861 = (i1)+0;
-	i8 v862 = (i8)(intptr_t)(ws+824);
-	i8 v863 = *(i8*)(intptr_t)v862;
-	i8 v864 = v863+(+6);
-	*(i1*)(intptr_t)v864 = v861;
+	i1 v515 = (i1)+0;
+	i8 v516 = (i8)(intptr_t)(ws+816);
+	i8 v517 = *(i8*)(intptr_t)v516;
+	i8 v518 = v517+(+6);
+	*(i1*)(intptr_t)v518 = v515;
 
 endsub:;
 }
 
-// fcb_i_blockout workspace at ws+824 length ws+28
-void f39(i8 p865 /* fcb */) {
-	*(i8*)(intptr_t)(ws+824) = p865; /*fcb */
+// fcb_i_blockout workspace at ws+816 length ws+28
+void f37(i8 p519 /* fcb */) {
+	*(i8*)(intptr_t)(ws+816) = p519; /*fcb */
 
-	i8 v866 = (i8)(intptr_t)(ws+824);
-	i8 v867 = *(i8*)(intptr_t)v866;
-	i8 v868 = v867+(+6);
-	i1 v869 = *(i1*)(intptr_t)v868;
-	i1 v870 = (i1)+0;
-	if (v869==v870) goto c02_00de; else goto c02_00dd;
+	i8 v520 = (i8)(intptr_t)(ws+816);
+	i8 v521 = *(i8*)(intptr_t)v520;
+	i8 v522 = v521+(+6);
+	i1 v523 = *(i1*)(intptr_t)v522;
+	i1 v524 = (i1)+0;
+	if (v523==v524) goto c02_008d; else goto c02_008c;
 
-c02_00dd:;
+c02_008c:;
 
-	i8 v871 = (i8)(intptr_t)(ws+824);
-	i8 v872 = *(i8*)(intptr_t)v871;
-	i4 v873 = *(i4*)(intptr_t)v872;
-	i8 v874 = (i8)(intptr_t)(ws+832);
-	*(i4*)(intptr_t)v874 = v873;
+	i8 v525 = (i8)(intptr_t)(ws+816);
+	i8 v526 = *(i8*)(intptr_t)v525;
+	i4 v527 = *(i4*)(intptr_t)v526;
+	i8 v528 = (i8)(intptr_t)(ws+824);
+	*(i4*)(intptr_t)v528 = v527;
 
-	i8 v875 = (i8)(intptr_t)(ws+824);
-	i8 v876 = *(i8*)(intptr_t)v875;
-	i8 v877 = v876+(+12);
-	i8 v878 = (i8)(intptr_t)(ws+840);
-	*(i8*)(intptr_t)v878 = v877;
+	i8 v529 = (i8)(intptr_t)(ws+816);
+	i8 v530 = *(i8*)(intptr_t)v529;
+	i8 v531 = v530+(+12);
+	i8 v532 = (i8)(intptr_t)(ws+832);
+	*(i8*)(intptr_t)v532 = v531;
 
-	i8 v879 = (i8)(intptr_t)(ws+824);
-	i8 v880 = *(i8*)(intptr_t)v879;
-	i8 v881 = v880+(+8);
-	i4 v882 = *(i4*)(intptr_t)v881;
-	i1 v883 = (i1)+9;
-	i4 v884 = ((i4)v882)<<v883;
-	i8 v885 = (i8)(intptr_t)(ws+848);
-	*(i4*)(intptr_t)v885 = v884;
+	i8 v533 = (i8)(intptr_t)(ws+816);
+	i8 v534 = *(i8*)(intptr_t)v533;
+	i8 v535 = v534+(+8);
+	i4 v536 = *(i4*)(intptr_t)v535;
+	i1 v537 = (i1)+9;
+	i4 v538 = ((i4)v536)<<v537;
+	i8 v539 = (i8)(intptr_t)(ws+840);
+	*(i4*)(intptr_t)v539 = v538;
 
 	
 pwrite( 
-*(i4*)(intptr_t)(ws+832) 
+*(i4*)(intptr_t)(ws+824) 
 , (void*)(intptr_t) 
-*(i8*)(intptr_t)(ws+840) 
+*(i8*)(intptr_t)(ws+832) 
 ,  
 (+512)
 ,  
-*(i4*)(intptr_t)(ws+848) 
+*(i4*)(intptr_t)(ws+840) 
 ); 
 
 
-	i1 v886 = (i1)+0;
-	i8 v887 = (i8)(intptr_t)(ws+824);
-	i8 v888 = *(i8*)(intptr_t)v887;
-	i8 v889 = v888+(+6);
-	*(i1*)(intptr_t)v889 = v886;
+	i1 v540 = (i1)+0;
+	i8 v541 = (i8)(intptr_t)(ws+816);
+	i8 v542 = *(i8*)(intptr_t)v541;
+	i8 v543 = v542+(+6);
+	*(i1*)(intptr_t)v543 = v540;
 
-	goto c02_00da;
+	goto c02_0089;
 
-c02_00de:;
+c02_008d:;
 
-c02_00da:;
-
-endsub:;
-}
-
-// fcb_i_changeblock workspace at ws+808 length ws+12
-void f40(i4 p890 /* newblock */, i8 p891 /* fcb */) {
-	*(i8*)(intptr_t)(ws+808) = p891; /*fcb */
-	*(i4*)(intptr_t)(ws+816) = p890; /*newblock */
-
-	i8 v892 = (i8)(intptr_t)(ws+816);
-	i4 v893 = *(i4*)(intptr_t)v892;
-	i8 v894 = (i8)(intptr_t)(ws+808);
-	i8 v895 = *(i8*)(intptr_t)v894;
-	i8 v896 = v895+(+8);
-	i4 v897 = *(i4*)(intptr_t)v896;
-	if (v893==v897) goto c02_00e3; else goto c02_00e2;
-
-c02_00e2:;
-
-	i8 v898 = (i8)(intptr_t)(ws+808);
-	i8 v899 = *(i8*)(intptr_t)v898;
-	f39(v899);
-
-	i8 v900 = (i8)(intptr_t)(ws+816);
-	i4 v901 = *(i4*)(intptr_t)v900;
-	i8 v902 = (i8)(intptr_t)(ws+808);
-	i8 v903 = *(i8*)(intptr_t)v902;
-	i8 v904 = v903+(+8);
-	*(i4*)(intptr_t)v904 = v901;
-
-	i8 v905 = (i8)(intptr_t)(ws+808);
-	i8 v906 = *(i8*)(intptr_t)v905;
-	f38(v906);
-
-	goto c02_00df;
-
-c02_00e3:;
-
-c02_00df:;
+c02_0089:;
 
 endsub:;
 }
 
-// fcb_i_open workspace at ws+752 length ws+28
-void f41(i1* p907 /* errno */, i4 p908 /* flags */, i8 p909 /* filename */, i8 p910 /* fcb */) {
-	*(i8*)(intptr_t)(ws+752) = p910; /*fcb */
-	*(i8*)(intptr_t)(ws+760) = p909; /*filename */
-	*(i4*)(intptr_t)(ws+768) = p908; /*flags */
+// fcb_i_changeblock workspace at ws+800 length ws+12
+void f38(i4 p544 /* newblock */, i8 p545 /* fcb */) {
+	*(i8*)(intptr_t)(ws+800) = p545; /*fcb */
+	*(i4*)(intptr_t)(ws+808) = p544; /*newblock */
 
-	i8 v911 = (i8)(intptr_t)(ws+752);
-	i8 v912 = *(i8*)(intptr_t)v911;
-	i1 v913 = (i1)+0;
-	i8 v914 = (i8)+524;
-	f7(v914, v913, v912);
+	i8 v546 = (i8)(intptr_t)(ws+808);
+	i4 v547 = *(i4*)(intptr_t)v546;
+	i8 v548 = (i8)(intptr_t)(ws+800);
+	i8 v549 = *(i8*)(intptr_t)v548;
+	i8 v550 = v549+(+8);
+	i4 v551 = *(i4*)(intptr_t)v550;
+	if (v547==v551) goto c02_0092; else goto c02_0091;
 
-	i2 v915 = (i2)+511;
-	i8 v916 = (i8)(intptr_t)(ws+752);
-	i8 v917 = *(i8*)(intptr_t)v916;
-	i8 v918 = v917+(+4);
-	*(i2*)(intptr_t)v918 = v915;
+c02_0091:;
 
-	i4 v919 = (i4)-1;
-	i8 v920 = (i8)(intptr_t)(ws+752);
-	i8 v921 = *(i8*)(intptr_t)v920;
-	i8 v922 = v921+(+8);
-	*(i4*)(intptr_t)v922 = v919;
+	i8 v552 = (i8)(intptr_t)(ws+800);
+	i8 v553 = *(i8*)(intptr_t)v552;
+	f37(v553);
+
+	i8 v554 = (i8)(intptr_t)(ws+808);
+	i4 v555 = *(i4*)(intptr_t)v554;
+	i8 v556 = (i8)(intptr_t)(ws+800);
+	i8 v557 = *(i8*)(intptr_t)v556;
+	i8 v558 = v557+(+8);
+	*(i4*)(intptr_t)v558 = v555;
+
+	i8 v559 = (i8)(intptr_t)(ws+800);
+	i8 v560 = *(i8*)(intptr_t)v559;
+	f36(v560);
+
+	goto c02_008e;
+
+c02_0092:;
+
+c02_008e:;
+
+endsub:;
+}
+
+// fcb_i_open workspace at ws+744 length ws+28
+void f39(i1* p561 /* errno */, i4 p562 /* flags */, i8 p563 /* filename */, i8 p564 /* fcb */) {
+	*(i8*)(intptr_t)(ws+744) = p564; /*fcb */
+	*(i8*)(intptr_t)(ws+752) = p563; /*filename */
+	*(i4*)(intptr_t)(ws+760) = p562; /*flags */
+
+	i8 v565 = (i8)(intptr_t)(ws+744);
+	i8 v566 = *(i8*)(intptr_t)v565;
+	i1 v567 = (i1)+0;
+	i8 v568 = (i8)+524;
+	f7(v568, v567, v566);
+
+	i2 v569 = (i2)+511;
+	i8 v570 = (i8)(intptr_t)(ws+744);
+	i8 v571 = *(i8*)(intptr_t)v570;
+	i8 v572 = v571+(+4);
+	*(i2*)(intptr_t)v572 = v569;
+
+	i4 v573 = (i4)-1;
+	i8 v574 = (i8)(intptr_t)(ws+744);
+	i8 v575 = *(i8*)(intptr_t)v574;
+	i8 v576 = v575+(+8);
+	*(i4*)(intptr_t)v576 = v573;
 
 	
 errno = 0; 
 
 
 	
-*(i4*)(intptr_t)(ws+776) 
- = open((char*)(intptr_t) 
-*(i8*)(intptr_t)(ws+760) 
-,  
 *(i4*)(intptr_t)(ws+768) 
+ = open((char*)(intptr_t) 
+*(i8*)(intptr_t)(ws+752) 
+,  
+*(i4*)(intptr_t)(ws+760) 
 ,  
 (+438)
 ); 
 
 
-	i8 v923 = (i8)(intptr_t)(ws+776);
-	i4 v924 = *(i4*)(intptr_t)v923;
-	i8 v925 = (i8)(intptr_t)(ws+752);
-	i8 v926 = *(i8*)(intptr_t)v925;
-	*(i4*)(intptr_t)v926 = v924;
+	i8 v577 = (i8)(intptr_t)(ws+768);
+	i4 v578 = *(i4*)(intptr_t)v577;
+	i8 v579 = (i8)(intptr_t)(ws+744);
+	i8 v580 = *(i8*)(intptr_t)v579;
+	*(i4*)(intptr_t)v580 = v578;
 
-	i8 v927 = (i8)(intptr_t)(ws+776);
-	i4 v928 = *(i4*)(intptr_t)v927;
-	i4 v929 = (i4)+0;
-	if ((s4)v928<(s4)v929) goto c02_00e7; else goto c02_00e8;
+	i8 v581 = (i8)(intptr_t)(ws+768);
+	i4 v582 = *(i4*)(intptr_t)v581;
+	i4 v583 = (i4)+0;
+	if ((s4)v582<(s4)v583) goto c02_0096; else goto c02_0097;
 
-c02_00e7:;
+c02_0096:;
 
 	
-*(i1*)(intptr_t)(ws+772) 
+*(i1*)(intptr_t)(ws+764) 
  = errno; 
 
 
-	goto c02_00e4;
+	goto c02_0093;
 
-c02_00e8:;
+c02_0097:;
 
-	i1 v930 = (i1)+0;
-	i8 v931 = (i8)(intptr_t)(ws+772);
-	*(i1*)(intptr_t)v931 = v930;
+	i1 v584 = (i1)+0;
+	i8 v585 = (i8)(intptr_t)(ws+764);
+	*(i1*)(intptr_t)v585 = v584;
 
-c02_00e4:;
-
-endsub:;
-	*p907 = *(i1*)(intptr_t)(ws+772);
-}
-
-// FCBOpenIn workspace at ws+728 length ws+17
-void f42(i1* p932 /* errno */, i8 p933 /* filename */, i8 p934 /* fcb */) {
-	*(i8*)(intptr_t)(ws+728) = p934; /*fcb */
-	*(i8*)(intptr_t)(ws+736) = p933; /*filename */
-
-	i8 v935 = (i8)(intptr_t)(ws+728);
-	i8 v936 = *(i8*)(intptr_t)v935;
-	i8 v937 = (i8)(intptr_t)(ws+736);
-	i8 v938 = *(i8*)(intptr_t)v937;
-	i4 v939 = (i4)+0;
-	i1 v940;
-	f41(&v940, v939, v938, v936);
-	i8 v941 = (i8)(intptr_t)(ws+744);
-	*(i1*)(intptr_t)v941 = v940;
+c02_0093:;
 
 endsub:;
-	*p932 = *(i1*)(intptr_t)(ws+744);
+	*p561 = *(i1*)(intptr_t)(ws+764);
 }
 
-// FCBOpenOut workspace at ws+648 length ws+17
-void f44(i1* p952 /* errno */, i8 p953 /* filename */, i8 p954 /* fcb */) {
-	*(i8*)(intptr_t)(ws+648) = p954; /*fcb */
-	*(i8*)(intptr_t)(ws+656) = p953; /*filename */
+// FCBOpenIn workspace at ws+720 length ws+17
+void f40(i1* p586 /* errno */, i8 p587 /* filename */, i8 p588 /* fcb */) {
+	*(i8*)(intptr_t)(ws+720) = p588; /*fcb */
+	*(i8*)(intptr_t)(ws+728) = p587; /*filename */
 
-	i8 v955 = (i8)(intptr_t)(ws+648);
-	i8 v956 = *(i8*)(intptr_t)v955;
-	i8 v957 = (i8)(intptr_t)(ws+656);
-	i8 v958 = *(i8*)(intptr_t)v957;
-	i4 v959 = (i4)+578;
-	i1 v960;
-	f41(&v960, v959, v958, v956);
-	i8 v961 = (i8)(intptr_t)(ws+664);
-	*(i1*)(intptr_t)v961 = v960;
+	i8 v589 = (i8)(intptr_t)(ws+720);
+	i8 v590 = *(i8*)(intptr_t)v589;
+	i8 v591 = (i8)(intptr_t)(ws+728);
+	i8 v592 = *(i8*)(intptr_t)v591;
+	i4 v593 = (i4)+0;
+	i1 v594;
+	f39(&v594, v593, v592, v590);
+	i8 v595 = (i8)(intptr_t)(ws+736);
+	*(i1*)(intptr_t)v595 = v594;
 
 endsub:;
-	*p952 = *(i1*)(intptr_t)(ws+664);
+	*p586 = *(i1*)(intptr_t)(ws+736);
 }
 
-// FCBClose workspace at ws+640 length ws+16
-void f45(i1* p962 /* errno */, i8 p963 /* fcb */) {
-	*(i8*)(intptr_t)(ws+640) = p963; /*fcb */
+// FCBOpenOut workspace at ws+640 length ws+17
+void f42(i1* p606 /* errno */, i8 p607 /* filename */, i8 p608 /* fcb */) {
+	*(i8*)(intptr_t)(ws+640) = p608; /*fcb */
+	*(i8*)(intptr_t)(ws+648) = p607; /*filename */
 
-	i8 v964 = (i8)(intptr_t)(ws+640);
-	i8 v965 = *(i8*)(intptr_t)v964;
-	f39(v965);
+	i8 v609 = (i8)(intptr_t)(ws+640);
+	i8 v610 = *(i8*)(intptr_t)v609;
+	i8 v611 = (i8)(intptr_t)(ws+648);
+	i8 v612 = *(i8*)(intptr_t)v611;
+	i4 v613 = (i4)+578;
+	i1 v614;
+	f39(&v614, v613, v612, v610);
+	i8 v615 = (i8)(intptr_t)(ws+656);
+	*(i1*)(intptr_t)v615 = v614;
 
-	i8 v966 = (i8)(intptr_t)(ws+640);
-	i8 v967 = *(i8*)(intptr_t)v966;
-	i4 v968 = *(i4*)(intptr_t)v967;
-	i8 v969 = (i8)(intptr_t)(ws+652);
-	*(i4*)(intptr_t)v969 = v968;
+endsub:;
+	*p606 = *(i1*)(intptr_t)(ws+656);
+}
+
+// FCBClose workspace at ws+632 length ws+16
+void f43(i1* p616 /* errno */, i8 p617 /* fcb */) {
+	*(i8*)(intptr_t)(ws+632) = p617; /*fcb */
+
+	i8 v618 = (i8)(intptr_t)(ws+632);
+	i8 v619 = *(i8*)(intptr_t)v618;
+	f37(v619);
+
+	i8 v620 = (i8)(intptr_t)(ws+632);
+	i8 v621 = *(i8*)(intptr_t)v620;
+	i4 v622 = *(i4*)(intptr_t)v621;
+	i8 v623 = (i8)(intptr_t)(ws+644);
+	*(i4*)(intptr_t)v623 = v622;
 
 	
 errno = 0; 
@@ -1291,231 +965,231 @@ errno = 0;
 
 	
 close( 
-*(i4*)(intptr_t)(ws+652) 
+*(i4*)(intptr_t)(ws+644) 
 ); 
 
 
 	
-*(i1*)(intptr_t)(ws+648) 
+*(i1*)(intptr_t)(ws+640) 
  = errno; 
 
 
 endsub:;
-	*p962 = *(i1*)(intptr_t)(ws+648);
+	*p616 = *(i1*)(intptr_t)(ws+640);
 }
 
-// FCBSeek workspace at ws+728 length ws+18
-void f46(i4 p970 /* pos */, i8 p971 /* fcb */) {
-	*(i8*)(intptr_t)(ws+728) = p971; /*fcb */
-	*(i4*)(intptr_t)(ws+736) = p970; /*pos */
+// FCBSeek workspace at ws+720 length ws+18
+void f44(i4 p624 /* pos */, i8 p625 /* fcb */) {
+	*(i8*)(intptr_t)(ws+720) = p625; /*fcb */
+	*(i4*)(intptr_t)(ws+728) = p624; /*pos */
 
-	i8 v972 = (i8)(intptr_t)(ws+736);
-	i4 v973 = *(i4*)(intptr_t)v972;
-	i4 v974 = v973+(-1);
-	i8 v975 = (i8)(intptr_t)(ws+736);
-	*(i4*)(intptr_t)v975 = v974;
+	i8 v626 = (i8)(intptr_t)(ws+728);
+	i4 v627 = *(i4*)(intptr_t)v626;
+	i4 v628 = v627+(-1);
+	i8 v629 = (i8)(intptr_t)(ws+728);
+	*(i4*)(intptr_t)v629 = v628;
 
-	i8 v976 = (i8)(intptr_t)(ws+736);
-	i4 v977 = *(i4*)(intptr_t)v976;
-	i1 v978 = (i1)+9;
-	i4 v979 = ((i4)v977)>>v978;
-	i8 v980 = (i8)(intptr_t)(ws+740);
-	*(i4*)(intptr_t)v980 = v979;
+	i8 v630 = (i8)(intptr_t)(ws+728);
+	i4 v631 = *(i4*)(intptr_t)v630;
+	i1 v632 = (i1)+9;
+	i4 v633 = ((i4)v631)>>v632;
+	i8 v634 = (i8)(intptr_t)(ws+732);
+	*(i4*)(intptr_t)v634 = v633;
 
-	i8 v981 = (i8)(intptr_t)(ws+736);
-	i4 v982 = *(i4*)(intptr_t)v981;
-	i2 v983 = v982;
-	i2 v984 = v983&(+511);
-	i8 v985 = (i8)(intptr_t)(ws+744);
-	*(i2*)(intptr_t)v985 = v984;
+	i8 v635 = (i8)(intptr_t)(ws+728);
+	i4 v636 = *(i4*)(intptr_t)v635;
+	i2 v637 = v636;
+	i2 v638 = v637&(+511);
+	i8 v639 = (i8)(intptr_t)(ws+736);
+	*(i2*)(intptr_t)v639 = v638;
 
-	i8 v986 = (i8)(intptr_t)(ws+728);
-	i8 v987 = *(i8*)(intptr_t)v986;
-	i8 v988 = (i8)(intptr_t)(ws+740);
-	i4 v989 = *(i4*)(intptr_t)v988;
-	f40(v989, v987);
+	i8 v640 = (i8)(intptr_t)(ws+720);
+	i8 v641 = *(i8*)(intptr_t)v640;
+	i8 v642 = (i8)(intptr_t)(ws+732);
+	i4 v643 = *(i4*)(intptr_t)v642;
+	f38(v643, v641);
 
-	i8 v990 = (i8)(intptr_t)(ws+744);
-	i2 v991 = *(i2*)(intptr_t)v990;
-	i8 v992 = (i8)(intptr_t)(ws+728);
-	i8 v993 = *(i8*)(intptr_t)v992;
-	i8 v994 = v993+(+4);
-	*(i2*)(intptr_t)v994 = v991;
+	i8 v644 = (i8)(intptr_t)(ws+736);
+	i2 v645 = *(i2*)(intptr_t)v644;
+	i8 v646 = (i8)(intptr_t)(ws+720);
+	i8 v647 = *(i8*)(intptr_t)v646;
+	i8 v648 = v647+(+4);
+	*(i2*)(intptr_t)v648 = v645;
 
 endsub:;
 }
 
-// FCBPos workspace at ws+768 length ws+12
-void f47(i4* p995 /* pos */, i8 p996 /* fcb */) {
-	*(i8*)(intptr_t)(ws+768) = p996; /*fcb */
+// FCBPos workspace at ws+760 length ws+12
+void f45(i4* p649 /* pos */, i8 p650 /* fcb */) {
+	*(i8*)(intptr_t)(ws+760) = p650; /*fcb */
 
-	i8 v997 = (i8)(intptr_t)(ws+768);
-	i8 v998 = *(i8*)(intptr_t)v997;
-	i8 v999 = v998+(+8);
-	i4 v1000 = *(i4*)(intptr_t)v999;
-	i1 v1001 = (i1)+9;
-	i4 v1002 = ((i4)v1000)<<v1001;
-	i8 v1003 = (i8)(intptr_t)(ws+768);
-	i8 v1004 = *(i8*)(intptr_t)v1003;
-	i8 v1005 = v1004+(+4);
-	i2 v1006 = *(i2*)(intptr_t)v1005;
-	i4 v1007 = v1006;
-	i4 v1008 = v1002|v1007;
-	i4 v1009 = v1008+(+1);
-	i8 v1010 = (i8)(intptr_t)(ws+776);
-	*(i4*)(intptr_t)v1010 = v1009;
+	i8 v651 = (i8)(intptr_t)(ws+760);
+	i8 v652 = *(i8*)(intptr_t)v651;
+	i8 v653 = v652+(+8);
+	i4 v654 = *(i4*)(intptr_t)v653;
+	i1 v655 = (i1)+9;
+	i4 v656 = ((i4)v654)<<v655;
+	i8 v657 = (i8)(intptr_t)(ws+760);
+	i8 v658 = *(i8*)(intptr_t)v657;
+	i8 v659 = v658+(+4);
+	i2 v660 = *(i2*)(intptr_t)v659;
+	i4 v661 = v660;
+	i4 v662 = v656|v661;
+	i4 v663 = v662+(+1);
+	i8 v664 = (i8)(intptr_t)(ws+768);
+	*(i4*)(intptr_t)v664 = v663;
 
 endsub:;
-	*p995 = *(i4*)(intptr_t)(ws+776);
+	*p649 = *(i4*)(intptr_t)(ws+768);
 }
 
-// FCBExt workspace at ws+664 length ws+16
-void f48(i4* p1011 /* len */, i8 p1012 /* fcb */) {
-	*(i8*)(intptr_t)(ws+664) = p1012; /*fcb */
+// FCBExt workspace at ws+656 length ws+16
+void f46(i4* p665 /* len */, i8 p666 /* fcb */) {
+	*(i8*)(intptr_t)(ws+656) = p666; /*fcb */
 
-	i8 v1013 = (i8)(intptr_t)(ws+664);
-	i8 v1014 = *(i8*)(intptr_t)v1013;
-	f39(v1014);
+	i8 v667 = (i8)(intptr_t)(ws+656);
+	i8 v668 = *(i8*)(intptr_t)v667;
+	f37(v668);
 
-	i8 v1015 = (i8)(intptr_t)(ws+664);
-	i8 v1016 = *(i8*)(intptr_t)v1015;
-	i4 v1017 = *(i4*)(intptr_t)v1016;
-	i8 v1018 = (i8)(intptr_t)(ws+676);
-	*(i4*)(intptr_t)v1018 = v1017;
+	i8 v669 = (i8)(intptr_t)(ws+656);
+	i8 v670 = *(i8*)(intptr_t)v669;
+	i4 v671 = *(i4*)(intptr_t)v670;
+	i8 v672 = (i8)(intptr_t)(ws+668);
+	*(i4*)(intptr_t)v672 = v671;
 
 	
-*(i4*)(intptr_t)(ws+672) 
+*(i4*)(intptr_t)(ws+664) 
  = lseek( 
-*(i4*)(intptr_t)(ws+676) 
+*(i4*)(intptr_t)(ws+668) 
 , 0, SEEK_END); 
 
 
-	i8 v1019 = (i8)(intptr_t)(ws+672);
-	i4 v1020 = *(i4*)(intptr_t)v1019;
-	i4 v1021 = v1020+(+511);
-	i4 v1022 = v1021&(-512);
-	i8 v1023 = (i8)(intptr_t)(ws+672);
-	*(i4*)(intptr_t)v1023 = v1022;
+	i8 v673 = (i8)(intptr_t)(ws+664);
+	i4 v674 = *(i4*)(intptr_t)v673;
+	i4 v675 = v674+(+511);
+	i4 v676 = v675&(-512);
+	i8 v677 = (i8)(intptr_t)(ws+664);
+	*(i4*)(intptr_t)v677 = v676;
 
 endsub:;
-	*p1011 = *(i4*)(intptr_t)(ws+672);
+	*p665 = *(i4*)(intptr_t)(ws+664);
 }
 
-// fcb_i_nextchar workspace at ws+800 length ws+8
-void f49(i8 p1024 /* fcb */) {
-	*(i8*)(intptr_t)(ws+800) = p1024; /*fcb */
+// fcb_i_nextchar workspace at ws+792 length ws+8
+void f47(i8 p678 /* fcb */) {
+	*(i8*)(intptr_t)(ws+792) = p678; /*fcb */
 
-	i8 v1025 = (i8)(intptr_t)(ws+800);
-	i8 v1026 = *(i8*)(intptr_t)v1025;
-	i8 v1027 = v1026+(+4);
-	i2 v1028 = *(i2*)(intptr_t)v1027;
-	i2 v1029 = v1028+(+1);
-	i8 v1030 = (i8)(intptr_t)(ws+800);
-	i8 v1031 = *(i8*)(intptr_t)v1030;
-	i8 v1032 = v1031+(+4);
-	*(i2*)(intptr_t)v1032 = v1029;
+	i8 v679 = (i8)(intptr_t)(ws+792);
+	i8 v680 = *(i8*)(intptr_t)v679;
+	i8 v681 = v680+(+4);
+	i2 v682 = *(i2*)(intptr_t)v681;
+	i2 v683 = v682+(+1);
+	i8 v684 = (i8)(intptr_t)(ws+792);
+	i8 v685 = *(i8*)(intptr_t)v684;
+	i8 v686 = v685+(+4);
+	*(i2*)(intptr_t)v686 = v683;
 
-	i8 v1033 = (i8)(intptr_t)(ws+800);
-	i8 v1034 = *(i8*)(intptr_t)v1033;
-	i8 v1035 = v1034+(+4);
-	i2 v1036 = *(i2*)(intptr_t)v1035;
-	i2 v1037 = (i2)+512;
-	if (v1036==v1037) goto c02_00ec; else goto c02_00ed;
+	i8 v687 = (i8)(intptr_t)(ws+792);
+	i8 v688 = *(i8*)(intptr_t)v687;
+	i8 v689 = v688+(+4);
+	i2 v690 = *(i2*)(intptr_t)v689;
+	i2 v691 = (i2)+512;
+	if (v690==v691) goto c02_009b; else goto c02_009c;
 
-c02_00ec:;
+c02_009b:;
 
-	i8 v1038 = (i8)(intptr_t)(ws+800);
-	i8 v1039 = *(i8*)(intptr_t)v1038;
-	i8 v1040 = (i8)(intptr_t)(ws+800);
-	i8 v1041 = *(i8*)(intptr_t)v1040;
-	i8 v1042 = v1041+(+8);
-	i4 v1043 = *(i4*)(intptr_t)v1042;
-	i4 v1044 = v1043+(+1);
-	f40(v1044, v1039);
+	i8 v692 = (i8)(intptr_t)(ws+792);
+	i8 v693 = *(i8*)(intptr_t)v692;
+	i8 v694 = (i8)(intptr_t)(ws+792);
+	i8 v695 = *(i8*)(intptr_t)v694;
+	i8 v696 = v695+(+8);
+	i4 v697 = *(i4*)(intptr_t)v696;
+	i4 v698 = v697+(+1);
+	f38(v698, v693);
 
-	i2 v1045 = (i2)+0;
-	i8 v1046 = (i8)(intptr_t)(ws+800);
-	i8 v1047 = *(i8*)(intptr_t)v1046;
-	i8 v1048 = v1047+(+4);
-	*(i2*)(intptr_t)v1048 = v1045;
+	i2 v699 = (i2)+0;
+	i8 v700 = (i8)(intptr_t)(ws+792);
+	i8 v701 = *(i8*)(intptr_t)v700;
+	i8 v702 = v701+(+4);
+	*(i2*)(intptr_t)v702 = v699;
 
-	goto c02_00e9;
+	goto c02_0098;
 
-c02_00ed:;
+c02_009c:;
 
-c02_00e9:;
-
-endsub:;
-}
-
-// FCBGetChar workspace at ws+784 length ws+9
-void f50(i1* p1049 /* c */, i8 p1050 /* fcb */) {
-	*(i8*)(intptr_t)(ws+784) = p1050; /*fcb */
-
-	i8 v1051 = (i8)(intptr_t)(ws+784);
-	i8 v1052 = *(i8*)(intptr_t)v1051;
-	f49(v1052);
-
-	i8 v1053 = (i8)(intptr_t)(ws+784);
-	i8 v1054 = *(i8*)(intptr_t)v1053;
-	i8 v1055 = v1054+(+12);
-	i8 v1056 = (i8)(intptr_t)(ws+784);
-	i8 v1057 = *(i8*)(intptr_t)v1056;
-	i8 v1058 = v1057+(+4);
-	i2 v1059 = *(i2*)(intptr_t)v1058;
-	i8 v1060 = v1059;
-	i8 v1061 = v1055+v1060;
-	i1 v1062 = *(i1*)(intptr_t)v1061;
-	i8 v1063 = (i8)(intptr_t)(ws+792);
-	*(i1*)(intptr_t)v1063 = v1062;
-
-endsub:;
-	*p1049 = *(i1*)(intptr_t)(ws+792);
-}
-
-// FCBPutChar workspace at ws+768 length ws+9
-void f51(i1 p1064 /* c */, i8 p1065 /* fcb */) {
-	*(i8*)(intptr_t)(ws+768) = p1065; /*fcb */
-	*(i1*)(intptr_t)(ws+776) = p1064; /*c */
-
-	i8 v1066 = (i8)(intptr_t)(ws+768);
-	i8 v1067 = *(i8*)(intptr_t)v1066;
-	f49(v1067);
-
-	i8 v1068 = (i8)(intptr_t)(ws+776);
-	i1 v1069 = *(i1*)(intptr_t)v1068;
-	i8 v1070 = (i8)(intptr_t)(ws+768);
-	i8 v1071 = *(i8*)(intptr_t)v1070;
-	i8 v1072 = v1071+(+12);
-	i8 v1073 = (i8)(intptr_t)(ws+768);
-	i8 v1074 = *(i8*)(intptr_t)v1073;
-	i8 v1075 = v1074+(+4);
-	i2 v1076 = *(i2*)(intptr_t)v1075;
-	i8 v1077 = v1076;
-	i8 v1078 = v1072+v1077;
-	*(i1*)(intptr_t)v1078 = v1069;
-
-	i1 v1079 = (i1)+1;
-	i8 v1080 = (i8)(intptr_t)(ws+768);
-	i8 v1081 = *(i8*)(intptr_t)v1080;
-	i8 v1082 = v1081+(+6);
-	*(i1*)(intptr_t)v1082 = v1079;
-
-endsub:;
-}
-const i1 c02_s0009[] = { 0x65,0x72,0x72,0x6f,0x72,0x3a,0x20,0 };
-
-// StartError workspace at ws+768 length ws+0
-void f55(void) {
-
-	i8 v1144 = (i8)(intptr_t)c02_s0009;
-	f11(v1144);
+c02_0098:;
 
 endsub:;
 }
 
-// EndError workspace at ws+768 length ws+0
-void f56(void) {
+// FCBGetChar workspace at ws+776 length ws+9
+void f48(i1* p703 /* c */, i8 p704 /* fcb */) {
+	*(i8*)(intptr_t)(ws+776) = p704; /*fcb */
+
+	i8 v705 = (i8)(intptr_t)(ws+776);
+	i8 v706 = *(i8*)(intptr_t)v705;
+	f47(v706);
+
+	i8 v707 = (i8)(intptr_t)(ws+776);
+	i8 v708 = *(i8*)(intptr_t)v707;
+	i8 v709 = v708+(+12);
+	i8 v710 = (i8)(intptr_t)(ws+776);
+	i8 v711 = *(i8*)(intptr_t)v710;
+	i8 v712 = v711+(+4);
+	i2 v713 = *(i2*)(intptr_t)v712;
+	i8 v714 = v713;
+	i8 v715 = v709+v714;
+	i1 v716 = *(i1*)(intptr_t)v715;
+	i8 v717 = (i8)(intptr_t)(ws+784);
+	*(i1*)(intptr_t)v717 = v716;
+
+endsub:;
+	*p703 = *(i1*)(intptr_t)(ws+784);
+}
+
+// FCBPutChar workspace at ws+760 length ws+9
+void f49(i1 p718 /* c */, i8 p719 /* fcb */) {
+	*(i8*)(intptr_t)(ws+760) = p719; /*fcb */
+	*(i1*)(intptr_t)(ws+768) = p718; /*c */
+
+	i8 v720 = (i8)(intptr_t)(ws+760);
+	i8 v721 = *(i8*)(intptr_t)v720;
+	f47(v721);
+
+	i8 v722 = (i8)(intptr_t)(ws+768);
+	i1 v723 = *(i1*)(intptr_t)v722;
+	i8 v724 = (i8)(intptr_t)(ws+760);
+	i8 v725 = *(i8*)(intptr_t)v724;
+	i8 v726 = v725+(+12);
+	i8 v727 = (i8)(intptr_t)(ws+760);
+	i8 v728 = *(i8*)(intptr_t)v727;
+	i8 v729 = v728+(+4);
+	i2 v730 = *(i2*)(intptr_t)v729;
+	i8 v731 = v730;
+	i8 v732 = v726+v731;
+	*(i1*)(intptr_t)v732 = v723;
+
+	i1 v733 = (i1)+1;
+	i8 v734 = (i8)(intptr_t)(ws+760);
+	i8 v735 = *(i8*)(intptr_t)v734;
+	i8 v736 = v735+(+6);
+	*(i1*)(intptr_t)v736 = v733;
+
+endsub:;
+}
+const i1 c02_s0000[] = { 0x65,0x72,0x72,0x6f,0x72,0x3a,0x20,0 };
+
+// StartError workspace at ws+760 length ws+0
+void f53(void) {
+
+	i8 v798 = (i8)(intptr_t)c02_s0000;
+	f11(v798);
+
+endsub:;
+}
+
+// EndError workspace at ws+760 length ws+0
+void f54(void) {
 
 	f12();
 
@@ -1524,2195 +1198,2793 @@ void f56(void) {
 endsub:;
 }
 
-// SimpleError workspace at ws+728 length ws+8
-void f57(i8 p1145 /* s */) {
-	*(i8*)(intptr_t)(ws+728) = p1145; /*s */
+// SimpleError workspace at ws+720 length ws+8
+void f55(i8 p799 /* s */) {
+	*(i8*)(intptr_t)(ws+720) = p799; /*s */
 
-	f55();
+	f53();
 
-	i8 v1146 = (i8)(intptr_t)(ws+728);
-	i8 v1147 = *(i8*)(intptr_t)v1146;
-	f11(v1147);
+	i8 v800 = (i8)(intptr_t)(ws+720);
+	i8 v801 = *(i8*)(intptr_t)v800;
+	f11(v801);
 
-	f56();
-
-endsub:;
-}
-const i1 c02_s000a[] = { 0x75,0x6e,0x61,0x62,0x6c,0x65,0x20,0x74,0x6f,0x20,0x6f,0x70,0x65,0x6e,0x20,0x27,0 };
-const i1 c02_s000b[] = { 0x27,0 };
-
-// CannotOpen workspace at ws+728 length ws+8
-void f58(i8 p1148 /* filename */) {
-	*(i8*)(intptr_t)(ws+728) = p1148; /*filename */
-
-	f55();
-
-	i8 v1149 = (i8)(intptr_t)c02_s000a;
-	f11(v1149);
-
-	i8 v1150 = (i8)(intptr_t)(ws+728);
-	i8 v1151 = *(i8*)(intptr_t)v1150;
-	f11(v1151);
-
-	i8 v1152 = (i8)(intptr_t)c02_s000b;
-	f11(v1152);
-
-	f56();
+	f54();
 
 endsub:;
 }
+const i1 c02_s0001[] = { 0x75,0x6e,0x61,0x62,0x6c,0x65,0x20,0x74,0x6f,0x20,0x6f,0x70,0x65,0x6e,0x20,0x27,0 };
+const i1 c02_s0002[] = { 0x27,0 };
 
-// EmitByte workspace at ws+760 length ws+1
-void f59(i1 p1153 /* c */) {
-	*(i1*)(intptr_t)(ws+760) = p1153; /*c */
+// CannotOpen workspace at ws+720 length ws+8
+void f56(i8 p802 /* filename */) {
+	*(i8*)(intptr_t)(ws+720) = p802; /*filename */
 
-	i8 v1154 = (i8)(intptr_t)(ws+52);
-	i8 v1155 = (i8)(intptr_t)(ws+760);
-	i1 v1156 = *(i1*)(intptr_t)v1155;
-	f51(v1156, v1154);
+	f53();
+
+	i8 v803 = (i8)(intptr_t)c02_s0001;
+	f11(v803);
+
+	i8 v804 = (i8)(intptr_t)(ws+720);
+	i8 v805 = *(i8*)(intptr_t)v804;
+	f11(v805);
+
+	i8 v806 = (i8)(intptr_t)c02_s0002;
+	f11(v806);
+
+	f54();
 
 endsub:;
 }
 
-// E workspace at ws+744 length ws+9
-void f60(i8 p1157 /* text */) {
-	*(i8*)(intptr_t)(ws+744) = p1157; /*text */
+// EmitByte workspace at ws+752 length ws+1
+void f57(i1 p807 /* c */) {
+	*(i1*)(intptr_t)(ws+752) = p807; /*c */
 
-c02_0101:;
+	i8 v808 = (i8)(intptr_t)(ws+44);
+	i8 v809 = (i8)(intptr_t)(ws+752);
+	i1 v810 = *(i1*)(intptr_t)v809;
+	f49(v810, v808);
 
-	i8 v1158 = (i8)(intptr_t)(ws+744);
-	i8 v1159 = *(i8*)(intptr_t)v1158;
-	i1 v1160 = *(i1*)(intptr_t)v1159;
-	i8 v1161 = (i8)(intptr_t)(ws+752);
-	*(i1*)(intptr_t)v1161 = v1160;
+endsub:;
+}
 
-	i8 v1162 = (i8)(intptr_t)(ws+744);
-	i8 v1163 = *(i8*)(intptr_t)v1162;
-	i8 v1164 = v1163+(+1);
-	i8 v1165 = (i8)(intptr_t)(ws+744);
-	*(i8*)(intptr_t)v1165 = v1164;
+// E workspace at ws+736 length ws+9
+void f58(i8 p811 /* text */) {
+	*(i8*)(intptr_t)(ws+736) = p811; /*text */
 
-	i8 v1166 = (i8)(intptr_t)(ws+752);
-	i1 v1167 = *(i1*)(intptr_t)v1166;
-	i1 v1168 = (i1)+0;
-	if (v1167==v1168) goto c02_0106; else goto c02_0107;
+c02_00b0:;
 
-c02_0106:;
+	i8 v812 = (i8)(intptr_t)(ws+736);
+	i8 v813 = *(i8*)(intptr_t)v812;
+	i1 v814 = *(i1*)(intptr_t)v813;
+	i8 v815 = (i8)(intptr_t)(ws+744);
+	*(i1*)(intptr_t)v815 = v814;
 
-	goto c02_0102;
+	i8 v816 = (i8)(intptr_t)(ws+736);
+	i8 v817 = *(i8*)(intptr_t)v816;
+	i8 v818 = v817+(+1);
+	i8 v819 = (i8)(intptr_t)(ws+736);
+	*(i8*)(intptr_t)v819 = v818;
 
-	goto c02_0103;
+	i8 v820 = (i8)(intptr_t)(ws+744);
+	i1 v821 = *(i1*)(intptr_t)v820;
+	i1 v822 = (i1)+0;
+	if (v821==v822) goto c02_00b5; else goto c02_00b6;
 
-c02_0107:;
+c02_00b5:;
 
-c02_0103:;
+	goto c02_00b1;
 
-	i8 v1169 = (i8)(intptr_t)(ws+752);
-	i1 v1170 = *(i1*)(intptr_t)v1169;
-	f59(v1170);
+	goto c02_00b2;
+
+c02_00b6:;
+
+c02_00b2:;
+
+	i8 v823 = (i8)(intptr_t)(ws+744);
+	i1 v824 = *(i1*)(intptr_t)v823;
+	f57(v824);
+
+	goto c02_00b0;
+
+c02_00b1:;
+
+endsub:;
+}
+
+// E_u32 workspace at ws+712 length ws+33
+void f59(i4 p825 /* value */) {
+	*(i4*)(intptr_t)(ws+712) = p825; /*value */
+
+	i8 v826 = (i8)(intptr_t)(ws+716);
+	i8 v827 = (i8)(intptr_t)(ws+728);
+	*(i8*)(intptr_t)v827 = v826;
+
+	i8 v828 = (i8)(intptr_t)(ws+712);
+	i4 v829 = *(i4*)(intptr_t)v828;
+	i1 v830 = (i1)+10;
+	i8 v831 = (i8)(intptr_t)(ws+728);
+	i8 v832 = *(i8*)(intptr_t)v831;
+	i8 v833;
+	f13(&v833, v832, v830, v829);
+	i8 v834 = (i8)(intptr_t)(ws+736);
+	*(i8*)(intptr_t)v834 = v833;
+
+c02_00b7:;
+
+	i8 v835 = (i8)(intptr_t)(ws+728);
+	i8 v836 = *(i8*)(intptr_t)v835;
+	i1 v837 = *(i1*)(intptr_t)v836;
+	i8 v838 = (i8)(intptr_t)(ws+744);
+	*(i1*)(intptr_t)v838 = v837;
+
+	i8 v839 = (i8)(intptr_t)(ws+744);
+	i1 v840 = *(i1*)(intptr_t)v839;
+	i1 v841 = (i1)+0;
+	if (v840==v841) goto c02_00bc; else goto c02_00bd;
+
+c02_00bc:;
+
+	goto c02_00b8;
+
+	goto c02_00b9;
+
+c02_00bd:;
+
+c02_00b9:;
+
+	i8 v842 = (i8)(intptr_t)(ws+744);
+	i1 v843 = *(i1*)(intptr_t)v842;
+	f57(v843);
+
+	i8 v844 = (i8)(intptr_t)(ws+728);
+	i8 v845 = *(i8*)(intptr_t)v844;
+	i8 v846 = v845+(+1);
+	i8 v847 = (i8)(intptr_t)(ws+728);
+	*(i8*)(intptr_t)v847 = v846;
+
+	goto c02_00b7;
+
+c02_00b8:;
+
+endsub:;
+}
+
+// E_u16 workspace at ws+704 length ws+2
+void f60(i2 p848 /* value */) {
+	*(i2*)(intptr_t)(ws+704) = p848; /*value */
+
+	i8 v849 = (i8)(intptr_t)(ws+704);
+	i2 v850 = *(i2*)(intptr_t)v849;
+	i4 v851 = v850;
+	f59(v851);
+
+endsub:;
+}
+
+// E_h workspace at ws+704 length ws+25
+void f63(i1 p868 /* width */, i4 p869 /* value */) {
+	*(i4*)(intptr_t)(ws+704) = p869; /*value */
+	*(i1*)(intptr_t)(ws+708) = p868; /*width */
+
+	i8 v870 = (i8)(intptr_t)(ws+704);
+	i4 v871 = *(i4*)(intptr_t)v870;
+	i1 v872 = (i1)+16;
+	i8 v873 = (i8)(intptr_t)(ws+709);
+	i8 v874;
+	f13(&v874, v873, v872, v871);
+	i8 v875 = (i8)(intptr_t)(ws+720);
+	*(i8*)(intptr_t)v875 = v874;
+
+	i8 v876 = (i8)(intptr_t)(ws+708);
+	i1 v877 = *(i1*)(intptr_t)v876;
+	i8 v878 = (i8)(intptr_t)(ws+720);
+	i8 v879 = *(i8*)(intptr_t)v878;
+	i8 v880 = (i8)(intptr_t)(ws+709);
+	i8 v881 = v879-v880;
+	i1 v882 = v881;
+	i1 v883 = v877-v882;
+	i8 v884 = (i8)(intptr_t)(ws+728);
+	*(i1*)(intptr_t)v884 = v883;
+
+c02_00c5:;
+
+	i8 v885 = (i8)(intptr_t)(ws+728);
+	i1 v886 = *(i1*)(intptr_t)v885;
+	i1 v887 = (i1)+0;
+	if (v886==v887) goto c02_00c8; else goto c02_00c7;
+
+c02_00c7:;
+
+	i1 v888 = (i1)+48;
+	f57(v888);
+
+	i8 v889 = (i8)(intptr_t)(ws+728);
+	i1 v890 = *(i1*)(intptr_t)v889;
+	i1 v891 = v890+(-1);
+	i8 v892 = (i8)(intptr_t)(ws+728);
+	*(i1*)(intptr_t)v892 = v891;
+
+	goto c02_00c5;
+
+c02_00c8:;
+
+	i8 v893 = (i8)(intptr_t)(ws+709);
+	f58(v893);
+
+endsub:;
+}
+
+// E_h8 workspace at ws+696 length ws+1
+void f64(i1 p894 /* value */) {
+	*(i1*)(intptr_t)(ws+696) = p894; /*value */
+
+	i8 v895 = (i8)(intptr_t)(ws+696);
+	i1 v896 = *(i1*)(intptr_t)v895;
+	i4 v897 = v896;
+	i1 v898 = (i1)+2;
+	f63(v898, v897);
+
+endsub:;
+}
+
+// E_h16 workspace at ws+640 length ws+2
+void f65(i2 p899 /* value */) {
+	*(i2*)(intptr_t)(ws+640) = p899; /*value */
+
+	i8 v900 = (i8)(intptr_t)(ws+640);
+	i2 v901 = *(i2*)(intptr_t)v900;
+	i4 v902 = v901;
+	i1 v903 = (i1)+4;
+	f63(v903, v902);
+
+endsub:;
+}
+const i1 c02_s0003[] = { 0x63,0x61,0x6e,0x6e,0x6f,0x74,0x20,0x6f,0x70,0x65,0x6e,0x20,0x6f,0x75,0x74,0x70,0x75,0x74,0x20,0x66,0x69,0x6c,0x65,0 };
+
+// EmitterOpenfile workspace at ws+632 length ws+8
+void f66(i8 p904 /* filename */) {
+	*(i8*)(intptr_t)(ws+632) = p904; /*filename */
+
+	i8 v905 = (i8)(intptr_t)(ws+44);
+	i8 v906 = (i8)(intptr_t)(ws+632);
+	i8 v907 = *(i8*)(intptr_t)v906;
+	i1 v908;
+	f42(&v908, v907, v905);
+	i1 v909 = (i1)+0;
+	if (v908==v909) goto c02_00cd; else goto c02_00cc;
+
+c02_00cc:;
+
+	i8 v910 = (i8)(intptr_t)c02_s0003;
+	f55(v910);
+
+	goto c02_00c9;
+
+c02_00cd:;
+
+c02_00c9:;
+
+endsub:;
+}
+const i1 c02_s0004[] = { 0x63,0x61,0x6e,0x6e,0x6f,0x74,0x20,0x63,0x6c,0x6f,0x73,0x65,0x20,0x6f,0x75,0x74,0x70,0x75,0x74,0x20,0x66,0x69,0x6c,0x65,0 };
+
+// EmitterClosefile workspace at ws+632 length ws+0
+void f67(void) {
+
+	i8 v911 = (i8)(intptr_t)(ws+44);
+	i1 v912;
+	f43(&v912, v911);
+	i1 v913 = (i1)+0;
+	if (v912==v913) goto c02_00d2; else goto c02_00d1;
+
+c02_00d1:;
+
+	i8 v914 = (i8)(intptr_t)c02_s0004;
+	f55(v914);
+
+	goto c02_00ce;
+
+c02_00d2:;
+
+c02_00ce:;
+
+endsub:;
+}
+
+// ArchAlignUp workspace at ws+3088 length ws+8
+void f68(i2* p915 /* newvalue */, i1 p916 /* alignment */, i2 p917 /* value */) {
+	*(i2*)(intptr_t)(ws+3088) = p917; /*value */
+	*(i1*)(intptr_t)(ws+3090) = p916; /*alignment */
+
+	i8 v918 = (i8)(intptr_t)(ws+3090);
+	i1 v919 = *(i1*)(intptr_t)v918;
+	i1 v920 = v919+(-1);
+	i2 v921 = v920;
+	i8 v922 = (i8)(intptr_t)(ws+3094);
+	*(i2*)(intptr_t)v922 = v921;
+
+	i8 v923 = (i8)(intptr_t)(ws+3088);
+	i2 v924 = *(i2*)(intptr_t)v923;
+	i8 v925 = (i8)(intptr_t)(ws+3094);
+	i2 v926 = *(i2*)(intptr_t)v925;
+	i2 v927 = v924+v926;
+	i8 v928 = (i8)(intptr_t)(ws+3094);
+	i2 v929 = *(i2*)(intptr_t)v928;
+	i2 v930 = ~v929;
+	i2 v931 = v927&v930;
+	i8 v932 = (i8)(intptr_t)(ws+3092);
+	*(i2*)(intptr_t)v932 = v931;
+
+endsub:;
+	*p915 = *(i2*)(intptr_t)(ws+3092);
+}
+
+// ArchEmitSubRef workspace at ws+696 length ws+8
+void f70(i8 p934 /* subr */) {
+	*(i8*)(intptr_t)(ws+696) = p934; /*subr */
+
+	i1 v935 = (i1)+102;
+	f57(v935);
+
+	i8 v936 = (i8)(intptr_t)(ws+696);
+	i8 v937 = *(i8*)(intptr_t)v936;
+	i8 v938 = v937+(+186);
+	i2 v939 = *(i2*)(intptr_t)v938;
+	f60(v939);
+
+	i1 v940 = (i1)+95;
+	f57(v940);
+
+	i8 v941 = (i8)(intptr_t)(ws+696);
+	i8 v942 = *(i8*)(intptr_t)v941;
+	i8 v943 = v942+(+152);
+	i8 v944 = *(i8*)(intptr_t)v943;
+	f58(v944);
+
+endsub:;
+}
+const i1 c02_s0005[] = { 0x77,0x73,0x2b,0 };
+
+// ArchEmitWSRef workspace at ws+696 length ws+4
+void f71(i2 p945 /* address */, i1 p946 /* wid */) {
+	*(i1*)(intptr_t)(ws+696) = p946; /*wid */
+	*(i2*)(intptr_t)(ws+698) = p945; /*address */
+
+	i8 v947 = (i8)(intptr_t)c02_s0005;
+	f58(v947);
+
+	i8 v948 = (i8)(intptr_t)(ws+698);
+	i2 v949 = *(i2*)(intptr_t)v948;
+	f60(v949);
+
+endsub:;
+}
+const i1 c02_s0006[] = { 0x23,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x22,0x63,0x6f,0x77,0x67,0x6f,0x6c,0x2e,0x68,0x22,0x0a,0 };
+const i1 c02_s0007[] = { 0x73,0x74,0x61,0x74,0x69,0x63,0x20,0x69,0x38,0x20,0x77,0x6f,0x72,0x6b,0x73,0x70,0x61,0x63,0x65,0x5b,0x30,0x78,0 };
+const i1 c02_s0008[] = { 0x5d,0x3b,0x0a,0 };
+const i1 c02_s0009[] = { 0x73,0x74,0x61,0x74,0x69,0x63,0x20,0x69,0x31,0x2a,0x20,0x77,0x73,0x20,0x3d,0x20,0x28,0x69,0x31,0x2a,0x29,0x77,0x6f,0x72,0x6b,0x73,0x70,0x61,0x63,0x65,0x3b,0x0a,0 };
+
+// ArchEmitHeader workspace at ws+632 length ws+8
+void f72(i8 p950 /* coo */) {
+	*(i8*)(intptr_t)(ws+632) = p950; /*coo */
+
+	i8 v951 = (i8)(intptr_t)c02_s0006;
+	f58(v951);
+
+	i8 v952 = (i8)(intptr_t)c02_s0007;
+	f58(v952);
+
+	i8 v953 = (i8)(intptr_t)(ws+568);
+	i2 v954 = *(i2*)(intptr_t)v953;
+	i2 v955 = v954+(+7);
+	i1 v956 = (i1)+3;
+	i2 v957 = ((i2)v955)>>v956;
+	f65(v957);
+
+	i8 v958 = (i8)(intptr_t)c02_s0008;
+	f58(v958);
+
+	i8 v959 = (i8)(intptr_t)c02_s0009;
+	f58(v959);
+
+endsub:;
+}
+const i1 c02_s000a[] = { 0x76,0x6f,0x69,0x64,0x20,0x63,0x6d,0x61,0x69,0x6e,0x28,0x76,0x6f,0x69,0x64,0x29,0x20,0x7b,0x0a,0 };
+const i1 c02_s000b[] = { 0x28,0x29,0x3b,0x0a,0 };
+const i1 c02_s000c[] = { 0x7d,0x0a,0 };
+
+// ArchEmitFooter workspace at ws+632 length ws+20
+void f73(i8 p960 /* coo */) {
+	*(i8*)(intptr_t)(ws+632) = p960; /*coo */
+
+	i8 v961 = (i8)(intptr_t)c02_s000a;
+	f58(v961);
+
+c02_00d5:;
+
+	i8 v962 = (i8)(intptr_t)(ws+632);
+	i8 v963 = *(i8*)(intptr_t)v962;
+	i8 v964 = (i8)+0;
+	if (v963==v964) goto c02_00d8; else goto c02_00d7;
+
+c02_00d7:;
+
+	i8 v965 = (i8)(intptr_t)(ws+632);
+	i8 v966 = *(i8*)(intptr_t)v965;
+	i8 v967 = v966+(+536);
+	i8 v968 = *(i8*)(intptr_t)v967;
+	i8 v969 = (i8)(intptr_t)(ws+640);
+	*(i8*)(intptr_t)v969 = v968;
+
+	i8 v970 = (i8)(intptr_t)(ws+640);
+	i8 v971 = *(i8*)(intptr_t)v970;
+	i8 v972 = (i8)+0;
+	if (v971==v972) goto c02_00dd; else goto c02_00dc;
+
+c02_00dc:;
+
+	i1 v973 = (i1)+9;
+	f57(v973);
+
+	i8 v974 = (i8)(intptr_t)(ws+640);
+	i8 v975 = *(i8*)(intptr_t)v974;
+	f70(v975);
+
+	i8 v976 = (i8)(intptr_t)c02_s000b;
+	f58(v976);
+
+	goto c02_00d9;
+
+c02_00dd:;
+
+c02_00d9:;
+
+	i8 v977 = (i8)(intptr_t)(ws+632);
+	i8 v978 = *(i8*)(intptr_t)v977;
+	i8 v979 = v978+(+664);
+	i8 v980 = *(i8*)(intptr_t)v979;
+	i8 v981 = (i8)(intptr_t)(ws+632);
+	*(i8*)(intptr_t)v981 = v980;
+
+	goto c02_00d5;
+
+c02_00d8:;
+
+	i8 v982 = (i8)(intptr_t)c02_s000c;
+	f58(v982);
+
+	i8 v983 = (i8)(intptr_t)(ws+44);
+	i4 v984;
+	f46(&v984, v983);
+	i8 v985 = (i8)(intptr_t)(ws+44);
+	i4 v986;
+	f45(&v986, v985);
+	i4 v987 = v984-v986;
+	i8 v988 = (i8)(intptr_t)(ws+648);
+	*(i4*)(intptr_t)v988 = v987;
+
+c02_00e0:;
+
+	i8 v989 = (i8)(intptr_t)(ws+648);
+	i4 v990 = *(i4*)(intptr_t)v989;
+	i4 v991 = (i4)+0;
+	if (v990==v991) goto c02_00e3; else goto c02_00e2;
+
+c02_00e2:;
+
+	i1 v992 = (i1)+32;
+	f57(v992);
+
+	i8 v993 = (i8)(intptr_t)(ws+648);
+	i4 v994 = *(i4*)(intptr_t)v993;
+	i4 v995 = v994+(-1);
+	i8 v996 = (i8)(intptr_t)(ws+648);
+	*(i4*)(intptr_t)v996 = v995;
+
+	goto c02_00e0;
+
+c02_00e3:;
+
+endsub:;
+}
+
+// getchar workspace at ws+760 length ws+9
+void f74(i1* p1001 /* c */, i8 p1002 /* fcb */) {
+	*(i8*)(intptr_t)(ws+760) = p1002; /*fcb */
+
+	i8 v1003 = (i8)(intptr_t)(ws+577);
+	i1 v1004 = *(i1*)(intptr_t)v1003;
+	i1 v1005 = (i1)+0;
+	if (v1004==v1005) goto c02_00e7; else goto c02_00e8;
+
+c02_00e7:;
+
+	i8 v1006 = (i8)(intptr_t)(ws+760);
+	i8 v1007 = *(i8*)(intptr_t)v1006;
+	i1 v1008;
+	f48(&v1008, v1007);
+	i8 v1009 = (i8)(intptr_t)(ws+768);
+	*(i1*)(intptr_t)v1009 = v1008;
+
+	goto c02_00e4;
+
+c02_00e8:;
+
+	i8 v1010 = (i8)(intptr_t)(ws+577);
+	i1 v1011 = *(i1*)(intptr_t)v1010;
+	i8 v1012 = (i8)(intptr_t)(ws+768);
+	*(i1*)(intptr_t)v1012 = v1011;
+
+	i1 v1013 = (i1)+0;
+	i8 v1014 = (i8)(intptr_t)(ws+577);
+	*(i1*)(intptr_t)v1014 = v1013;
+
+c02_00e4:;
+
+endsub:;
+	*p1001 = *(i1*)(intptr_t)(ws+768);
+}
+const i1 c02_s000d[] = { 0x69,0x6e,0x76,0x61,0x6c,0x69,0x64,0x20,0x68,0x65,0x78,0x20,0x6e,0x75,0x6d,0x62,0x65,0x72,0x20,0x69,0x6e,0x20,0x63,0x6f,0x6f,0x66,0x69,0x6c,0x65,0x20,0x61,0x74,0x20,0x6f,0x66,0x66,0x73,0x65,0x74,0x20,0x30,0x78,0 };
+
+// read_hex workspace at ws+736 length ws+17
+void f76(i4* p1019 /* val */, i1 p1020 /* len */, i8 p1021 /* fcb */) {
+	*(i8*)(intptr_t)(ws+736) = p1021; /*fcb */
+	*(i1*)(intptr_t)(ws+744) = p1020; /*len */
+
+	i4 v1022 = (i4)+0;
+	i8 v1023 = (i8)(intptr_t)(ws+748);
+	*(i4*)(intptr_t)v1023 = v1022;
+
+c02_00e9:;
+
+	i8 v1024 = (i8)(intptr_t)(ws+736);
+	i8 v1025 = *(i8*)(intptr_t)v1024;
+	i1 v1026;
+	f74(&v1026, v1025);
+	i8 v1027 = (i8)(intptr_t)(ws+752);
+	*(i1*)(intptr_t)v1027 = v1026;
+
+	i8 v1028 = (i8)(intptr_t)(ws+752);
+	i1 v1029 = *(i1*)(intptr_t)v1028;
+	i1 v1030 = (i1)+48;
+	if (v1029<v1030) goto c02_00f1; else goto c02_00f2;
+
+c02_00f2:;
+
+	i1 v1031 = (i1)+57;
+	i8 v1032 = (i8)(intptr_t)(ws+752);
+	i1 v1033 = *(i1*)(intptr_t)v1032;
+	if (v1031<v1033) goto c02_00f1; else goto c02_00f0;
+
+c02_00f0:;
+
+	i8 v1034 = (i8)(intptr_t)(ws+752);
+	i1 v1035 = *(i1*)(intptr_t)v1034;
+	i1 v1036 = v1035+(-48);
+	i8 v1037 = (i8)(intptr_t)(ws+752);
+	*(i1*)(intptr_t)v1037 = v1036;
+
+	goto c02_00eb;
+
+c02_00f1:;
+
+	i8 v1038 = (i8)(intptr_t)(ws+752);
+	i1 v1039 = *(i1*)(intptr_t)v1038;
+	i1 v1040 = v1039&(-33);
+	i8 v1041 = (i8)(intptr_t)(ws+752);
+	*(i1*)(intptr_t)v1041 = v1040;
+
+	i8 v1042 = (i8)(intptr_t)(ws+752);
+	i1 v1043 = *(i1*)(intptr_t)v1042;
+	i1 v1044 = (i1)+65;
+	if (v1043<v1044) goto c02_00f9; else goto c02_00fa;
+
+c02_00fa:;
+
+	i1 v1045 = (i1)+70;
+	i8 v1046 = (i8)(intptr_t)(ws+752);
+	i1 v1047 = *(i1*)(intptr_t)v1046;
+	if (v1045<v1047) goto c02_00f9; else goto c02_00f8;
+
+c02_00f8:;
+
+	i8 v1048 = (i8)(intptr_t)(ws+752);
+	i1 v1049 = *(i1*)(intptr_t)v1048;
+	i1 v1050 = v1049+(-55);
+	i8 v1051 = (i8)(intptr_t)(ws+752);
+	*(i1*)(intptr_t)v1051 = v1050;
+
+	goto c02_00f3;
+
+c02_00f9:;
+
+	f53();
+
+	i8 v1052 = (i8)(intptr_t)c02_s000d;
+	f11(v1052);
+
+	i8 v1053 = (i8)(intptr_t)(ws+736);
+	i8 v1054 = *(i8*)(intptr_t)v1053;
+	i4 v1055;
+	f45(&v1055, v1054);
+	i4 v1056 = v1055+(-1);
+	f20(v1056);
+
+	f54();
+
+c02_00f3:;
+
+c02_00eb:;
+
+	i8 v1057 = (i8)(intptr_t)(ws+748);
+	i4 v1058 = *(i4*)(intptr_t)v1057;
+	i1 v1059 = (i1)+4;
+	i4 v1060 = ((i4)v1058)<<v1059;
+	i8 v1061 = (i8)(intptr_t)(ws+752);
+	i1 v1062 = *(i1*)(intptr_t)v1061;
+	i4 v1063 = v1062;
+	i4 v1064 = v1060+v1063;
+	i8 v1065 = (i8)(intptr_t)(ws+748);
+	*(i4*)(intptr_t)v1065 = v1064;
+
+	i8 v1066 = (i8)(intptr_t)(ws+744);
+	i1 v1067 = *(i1*)(intptr_t)v1066;
+	i1 v1068 = v1067+(-1);
+	i8 v1069 = (i8)(intptr_t)(ws+744);
+	*(i1*)(intptr_t)v1069 = v1068;
+
+	i8 v1070 = (i8)(intptr_t)(ws+744);
+	i1 v1071 = *(i1*)(intptr_t)v1070;
+	i1 v1072 = (i1)+0;
+	if (v1071==v1072) goto c02_00fe; else goto c02_00ff;
+
+c02_00fe:;
+
+	goto c02_00ea;
+
+	goto c02_00fb;
+
+c02_00ff:;
+
+c02_00fb:;
+
+	goto c02_00e9;
+
+c02_00ea:;
+
+endsub:;
+	*p1019 = *(i4*)(intptr_t)(ws+748);
+}
+
+// read_hex2 workspace at ws+720 length ws+9
+void f77(i1* p1073 /* val */, i8 p1074 /* fcb */) {
+	*(i8*)(intptr_t)(ws+720) = p1074; /*fcb */
+
+	i8 v1075 = (i8)(intptr_t)(ws+720);
+	i8 v1076 = *(i8*)(intptr_t)v1075;
+	i1 v1077 = (i1)+2;
+	i4 v1078;
+	f76(&v1078, v1077, v1076);
+	i1 v1079 = v1078;
+	i8 v1080 = (i8)(intptr_t)(ws+728);
+	*(i1*)(intptr_t)v1080 = v1079;
+
+endsub:;
+	*p1073 = *(i1*)(intptr_t)(ws+728);
+}
+
+// read_hex4 workspace at ws+720 length ws+10
+void f78(i2* p1081 /* val */, i8 p1082 /* fcb */) {
+	*(i8*)(intptr_t)(ws+720) = p1082; /*fcb */
+
+	i8 v1083 = (i8)(intptr_t)(ws+720);
+	i8 v1084 = *(i8*)(intptr_t)v1083;
+	i1 v1085 = (i1)+4;
+	i4 v1086;
+	f76(&v1086, v1085, v1084);
+	i2 v1087 = v1086;
+	i8 v1088 = (i8)(intptr_t)(ws+728);
+	*(i2*)(intptr_t)v1088 = v1087;
+
+endsub:;
+	*p1081 = *(i2*)(intptr_t)(ws+728);
+}
+
+// read_string workspace at ws+720 length ws+32
+void f79(i8* p1089 /* ptr */, i1 p1090 /* len */, i8 p1091 /* fcb */) {
+	*(i8*)(intptr_t)(ws+720) = p1091; /*fcb */
+	*(i1*)(intptr_t)(ws+728) = p1090; /*len */
+
+	i8 v1092 = (i8)(intptr_t)(ws+728);
+	i1 v1093 = *(i1*)(intptr_t)v1092;
+	i1 v1094 = v1093+(+1);
+	i8 v1095 = v1094;
+	i8 v1096;
+	f31(&v1096, v1095);
+	i8 v1097 = (i8)(intptr_t)(ws+736);
+	*(i8*)(intptr_t)v1097 = v1096;
+
+	i8 v1098 = (i8)(intptr_t)(ws+736);
+	i8 v1099 = *(i8*)(intptr_t)v1098;
+	i8 v1100 = (i8)(intptr_t)(ws+744);
+	*(i8*)(intptr_t)v1100 = v1099;
+
+c02_0100:;
+
+	i8 v1101 = (i8)(intptr_t)(ws+728);
+	i1 v1102 = *(i1*)(intptr_t)v1101;
+	i1 v1103 = (i1)+0;
+	if (v1102==v1103) goto c02_0105; else goto c02_0106;
+
+c02_0105:;
 
 	goto c02_0101;
 
+	goto c02_0102;
+
+c02_0106:;
+
 c02_0102:;
 
+	i8 v1104 = (i8)(intptr_t)(ws+720);
+	i8 v1105 = *(i8*)(intptr_t)v1104;
+	i1 v1106;
+	f74(&v1106, v1105);
+	i8 v1107 = (i8)(intptr_t)(ws+744);
+	i8 v1108 = *(i8*)(intptr_t)v1107;
+	*(i1*)(intptr_t)v1108 = v1106;
+
+	i8 v1109 = (i8)(intptr_t)(ws+744);
+	i8 v1110 = *(i8*)(intptr_t)v1109;
+	i8 v1111 = v1110+(+1);
+	i8 v1112 = (i8)(intptr_t)(ws+744);
+	*(i8*)(intptr_t)v1112 = v1111;
+
+	i8 v1113 = (i8)(intptr_t)(ws+728);
+	i1 v1114 = *(i1*)(intptr_t)v1113;
+	i1 v1115 = v1114+(-1);
+	i8 v1116 = (i8)(intptr_t)(ws+728);
+	*(i1*)(intptr_t)v1116 = v1115;
+
+	goto c02_0100;
+
+c02_0101:;
+
 endsub:;
+	*p1089 = *(i8*)(intptr_t)(ws+736);
 }
 
-// E_u32 workspace at ws+720 length ws+33
-void f61(i4 p1171 /* value */) {
-	*(i4*)(intptr_t)(ws+720) = p1171; /*value */
+// AddRef workspace at ws+720 length ws+32
+void f80(i8 p1117 /* calls */, i8 p1118 /* subr */) {
+	*(i8*)(intptr_t)(ws+720) = p1118; /*subr */
+	*(i8*)(intptr_t)(ws+728) = p1117; /*calls */
 
-	i8 v1172 = (i8)(intptr_t)(ws+724);
-	i8 v1173 = (i8)(intptr_t)(ws+736);
-	*(i8*)(intptr_t)v1173 = v1172;
+	i8 v1119 = (i8)(intptr_t)(ws+720);
+	i8 v1120 = *(i8*)(intptr_t)v1119;
+	i8 v1121 = v1120+(+184);
+	i2 v1122 = *(i2*)(intptr_t)v1121;
+	i8 v1123 = (i8)(intptr_t)(ws+736);
+	*(i2*)(intptr_t)v1123 = v1122;
 
-	i8 v1174 = (i8)(intptr_t)(ws+720);
-	i4 v1175 = *(i4*)(intptr_t)v1174;
-	i1 v1176 = (i1)+10;
-	i8 v1177 = (i8)(intptr_t)(ws+736);
-	i8 v1178 = *(i8*)(intptr_t)v1177;
-	i8 v1179;
-	f13(&v1179, v1178, v1176, v1175);
-	i8 v1180 = (i8)(intptr_t)(ws+744);
-	*(i8*)(intptr_t)v1180 = v1179;
+	i8 v1124 = (i8)(intptr_t)(ws+736);
+	i2 v1125 = *(i2*)(intptr_t)v1124;
+	i2 v1126 = v1125+(+1);
+	i8 v1127 = (i8)(intptr_t)(ws+720);
+	i8 v1128 = *(i8*)(intptr_t)v1127;
+	i8 v1129 = v1128+(+184);
+	*(i2*)(intptr_t)v1129 = v1126;
 
-c02_0108:;
-
-	i8 v1181 = (i8)(intptr_t)(ws+736);
-	i8 v1182 = *(i8*)(intptr_t)v1181;
-	i1 v1183 = *(i1*)(intptr_t)v1182;
-	i8 v1184 = (i8)(intptr_t)(ws+752);
-	*(i1*)(intptr_t)v1184 = v1183;
-
-	i8 v1185 = (i8)(intptr_t)(ws+752);
-	i1 v1186 = *(i1*)(intptr_t)v1185;
-	i1 v1187 = (i1)+0;
-	if (v1186==v1187) goto c02_010d; else goto c02_010e;
-
-c02_010d:;
-
-	goto c02_0109;
-
-	goto c02_010a;
-
-c02_010e:;
-
-c02_010a:;
-
-	i8 v1188 = (i8)(intptr_t)(ws+752);
-	i1 v1189 = *(i1*)(intptr_t)v1188;
-	f59(v1189);
-
-	i8 v1190 = (i8)(intptr_t)(ws+736);
-	i8 v1191 = *(i8*)(intptr_t)v1190;
-	i8 v1192 = v1191+(+1);
-	i8 v1193 = (i8)(intptr_t)(ws+736);
-	*(i8*)(intptr_t)v1193 = v1192;
-
-	goto c02_0108;
+	i8 v1130 = (i8)(intptr_t)(ws+720);
+	i8 v1131 = *(i8*)(intptr_t)v1130;
+	i8 v1132 = v1131+(+16);
+	i8 v1133 = (i8)(intptr_t)(ws+744);
+	*(i8*)(intptr_t)v1133 = v1132;
 
 c02_0109:;
 
+	i8 v1134 = (i8)(intptr_t)(ws+736);
+	i2 v1135 = *(i2*)(intptr_t)v1134;
+	i2 v1136 = (i2)+16;
+	if (v1135<v1136) goto c02_010c; else goto c02_010b;
+
+c02_010b:;
+
+	i8 v1137 = (i8)(intptr_t)(ws+744);
+	i8 v1138 = *(i8*)(intptr_t)v1137;
+	i8 v1139 = *(i8*)(intptr_t)v1138;
+	i8 v1140 = (i8)+0;
+	if (v1139==v1140) goto c02_0110; else goto c02_0111;
+
+c02_0110:;
+
+	i8 v1141 = (i8)+136;
+	i8 v1142;
+	f31(&v1142, v1141);
+	i8 v1143 = (i8)(intptr_t)(ws+744);
+	i8 v1144 = *(i8*)(intptr_t)v1143;
+	*(i8*)(intptr_t)v1144 = v1142;
+
+	goto c02_010d;
+
+c02_0111:;
+
+c02_010d:;
+
+	i8 v1145 = (i8)(intptr_t)(ws+744);
+	i8 v1146 = *(i8*)(intptr_t)v1145;
+	i8 v1147 = *(i8*)(intptr_t)v1146;
+	i8 v1148 = (i8)(intptr_t)(ws+744);
+	*(i8*)(intptr_t)v1148 = v1147;
+
+	i8 v1149 = (i8)(intptr_t)(ws+736);
+	i2 v1150 = *(i2*)(intptr_t)v1149;
+	i2 v1151 = v1150+(-16);
+	i8 v1152 = (i8)(intptr_t)(ws+736);
+	*(i2*)(intptr_t)v1152 = v1151;
+
+	goto c02_0109;
+
+c02_010c:;
+
+	i8 v1153 = (i8)(intptr_t)(ws+728);
+	i8 v1154 = *(i8*)(intptr_t)v1153;
+	i8 v1155 = (i8)(intptr_t)(ws+744);
+	i8 v1156 = *(i8*)(intptr_t)v1155;
+	i8 v1157 = v1156+(+8);
+	i8 v1158 = (i8)(intptr_t)(ws+736);
+	i2 v1159 = *(i2*)(intptr_t)v1158;
+	i1 v1160 = v1159;
+	i8 v1161 = v1160;
+	i1 v1162 = (i1)+3;
+	i8 v1163 = ((i8)v1161)<<v1162;
+	i8 v1164 = v1157+v1163;
+	*(i8*)(intptr_t)v1164 = v1154;
+
 endsub:;
 }
 
-// E_u16 workspace at ws+712 length ws+2
-void f62(i2 p1194 /* value */) {
-	*(i2*)(intptr_t)(ws+712) = p1194; /*value */
+// FindSub workspace at ws+752 length ws+32
+void f81(i8* p1165 /* ptr */, i2 p1166 /* id */, i8 p1167 /* coo */) {
+	*(i8*)(intptr_t)(ws+752) = p1167; /*coo */
+	*(i2*)(intptr_t)(ws+760) = p1166; /*id */
 
-	i8 v1195 = (i8)(intptr_t)(ws+712);
-	i2 v1196 = *(i2*)(intptr_t)v1195;
-	i4 v1197 = v1196;
-	f61(v1197);
+	i8 v1168 = (i8)(intptr_t)(ws+752);
+	i8 v1169 = *(i8*)(intptr_t)v1168;
+	i8 v1170 = v1169+(+528);
+	i8 v1171 = (i8)(intptr_t)(ws+776);
+	*(i8*)(intptr_t)v1171 = v1170;
 
-endsub:;
-}
+c02_0114:;
 
-// E_h workspace at ws+712 length ws+25
-void f65(i1 p1214 /* width */, i4 p1215 /* value */) {
-	*(i4*)(intptr_t)(ws+712) = p1215; /*value */
-	*(i1*)(intptr_t)(ws+716) = p1214; /*width */
-
-	i8 v1216 = (i8)(intptr_t)(ws+712);
-	i4 v1217 = *(i4*)(intptr_t)v1216;
-	i1 v1218 = (i1)+16;
-	i8 v1219 = (i8)(intptr_t)(ws+717);
-	i8 v1220;
-	f13(&v1220, v1219, v1218, v1217);
-	i8 v1221 = (i8)(intptr_t)(ws+728);
-	*(i8*)(intptr_t)v1221 = v1220;
-
-	i8 v1222 = (i8)(intptr_t)(ws+716);
-	i1 v1223 = *(i1*)(intptr_t)v1222;
-	i8 v1224 = (i8)(intptr_t)(ws+728);
-	i8 v1225 = *(i8*)(intptr_t)v1224;
-	i8 v1226 = (i8)(intptr_t)(ws+717);
-	i8 v1227 = v1225-v1226;
-	i1 v1228 = v1227;
-	i1 v1229 = v1223-v1228;
-	i8 v1230 = (i8)(intptr_t)(ws+736);
-	*(i1*)(intptr_t)v1230 = v1229;
+	i8 v1172 = (i8)(intptr_t)(ws+760);
+	i2 v1173 = *(i2*)(intptr_t)v1172;
+	i2 v1174 = (i2)+16;
+	if (v1173<v1174) goto c02_0117; else goto c02_0116;
 
 c02_0116:;
 
-	i8 v1231 = (i8)(intptr_t)(ws+736);
-	i1 v1232 = *(i1*)(intptr_t)v1231;
-	i1 v1233 = (i1)+0;
-	if (v1232==v1233) goto c02_0119; else goto c02_0118;
+	i8 v1175 = (i8)(intptr_t)(ws+776);
+	i8 v1176 = *(i8*)(intptr_t)v1175;
+	i8 v1177 = *(i8*)(intptr_t)v1176;
+	i8 v1178 = (i8)+0;
+	if (v1177==v1178) goto c02_011b; else goto c02_011c;
+
+c02_011b:;
+
+	i8 v1179 = (i8)+136;
+	i8 v1180;
+	f31(&v1180, v1179);
+	i8 v1181 = (i8)(intptr_t)(ws+776);
+	i8 v1182 = *(i8*)(intptr_t)v1181;
+	*(i8*)(intptr_t)v1182 = v1180;
+
+	goto c02_0118;
+
+c02_011c:;
 
 c02_0118:;
 
-	i1 v1234 = (i1)+48;
-	f59(v1234);
+	i8 v1183 = (i8)(intptr_t)(ws+776);
+	i8 v1184 = *(i8*)(intptr_t)v1183;
+	i8 v1185 = *(i8*)(intptr_t)v1184;
+	i8 v1186 = (i8)(intptr_t)(ws+776);
+	*(i8*)(intptr_t)v1186 = v1185;
 
+	i8 v1187 = (i8)(intptr_t)(ws+760);
+	i2 v1188 = *(i2*)(intptr_t)v1187;
+	i2 v1189 = v1188+(-16);
+	i8 v1190 = (i8)(intptr_t)(ws+760);
+	*(i2*)(intptr_t)v1190 = v1189;
+
+	goto c02_0114;
+
+c02_0117:;
+
+	i8 v1191 = (i8)(intptr_t)(ws+776);
+	i8 v1192 = *(i8*)(intptr_t)v1191;
+	i8 v1193 = v1192+(+8);
+	i8 v1194 = (i8)(intptr_t)(ws+760);
+	i2 v1195 = *(i2*)(intptr_t)v1194;
+	i1 v1196 = v1195;
+	i8 v1197 = v1196;
+	i1 v1198 = (i1)+3;
+	i8 v1199 = ((i8)v1197)<<v1198;
+	i8 v1200 = v1193+v1199;
+	i8 v1201 = (i8)(intptr_t)(ws+768);
+	*(i8*)(intptr_t)v1201 = v1200;
+
+endsub:;
+	*p1165 = *(i8*)(intptr_t)(ws+768);
+}
+
+// FindOrCreateSub workspace at ws+720 length ws+32
+void f82(i8* p1202 /* subroutine */, i2 p1203 /* id */, i8 p1204 /* coo */) {
+	*(i8*)(intptr_t)(ws+720) = p1204; /*coo */
+	*(i2*)(intptr_t)(ws+728) = p1203; /*id */
+
+	i8 v1205 = (i8)(intptr_t)(ws+720);
+	i8 v1206 = *(i8*)(intptr_t)v1205;
+	i8 v1207 = (i8)(intptr_t)(ws+728);
+	i2 v1208 = *(i2*)(intptr_t)v1207;
+	i8 v1209;
+	f81(&v1209, v1208, v1206);
+	i8 v1210 = (i8)(intptr_t)(ws+744);
+	*(i8*)(intptr_t)v1210 = v1209;
+
+	i8 v1211 = (i8)(intptr_t)(ws+744);
+	i8 v1212 = *(i8*)(intptr_t)v1211;
+	i8 v1213 = *(i8*)(intptr_t)v1212;
+	i8 v1214 = (i8)(intptr_t)(ws+736);
+	*(i8*)(intptr_t)v1214 = v1213;
+
+	i8 v1215 = (i8)(intptr_t)(ws+736);
+	i8 v1216 = *(i8*)(intptr_t)v1215;
+	i8 v1217 = (i8)+0;
+	if (v1216==v1217) goto c02_0120; else goto c02_0121;
+
+c02_0120:;
+
+	i8 v1218 = (i8)+189;
+	i8 v1219;
+	f31(&v1219, v1218);
+	i8 v1220 = (i8)(intptr_t)(ws+736);
+	*(i8*)(intptr_t)v1220 = v1219;
+
+	i8 v1221 = (i8)(intptr_t)(ws+720);
+	i8 v1222 = *(i8*)(intptr_t)v1221;
+	i8 v1223 = (i8)(intptr_t)(ws+736);
+	i8 v1224 = *(i8*)(intptr_t)v1223;
+	*(i8*)(intptr_t)v1224 = v1222;
+
+	i8 v1225 = (i8)(intptr_t)(ws+32);
+	i8 v1226 = *(i8*)(intptr_t)v1225;
+	i8 v1227 = (i8)(intptr_t)(ws+736);
+	i8 v1228 = *(i8*)(intptr_t)v1227;
+	i8 v1229 = v1228+(+8);
+	*(i8*)(intptr_t)v1229 = v1226;
+
+	i8 v1230 = (i8)(intptr_t)(ws+736);
+	i8 v1231 = *(i8*)(intptr_t)v1230;
+	i8 v1232 = (i8)(intptr_t)(ws+32);
+	*(i8*)(intptr_t)v1232 = v1231;
+
+	i8 v1233 = (i8)(intptr_t)(ws+40);
+	i2 v1234 = *(i2*)(intptr_t)v1233;
 	i8 v1235 = (i8)(intptr_t)(ws+736);
-	i1 v1236 = *(i1*)(intptr_t)v1235;
-	i1 v1237 = v1236+(-1);
+	i8 v1236 = *(i8*)(intptr_t)v1235;
+	i8 v1237 = v1236+(+186);
+	*(i2*)(intptr_t)v1237 = v1234;
+
 	i8 v1238 = (i8)(intptr_t)(ws+736);
-	*(i1*)(intptr_t)v1238 = v1237;
+	i8 v1239 = *(i8*)(intptr_t)v1238;
+	i8 v1240 = (i8)(intptr_t)(ws+744);
+	i8 v1241 = *(i8*)(intptr_t)v1240;
+	*(i8*)(intptr_t)v1241 = v1239;
 
-	goto c02_0116;
+	i8 v1242 = (i8)(intptr_t)(ws+40);
+	i2 v1243 = *(i2*)(intptr_t)v1242;
+	i2 v1244 = v1243+(+1);
+	i8 v1245 = (i8)(intptr_t)(ws+40);
+	*(i2*)(intptr_t)v1245 = v1244;
 
-c02_0119:;
+	goto c02_011d;
 
-	i8 v1239 = (i8)(intptr_t)(ws+717);
-	f60(v1239);
-
-endsub:;
-}
-
-// E_h8 workspace at ws+704 length ws+1
-void f66(i1 p1240 /* value */) {
-	*(i1*)(intptr_t)(ws+704) = p1240; /*value */
-
-	i8 v1241 = (i8)(intptr_t)(ws+704);
-	i1 v1242 = *(i1*)(intptr_t)v1241;
-	i4 v1243 = v1242;
-	i1 v1244 = (i1)+2;
-	f65(v1244, v1243);
-
-endsub:;
-}
-
-// E_h16 workspace at ws+648 length ws+2
-void f67(i2 p1245 /* value */) {
-	*(i2*)(intptr_t)(ws+648) = p1245; /*value */
-
-	i8 v1246 = (i8)(intptr_t)(ws+648);
-	i2 v1247 = *(i2*)(intptr_t)v1246;
-	i4 v1248 = v1247;
-	i1 v1249 = (i1)+4;
-	f65(v1249, v1248);
-
-endsub:;
-}
-const i1 c02_s000c[] = { 0x63,0x61,0x6e,0x6e,0x6f,0x74,0x20,0x6f,0x70,0x65,0x6e,0x20,0x6f,0x75,0x74,0x70,0x75,0x74,0x20,0x66,0x69,0x6c,0x65,0 };
-
-// EmitterOpenfile workspace at ws+640 length ws+8
-void f68(i8 p1250 /* filename */) {
-	*(i8*)(intptr_t)(ws+640) = p1250; /*filename */
-
-	i8 v1251 = (i8)(intptr_t)(ws+52);
-	i8 v1252 = (i8)(intptr_t)(ws+640);
-	i8 v1253 = *(i8*)(intptr_t)v1252;
-	i1 v1254;
-	f44(&v1254, v1253, v1251);
-	i1 v1255 = (i1)+0;
-	if (v1254==v1255) goto c02_011e; else goto c02_011d;
+c02_0121:;
 
 c02_011d:;
 
-	i8 v1256 = (i8)(intptr_t)c02_s000c;
-	f57(v1256);
-
-	goto c02_011a;
-
-c02_011e:;
-
-c02_011a:;
-
 endsub:;
-}
-const i1 c02_s000d[] = { 0x63,0x61,0x6e,0x6e,0x6f,0x74,0x20,0x63,0x6c,0x6f,0x73,0x65,0x20,0x6f,0x75,0x74,0x70,0x75,0x74,0x20,0x66,0x69,0x6c,0x65,0 };
-
-// EmitterClosefile workspace at ws+640 length ws+0
-void f69(void) {
-
-	i8 v1257 = (i8)(intptr_t)(ws+52);
-	i1 v1258;
-	f45(&v1258, v1257);
-	i1 v1259 = (i1)+0;
-	if (v1258==v1259) goto c02_0123; else goto c02_0122;
-
-c02_0122:;
-
-	i8 v1260 = (i8)(intptr_t)c02_s000d;
-	f57(v1260);
-
-	goto c02_011f;
-
-c02_0123:;
-
-c02_011f:;
-
-endsub:;
+	*p1202 = *(i8*)(intptr_t)(ws+736);
 }
 
-// ArchAlignUp workspace at ws+3096 length ws+8
-void f70(i2* p1261 /* newvalue */, i1 p1262 /* alignment */, i2 p1263 /* value */) {
-	*(i2*)(intptr_t)(ws+3096) = p1263; /*value */
-	*(i1*)(intptr_t)(ws+3098) = p1262; /*alignment */
+// Deref workspace at ws+3088 length ws+24
+void f83(i8* p1246 /* subout */, i8 p1247 /* subin */) {
+	*(i8*)(intptr_t)(ws+3088) = p1247; /*subin */
 
-	i8 v1264 = (i8)(intptr_t)(ws+3098);
-	i1 v1265 = *(i1*)(intptr_t)v1264;
-	i1 v1266 = v1265+(-1);
-	i2 v1267 = v1266;
-	i8 v1268 = (i8)(intptr_t)(ws+3102);
-	*(i2*)(intptr_t)v1268 = v1267;
+	i8 v1248 = (i8)(intptr_t)(ws+3088);
+	i8 v1249 = *(i8*)(intptr_t)v1248;
+	i8 v1250 = (i8)(intptr_t)(ws+3096);
+	*(i8*)(intptr_t)v1250 = v1249;
 
-	i8 v1269 = (i8)(intptr_t)(ws+3096);
-	i2 v1270 = *(i2*)(intptr_t)v1269;
-	i8 v1271 = (i8)(intptr_t)(ws+3102);
-	i2 v1272 = *(i2*)(intptr_t)v1271;
-	i2 v1273 = v1270+v1272;
-	i8 v1274 = (i8)(intptr_t)(ws+3102);
-	i2 v1275 = *(i2*)(intptr_t)v1274;
-	i2 v1276 = ~v1275;
-	i2 v1277 = v1273&v1276;
-	i8 v1278 = (i8)(intptr_t)(ws+3100);
-	*(i2*)(intptr_t)v1278 = v1277;
+	i8 v1251 = (i8)(intptr_t)(ws+3088);
+	i8 v1252 = *(i8*)(intptr_t)v1251;
+	i8 v1253 = (i8)+0;
+	if (v1252==v1253) goto c02_0126; else goto c02_0125;
 
-endsub:;
-	*p1261 = *(i2*)(intptr_t)(ws+3100);
-}
-const i1 c02_s000e[] = { 0x66,0 };
+c02_0125:;
 
-// ArchEmitSubRef workspace at ws+704 length ws+2
-void f72(i2 p1280 /* subid */) {
-	*(i2*)(intptr_t)(ws+704) = p1280; /*subid */
+	i8 v1254 = (i8)(intptr_t)(ws+3088);
+	i8 v1255 = *(i8*)(intptr_t)v1254;
+	i8 v1256 = v1255+(+160);
+	i8 v1257 = *(i8*)(intptr_t)v1256;
+	i8 v1258 = (i8)(intptr_t)(ws+3104);
+	*(i8*)(intptr_t)v1258 = v1257;
 
-	i8 v1281 = (i8)(intptr_t)c02_s000e;
-	f60(v1281);
-
-	i8 v1282 = (i8)(intptr_t)(ws+704);
-	i2 v1283 = *(i2*)(intptr_t)v1282;
-	f62(v1283);
-
-endsub:;
-}
-const i1 c02_s000f[] = { 0x77,0x73,0x2b,0 };
-
-// ArchEmitWSRef workspace at ws+704 length ws+4
-void f73(i2 p1284 /* address */, i1 p1285 /* wid */) {
-	*(i1*)(intptr_t)(ws+704) = p1285; /*wid */
-	*(i2*)(intptr_t)(ws+706) = p1284; /*address */
-
-	i8 v1286 = (i8)(intptr_t)c02_s000f;
-	f60(v1286);
-
-	i8 v1287 = (i8)(intptr_t)(ws+706);
-	i2 v1288 = *(i2*)(intptr_t)v1287;
-	f62(v1288);
-
-endsub:;
-}
-const i1 c02_s0010[] = { 0x23,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x22,0x63,0x6f,0x77,0x67,0x6f,0x6c,0x2e,0x68,0x22,0x0a,0 };
-const i1 c02_s0011[] = { 0x73,0x74,0x61,0x74,0x69,0x63,0x20,0x69,0x38,0x20,0x77,0x6f,0x72,0x6b,0x73,0x70,0x61,0x63,0x65,0x5b,0x30,0x78,0 };
-const i1 c02_s0012[] = { 0x5d,0x3b,0x0a,0 };
-const i1 c02_s0013[] = { 0x73,0x74,0x61,0x74,0x69,0x63,0x20,0x69,0x31,0x2a,0x20,0x77,0x73,0x20,0x3d,0x20,0x28,0x69,0x31,0x2a,0x29,0x77,0x6f,0x72,0x6b,0x73,0x70,0x61,0x63,0x65,0x3b,0x0a,0 };
-
-// ArchEmitHeader workspace at ws+640 length ws+8
-void f74(i8 p1289 /* coo */) {
-	*(i8*)(intptr_t)(ws+640) = p1289; /*coo */
-
-	i8 v1290 = (i8)(intptr_t)c02_s0010;
-	f60(v1290);
-
-	i8 v1291 = (i8)(intptr_t)c02_s0011;
-	f60(v1291);
-
-	i8 v1292 = (i8)(intptr_t)(ws+576);
-	i2 v1293 = *(i2*)(intptr_t)v1292;
-	i2 v1294 = v1293+(+7);
-	i1 v1295 = (i1)+3;
-	i2 v1296 = ((i2)v1294)>>v1295;
-	f67(v1296);
-
-	i8 v1297 = (i8)(intptr_t)c02_s0012;
-	f60(v1297);
-
-	i8 v1298 = (i8)(intptr_t)c02_s0013;
-	f60(v1298);
-
-endsub:;
-}
-const i1 c02_s0014[] = { 0x76,0x6f,0x69,0x64,0x20,0x63,0x6d,0x61,0x69,0x6e,0x28,0x76,0x6f,0x69,0x64,0x29,0x20,0x7b,0x0a,0 };
-const i1 c02_s0015[] = { 0x28,0x29,0x3b,0x0a,0 };
-const i1 c02_s0016[] = { 0x7d,0x0a,0 };
-
-// ArchEmitFooter workspace at ws+640 length ws+20
-void f75(i8 p1299 /* coo */) {
-	*(i8*)(intptr_t)(ws+640) = p1299; /*coo */
-
-	i8 v1300 = (i8)(intptr_t)c02_s0014;
-	f60(v1300);
-
-c02_0126:;
-
-	i8 v1301 = (i8)(intptr_t)(ws+640);
-	i8 v1302 = *(i8*)(intptr_t)v1301;
-	i8 v1303 = (i8)+0;
-	if (v1302==v1303) goto c02_0129; else goto c02_0128;
-
-c02_0128:;
-
-	i8 v1304 = (i8)(intptr_t)(ws+640);
-	i8 v1305 = *(i8*)(intptr_t)v1304;
-	i8 v1306 = v1305+(+536);
-	i8 v1307 = *(i8*)(intptr_t)v1306;
-	i8 v1308 = (i8)(intptr_t)(ws+648);
-	*(i8*)(intptr_t)v1308 = v1307;
-
-	i8 v1309 = (i8)(intptr_t)(ws+648);
-	i8 v1310 = *(i8*)(intptr_t)v1309;
-	i8 v1311 = (i8)+0;
-	if (v1310==v1311) goto c02_012e; else goto c02_012d;
-
-c02_012d:;
-
-	i1 v1312 = (i1)+9;
-	f59(v1312);
-
-	i8 v1313 = (i8)(intptr_t)(ws+648);
-	i8 v1314 = *(i8*)(intptr_t)v1313;
-	i8 v1315 = v1314+(+186);
-	i2 v1316 = *(i2*)(intptr_t)v1315;
-	f72(v1316);
-
-	i8 v1317 = (i8)(intptr_t)c02_s0015;
-	f60(v1317);
-
-	goto c02_012a;
-
-c02_012e:;
+	i8 v1259 = (i8)(intptr_t)(ws+3104);
+	i8 v1260 = *(i8*)(intptr_t)v1259;
+	i8 v1261 = (i8)+0;
+	if (v1260==v1261) goto c02_012b; else goto c02_012a;
 
 c02_012a:;
 
-	i8 v1318 = (i8)(intptr_t)(ws+640);
-	i8 v1319 = *(i8*)(intptr_t)v1318;
-	i8 v1320 = v1319+(+664);
-	i8 v1321 = *(i8*)(intptr_t)v1320;
-	i8 v1322 = (i8)(intptr_t)(ws+640);
-	*(i8*)(intptr_t)v1322 = v1321;
+	i8 v1262 = (i8)(intptr_t)(ws+3104);
+	i8 v1263 = *(i8*)(intptr_t)v1262;
+	i8 v1264 = v1263+(+16);
+	i8 v1265 = *(i8*)(intptr_t)v1264;
+	i8 v1266 = (i8)(intptr_t)(ws+3096);
+	*(i8*)(intptr_t)v1266 = v1265;
 
-	goto c02_0126;
+	goto c02_0127;
 
-c02_0129:;
+c02_012b:;
 
-	i8 v1323 = (i8)(intptr_t)c02_s0016;
-	f60(v1323);
+c02_0127:;
 
-	i8 v1324 = (i8)(intptr_t)(ws+52);
-	i4 v1325;
-	f48(&v1325, v1324);
-	i8 v1326 = (i8)(intptr_t)(ws+52);
-	i4 v1327;
-	f47(&v1327, v1326);
-	i4 v1328 = v1325-v1327;
-	i8 v1329 = (i8)(intptr_t)(ws+656);
-	*(i4*)(intptr_t)v1329 = v1328;
+	goto c02_0122;
 
-c02_0131:;
+c02_0126:;
 
-	i8 v1330 = (i8)(intptr_t)(ws+656);
-	i4 v1331 = *(i4*)(intptr_t)v1330;
-	i4 v1332 = (i4)+0;
-	if (v1331==v1332) goto c02_0134; else goto c02_0133;
-
-c02_0133:;
-
-	i1 v1333 = (i1)+32;
-	f59(v1333);
-
-	i8 v1334 = (i8)(intptr_t)(ws+656);
-	i4 v1335 = *(i4*)(intptr_t)v1334;
-	i4 v1336 = v1335+(-1);
-	i8 v1337 = (i8)(intptr_t)(ws+656);
-	*(i4*)(intptr_t)v1337 = v1336;
-
-	goto c02_0131;
-
-c02_0134:;
+c02_0122:;
 
 endsub:;
+	*p1246 = *(i8*)(intptr_t)(ws+3096);
 }
 
-// getchar workspace at ws+768 length ws+9
-void f76(i1* p1342 /* c */, i8 p1343 /* fcb */) {
-	*(i8*)(intptr_t)(ws+768) = p1343; /*fcb */
+// FindOrCreateExternal workspace at ws+720 length ws+16
+void f84(i8* p1267 /* external */, i8 p1268 /* name */) {
+	*(i8*)(intptr_t)(ws+720) = p1268; /*name */
 
-	i8 v1344 = (i8)(intptr_t)(ws+585);
-	i1 v1345 = *(i1*)(intptr_t)v1344;
-	i1 v1346 = (i1)+0;
-	if (v1345==v1346) goto c02_0138; else goto c02_0139;
+	i8 v1269 = (i8)(intptr_t)(ws+24);
+	i8 v1270 = *(i8*)(intptr_t)v1269;
+	i8 v1271 = (i8)(intptr_t)(ws+728);
+	*(i8*)(intptr_t)v1271 = v1270;
 
-c02_0138:;
+c02_012e:;
 
-	i8 v1347 = (i8)(intptr_t)(ws+768);
-	i8 v1348 = *(i8*)(intptr_t)v1347;
-	i1 v1349;
-	f50(&v1349, v1348);
-	i8 v1350 = (i8)(intptr_t)(ws+776);
-	*(i1*)(intptr_t)v1350 = v1349;
+	i8 v1272 = (i8)(intptr_t)(ws+728);
+	i8 v1273 = *(i8*)(intptr_t)v1272;
+	i8 v1274 = (i8)+0;
+	if (v1273==v1274) goto c02_0131; else goto c02_0130;
 
-	goto c02_0135;
+c02_0130:;
 
-c02_0139:;
-
-	i8 v1351 = (i8)(intptr_t)(ws+585);
-	i1 v1352 = *(i1*)(intptr_t)v1351;
-	i8 v1353 = (i8)(intptr_t)(ws+776);
-	*(i1*)(intptr_t)v1353 = v1352;
-
-	i1 v1354 = (i1)+0;
-	i8 v1355 = (i8)(intptr_t)(ws+585);
-	*(i1*)(intptr_t)v1355 = v1354;
+	i8 v1275 = (i8)(intptr_t)(ws+728);
+	i8 v1276 = *(i8*)(intptr_t)v1275;
+	i8 v1277 = v1276+(+8);
+	i8 v1278 = *(i8*)(intptr_t)v1277;
+	i8 v1279 = (i8)(intptr_t)(ws+720);
+	i8 v1280 = *(i8*)(intptr_t)v1279;
+	i1 v1281;
+	f25(&v1281, v1280, v1278);
+	i1 v1282 = (i1)+0;
+	if (v1281==v1282) goto c02_0135; else goto c02_0136;
 
 c02_0135:;
 
+	goto endsub;
+
+	goto c02_0132;
+
+c02_0136:;
+
+c02_0132:;
+
+	i8 v1283 = (i8)(intptr_t)(ws+728);
+	i8 v1284 = *(i8*)(intptr_t)v1283;
+	i8 v1285 = *(i8*)(intptr_t)v1284;
+	i8 v1286 = (i8)(intptr_t)(ws+728);
+	*(i8*)(intptr_t)v1286 = v1285;
+
+	goto c02_012e;
+
+c02_0131:;
+
+	i8 v1287 = (i8)+24;
+	i8 v1288;
+	f31(&v1288, v1287);
+	i8 v1289 = (i8)(intptr_t)(ws+728);
+	*(i8*)(intptr_t)v1289 = v1288;
+
+	i8 v1290 = (i8)(intptr_t)(ws+24);
+	i8 v1291 = *(i8*)(intptr_t)v1290;
+	i8 v1292 = (i8)(intptr_t)(ws+728);
+	i8 v1293 = *(i8*)(intptr_t)v1292;
+	*(i8*)(intptr_t)v1293 = v1291;
+
+	i8 v1294 = (i8)(intptr_t)(ws+720);
+	i8 v1295 = *(i8*)(intptr_t)v1294;
+	i8 v1296;
+	f33(&v1296, v1295);
+	i8 v1297 = (i8)(intptr_t)(ws+728);
+	i8 v1298 = *(i8*)(intptr_t)v1297;
+	i8 v1299 = v1298+(+8);
+	*(i8*)(intptr_t)v1299 = v1296;
+
+	i8 v1300 = (i8)(intptr_t)(ws+728);
+	i8 v1301 = *(i8*)(intptr_t)v1300;
+	i8 v1302 = (i8)(intptr_t)(ws+24);
+	*(i8*)(intptr_t)v1302 = v1301;
+
 endsub:;
-	*p1342 = *(i1*)(intptr_t)(ws+776);
+	*p1267 = *(i8*)(intptr_t)(ws+728);
 }
-const i1 c02_s0017[] = { 0x69,0x6e,0x76,0x61,0x6c,0x69,0x64,0x20,0x68,0x65,0x78,0x20,0x6e,0x75,0x6d,0x62,0x65,0x72,0x20,0x69,0x6e,0x20,0x63,0x6f,0x6f,0x66,0x69,0x6c,0x65,0x20,0x61,0x74,0x20,0x6f,0x66,0x66,0x73,0x65,0x74,0x20,0x30,0x78,0 };
+const i1 c02_s000e[] = { 0x6d,0x75,0x6c,0x74,0x69,0x70,0x6c,0x65,0x20,0x65,0x78,0x74,0x65,0x72,0x6e,0x61,0x6c,0x20,0x64,0x65,0x63,0x6c,0x61,0x72,0x61,0x74,0x69,0x6f,0x6e,0x73,0 };
+const i1 c02_s000f[] = { 0x65,0x72,0x72,0x6f,0x72,0x3a,0x20,0x75,0x6e,0x73,0x75,0x70,0x70,0x6f,0x72,0x74,0x65,0x64,0x20,0x72,0x65,0x63,0x6f,0x72,0x64,0x20,0x27,0 };
+const i1 c02_s0010[] = { 0x27,0x20,0x69,0x6e,0x20,0x63,0x6f,0x6f,0x66,0x69,0x6c,0x65,0x0a,0 };
 
-// read_hex workspace at ws+744 length ws+17
-void f78(i4* p1360 /* val */, i1 p1361 /* len */, i8 p1362 /* fcb */) {
-	*(i8*)(intptr_t)(ws+744) = p1362; /*fcb */
-	*(i1*)(intptr_t)(ws+752) = p1361; /*len */
+// OpenAndLoadCoo workspace at ws+656 length ws+64
+void f85(i8* p1303 /* coo */, i8 p1304 /* filename */) {
+	*(i8*)(intptr_t)(ws+656) = p1304; /*filename */
 
-	i4 v1363 = (i4)+0;
-	i8 v1364 = (i8)(intptr_t)(ws+756);
-	*(i4*)(intptr_t)v1364 = v1363;
+	i8 v1305 = (i8)+674;
+	i8 v1306;
+	f31(&v1306, v1305);
+	i8 v1307 = (i8)(intptr_t)(ws+664);
+	*(i8*)(intptr_t)v1307 = v1306;
+
+	i8 v1308 = (i8)(intptr_t)(ws+40);
+	i2 v1309 = *(i2*)(intptr_t)v1308;
+	i8 v1310 = (i8)(intptr_t)(ws+664);
+	i8 v1311 = *(i8*)(intptr_t)v1310;
+	i8 v1312 = v1311+(+672);
+	*(i2*)(intptr_t)v1312 = v1309;
+
+	i8 v1313 = (i8)(intptr_t)(ws+40);
+	i2 v1314 = *(i2*)(intptr_t)v1313;
+	i2 v1315 = v1314+(+1);
+	i8 v1316 = (i8)(intptr_t)(ws+40);
+	*(i2*)(intptr_t)v1316 = v1315;
+
+	i8 v1317 = (i8)(intptr_t)(ws+664);
+	i8 v1318 = *(i8*)(intptr_t)v1317;
+	i8 v1319 = (i8)(intptr_t)(ws+656);
+	i8 v1320 = *(i8*)(intptr_t)v1319;
+	i1 v1321;
+	f40(&v1321, v1320, v1318);
+	i1 v1322 = (i1)+0;
+	if (v1321==v1322) goto c02_013b; else goto c02_013a;
 
 c02_013a:;
 
-	i8 v1365 = (i8)(intptr_t)(ws+744);
-	i8 v1366 = *(i8*)(intptr_t)v1365;
-	i1 v1367;
-	f76(&v1367, v1366);
-	i8 v1368 = (i8)(intptr_t)(ws+760);
-	*(i1*)(intptr_t)v1368 = v1367;
+	i8 v1323 = (i8)(intptr_t)(ws+656);
+	i8 v1324 = *(i8*)(intptr_t)v1323;
+	f56(v1324);
 
-	i8 v1369 = (i8)(intptr_t)(ws+760);
-	i1 v1370 = *(i1*)(intptr_t)v1369;
-	i1 v1371 = (i1)+48;
-	if (v1370<v1371) goto c02_0142; else goto c02_0143;
-
-c02_0143:;
-
-	i1 v1372 = (i1)+57;
-	i8 v1373 = (i8)(intptr_t)(ws+760);
-	i1 v1374 = *(i1*)(intptr_t)v1373;
-	if (v1372<v1374) goto c02_0142; else goto c02_0141;
-
-c02_0141:;
-
-	i8 v1375 = (i8)(intptr_t)(ws+760);
-	i1 v1376 = *(i1*)(intptr_t)v1375;
-	i1 v1377 = v1376+(-48);
-	i8 v1378 = (i8)(intptr_t)(ws+760);
-	*(i1*)(intptr_t)v1378 = v1377;
-
-	goto c02_013c;
-
-c02_0142:;
-
-	i8 v1379 = (i8)(intptr_t)(ws+760);
-	i1 v1380 = *(i1*)(intptr_t)v1379;
-	i1 v1381 = v1380&(-33);
-	i8 v1382 = (i8)(intptr_t)(ws+760);
-	*(i1*)(intptr_t)v1382 = v1381;
-
-	i8 v1383 = (i8)(intptr_t)(ws+760);
-	i1 v1384 = *(i1*)(intptr_t)v1383;
-	i1 v1385 = (i1)+65;
-	if (v1384<v1385) goto c02_014a; else goto c02_014b;
-
-c02_014b:;
-
-	i1 v1386 = (i1)+70;
-	i8 v1387 = (i8)(intptr_t)(ws+760);
-	i1 v1388 = *(i1*)(intptr_t)v1387;
-	if (v1386<v1388) goto c02_014a; else goto c02_0149;
-
-c02_0149:;
-
-	i8 v1389 = (i8)(intptr_t)(ws+760);
-	i1 v1390 = *(i1*)(intptr_t)v1389;
-	i1 v1391 = v1390+(-55);
-	i8 v1392 = (i8)(intptr_t)(ws+760);
-	*(i1*)(intptr_t)v1392 = v1391;
-
-	goto c02_0144;
-
-c02_014a:;
-
-	f55();
-
-	i8 v1393 = (i8)(intptr_t)c02_s0017;
-	f11(v1393);
-
-	i8 v1394 = (i8)(intptr_t)(ws+744);
-	i8 v1395 = *(i8*)(intptr_t)v1394;
-	i4 v1396;
-	f47(&v1396, v1395);
-	i4 v1397 = v1396+(-1);
-	f20(v1397);
-
-	f56();
-
-c02_0144:;
-
-c02_013c:;
-
-	i8 v1398 = (i8)(intptr_t)(ws+756);
-	i4 v1399 = *(i4*)(intptr_t)v1398;
-	i1 v1400 = (i1)+4;
-	i4 v1401 = ((i4)v1399)<<v1400;
-	i8 v1402 = (i8)(intptr_t)(ws+760);
-	i1 v1403 = *(i1*)(intptr_t)v1402;
-	i4 v1404 = v1403;
-	i4 v1405 = v1401+v1404;
-	i8 v1406 = (i8)(intptr_t)(ws+756);
-	*(i4*)(intptr_t)v1406 = v1405;
-
-	i8 v1407 = (i8)(intptr_t)(ws+752);
-	i1 v1408 = *(i1*)(intptr_t)v1407;
-	i1 v1409 = v1408+(-1);
-	i8 v1410 = (i8)(intptr_t)(ws+752);
-	*(i1*)(intptr_t)v1410 = v1409;
-
-	i8 v1411 = (i8)(intptr_t)(ws+752);
-	i1 v1412 = *(i1*)(intptr_t)v1411;
-	i1 v1413 = (i1)+0;
-	if (v1412==v1413) goto c02_014f; else goto c02_0150;
-
-c02_014f:;
-
-	goto c02_013b;
-
-	goto c02_014c;
-
-c02_0150:;
-
-c02_014c:;
-
-	goto c02_013a;
+	goto c02_0137;
 
 c02_013b:;
 
-endsub:;
-	*p1360 = *(i4*)(intptr_t)(ws+756);
-}
+c02_0137:;
 
-// read_hex2 workspace at ws+728 length ws+9
-void f79(i1* p1414 /* val */, i8 p1415 /* fcb */) {
-	*(i8*)(intptr_t)(ws+728) = p1415; /*fcb */
+c02_013c:;
 
-	i8 v1416 = (i8)(intptr_t)(ws+728);
-	i8 v1417 = *(i8*)(intptr_t)v1416;
-	i1 v1418 = (i1)+2;
-	i4 v1419;
-	f78(&v1419, v1418, v1417);
-	i1 v1420 = v1419;
-	i8 v1421 = (i8)(intptr_t)(ws+736);
-	*(i1*)(intptr_t)v1421 = v1420;
+	i8 v1325 = (i8)(intptr_t)(ws+664);
+	i8 v1326 = *(i8*)(intptr_t)v1325;
+	i1 v1327;
+	f74(&v1327, v1326);
+	i8 v1328 = (i8)(intptr_t)(ws+674);
+	*(i1*)(intptr_t)v1328 = v1327;
 
-endsub:;
-	*p1414 = *(i1*)(intptr_t)(ws+736);
-}
+	i8 v1329 = (i8)(intptr_t)(ws+664);
+	i8 v1330 = *(i8*)(intptr_t)v1329;
+	i2 v1331;
+	f78(&v1331, v1330);
+	i8 v1332 = (i8)(intptr_t)(ws+676);
+	*(i2*)(intptr_t)v1332 = v1331;
 
-// read_hex4 workspace at ws+728 length ws+10
-void f80(i2* p1422 /* val */, i8 p1423 /* fcb */) {
-	*(i8*)(intptr_t)(ws+728) = p1423; /*fcb */
+	i8 v1333 = (i8)(intptr_t)(ws+664);
+	i8 v1334 = *(i8*)(intptr_t)v1333;
+	i4 v1335;
+	f45(&v1335, v1334);
+	i8 v1336 = (i8)(intptr_t)(ws+680);
+	*(i4*)(intptr_t)v1336 = v1335;
 
-	i8 v1424 = (i8)(intptr_t)(ws+728);
-	i8 v1425 = *(i8*)(intptr_t)v1424;
-	i1 v1426 = (i1)+4;
-	i4 v1427;
-	f78(&v1427, v1426, v1425);
-	i2 v1428 = v1427;
-	i8 v1429 = (i8)(intptr_t)(ws+736);
-	*(i2*)(intptr_t)v1429 = v1428;
+	i8 v1337 = (i8)(intptr_t)(ws+674);
+	i1 v1338 = *(i1*)(intptr_t)v1337;
+	i1 v1339 = (i1)+69;
+	if (v1338==v1339) goto c02_0141; else goto c02_0142;
 
-endsub:;
-	*p1422 = *(i2*)(intptr_t)(ws+736);
-}
+c02_0141:;
 
-// read_string workspace at ws+728 length ws+32
-void f81(i8* p1430 /* ptr */, i1 p1431 /* len */, i8 p1432 /* fcb */) {
-	*(i8*)(intptr_t)(ws+728) = p1432; /*fcb */
-	*(i1*)(intptr_t)(ws+736) = p1431; /*len */
+	goto c02_013d;
 
-	i8 v1433 = (i8)(intptr_t)(ws+736);
-	i1 v1434 = *(i1*)(intptr_t)v1433;
-	i1 v1435 = v1434+(+1);
-	i8 v1436 = v1435;
-	i8 v1437;
-	f33(&v1437, v1436);
-	i8 v1438 = (i8)(intptr_t)(ws+744);
-	*(i8*)(intptr_t)v1438 = v1437;
+	goto c02_013e;
 
-	i8 v1439 = (i8)(intptr_t)(ws+744);
-	i8 v1440 = *(i8*)(intptr_t)v1439;
-	i8 v1441 = (i8)(intptr_t)(ws+752);
-	*(i8*)(intptr_t)v1441 = v1440;
+c02_0142:;
+
+	i8 v1340 = (i8)(intptr_t)(ws+674);
+	i1 v1341 = *(i1*)(intptr_t)v1340;
+	i1 v1342 = (i1)+83;
+	if (v1341==v1342) goto c02_0145; else goto c02_0146;
+
+c02_0145:;
+
+	i8 v1343 = (i8)(intptr_t)(ws+664);
+	i8 v1344 = *(i8*)(intptr_t)v1343;
+	i2 v1345;
+	f78(&v1345, v1344);
+	i8 v1346 = (i8)(intptr_t)(ws+672);
+	*(i2*)(intptr_t)v1346 = v1345;
+
+	i8 v1347 = (i8)(intptr_t)(ws+664);
+	i8 v1348 = *(i8*)(intptr_t)v1347;
+	i8 v1349 = (i8)(intptr_t)(ws+672);
+	i2 v1350 = *(i2*)(intptr_t)v1349;
+	i8 v1351;
+	f82(&v1351, v1350, v1348);
+	i8 v1352 = (i8)(intptr_t)(ws+688);
+	*(i8*)(intptr_t)v1352 = v1351;
+
+	i8 v1353 = (i8)(intptr_t)(ws+688);
+	i8 v1354 = *(i8*)(intptr_t)v1353;
+	i8 v1355 = v1354+(+188);
+	i1 v1356 = *(i1*)(intptr_t)v1355;
+	i1 v1357 = v1356|(+2);
+	i8 v1358 = (i8)(intptr_t)(ws+688);
+	i8 v1359 = *(i8*)(intptr_t)v1358;
+	i8 v1360 = v1359+(+188);
+	*(i1*)(intptr_t)v1360 = v1357;
+
+	goto c02_013e;
+
+c02_0146:;
+
+	i8 v1361 = (i8)(intptr_t)(ws+674);
+	i1 v1362 = *(i1*)(intptr_t)v1361;
+	i1 v1363 = (i1)+82;
+	if (v1362==v1363) goto c02_0149; else goto c02_014a;
+
+c02_0149:;
+
+	i8 v1364 = (i8)(intptr_t)(ws+664);
+	i8 v1365 = *(i8*)(intptr_t)v1364;
+	i2 v1366;
+	f78(&v1366, v1365);
+	i8 v1367 = (i8)(intptr_t)(ws+696);
+	*(i2*)(intptr_t)v1367 = v1366;
+
+	i8 v1368 = (i8)(intptr_t)(ws+664);
+	i8 v1369 = *(i8*)(intptr_t)v1368;
+	i2 v1370;
+	f78(&v1370, v1369);
+	i8 v1371 = (i8)(intptr_t)(ws+698);
+	*(i2*)(intptr_t)v1371 = v1370;
+
+	i8 v1372 = (i8)(intptr_t)(ws+664);
+	i8 v1373 = *(i8*)(intptr_t)v1372;
+	i8 v1374 = (i8)(intptr_t)(ws+696);
+	i2 v1375 = *(i2*)(intptr_t)v1374;
+	i8 v1376;
+	f82(&v1376, v1375, v1373);
+	i8 v1377 = (i8)(intptr_t)(ws+664);
+	i8 v1378 = *(i8*)(intptr_t)v1377;
+	i8 v1379 = (i8)(intptr_t)(ws+698);
+	i2 v1380 = *(i2*)(intptr_t)v1379;
+	i8 v1381;
+	f82(&v1381, v1380, v1378);
+	f80(v1381, v1376);
+
+	goto c02_013e;
+
+c02_014a:;
+
+	i8 v1382 = (i8)(intptr_t)(ws+674);
+	i1 v1383 = *(i1*)(intptr_t)v1382;
+	i1 v1384 = (i1)+87;
+	if (v1383==v1384) goto c02_014d; else goto c02_014e;
+
+c02_014d:;
+
+	i8 v1385 = (i8)(intptr_t)(ws+664);
+	i8 v1386 = *(i8*)(intptr_t)v1385;
+	i2 v1387;
+	f78(&v1387, v1386);
+	i8 v1388 = (i8)(intptr_t)(ws+672);
+	*(i2*)(intptr_t)v1388 = v1387;
+
+	i8 v1389 = (i8)(intptr_t)(ws+664);
+	i8 v1390 = *(i8*)(intptr_t)v1389;
+	i8 v1391 = (i8)(intptr_t)(ws+672);
+	i2 v1392 = *(i2*)(intptr_t)v1391;
+	i8 v1393;
+	f82(&v1393, v1392, v1390);
+	i8 v1394 = (i8)(intptr_t)(ws+688);
+	*(i8*)(intptr_t)v1394 = v1393;
+
+	i8 v1395 = (i8)(intptr_t)(ws+664);
+	i8 v1396 = *(i8*)(intptr_t)v1395;
+	i1 v1397;
+	f77(&v1397, v1396);
+	i8 v1398 = (i8)(intptr_t)(ws+700);
+	*(i1*)(intptr_t)v1398 = v1397;
+
+	i8 v1399 = (i8)(intptr_t)(ws+664);
+	i8 v1400 = *(i8*)(intptr_t)v1399;
+	i2 v1401;
+	f78(&v1401, v1400);
+	i8 v1402 = (i8)(intptr_t)(ws+688);
+	i8 v1403 = *(i8*)(intptr_t)v1402;
+	i8 v1404 = v1403+(+168);
+	i8 v1405 = (i8)(intptr_t)(ws+700);
+	i1 v1406 = *(i1*)(intptr_t)v1405;
+	i8 v1407 = v1406;
+	i1 v1408 = (i1)+1;
+	i8 v1409 = ((i8)v1407)<<v1408;
+	i8 v1410 = v1404+v1409;
+	*(i2*)(intptr_t)v1410 = v1401;
+
+	goto c02_013e;
+
+c02_014e:;
+
+	i8 v1411 = (i8)(intptr_t)(ws+674);
+	i1 v1412 = *(i1*)(intptr_t)v1411;
+	i1 v1413 = (i1)+78;
+	if (v1412==v1413) goto c02_0151; else goto c02_0152;
 
 c02_0151:;
 
-	i8 v1442 = (i8)(intptr_t)(ws+736);
-	i1 v1443 = *(i1*)(intptr_t)v1442;
-	i1 v1444 = (i1)+0;
-	if (v1443==v1444) goto c02_0156; else goto c02_0157;
+	i8 v1414 = (i8)(intptr_t)(ws+664);
+	i8 v1415 = *(i8*)(intptr_t)v1414;
+	i2 v1416;
+	f78(&v1416, v1415);
+	i8 v1417 = (i8)(intptr_t)(ws+672);
+	*(i2*)(intptr_t)v1417 = v1416;
 
-c02_0156:;
+	i8 v1418 = (i8)(intptr_t)(ws+664);
+	i8 v1419 = *(i8*)(intptr_t)v1418;
+	i8 v1420 = (i8)(intptr_t)(ws+672);
+	i2 v1421 = *(i2*)(intptr_t)v1420;
+	i8 v1422;
+	f82(&v1422, v1421, v1419);
+	i8 v1423 = (i8)(intptr_t)(ws+688);
+	*(i8*)(intptr_t)v1423 = v1422;
 
-	goto c02_0152;
+	i8 v1424 = (i8)(intptr_t)(ws+664);
+	i8 v1425 = *(i8*)(intptr_t)v1424;
+	i8 v1426 = (i8)(intptr_t)(ws+676);
+	i2 v1427 = *(i2*)(intptr_t)v1426;
+	i1 v1428 = v1427;
+	i1 v1429 = v1428+(-4);
+	i8 v1430;
+	f79(&v1430, v1429, v1425);
+	i8 v1431 = (i8)(intptr_t)(ws+688);
+	i8 v1432 = *(i8*)(intptr_t)v1431;
+	i8 v1433 = v1432+(+152);
+	*(i8*)(intptr_t)v1433 = v1430;
 
-	goto c02_0153;
-
-c02_0157:;
-
-c02_0153:;
-
-	i8 v1445 = (i8)(intptr_t)(ws+728);
-	i8 v1446 = *(i8*)(intptr_t)v1445;
-	i1 v1447;
-	f76(&v1447, v1446);
-	i8 v1448 = (i8)(intptr_t)(ws+752);
-	i8 v1449 = *(i8*)(intptr_t)v1448;
-	*(i1*)(intptr_t)v1449 = v1447;
-
-	i8 v1450 = (i8)(intptr_t)(ws+752);
-	i8 v1451 = *(i8*)(intptr_t)v1450;
-	i8 v1452 = v1451+(+1);
-	i8 v1453 = (i8)(intptr_t)(ws+752);
-	*(i8*)(intptr_t)v1453 = v1452;
-
-	i8 v1454 = (i8)(intptr_t)(ws+736);
-	i1 v1455 = *(i1*)(intptr_t)v1454;
-	i1 v1456 = v1455+(-1);
-	i8 v1457 = (i8)(intptr_t)(ws+736);
-	*(i1*)(intptr_t)v1457 = v1456;
-
-	goto c02_0151;
+	goto c02_013e;
 
 c02_0152:;
 
-endsub:;
-	*p1430 = *(i8*)(intptr_t)(ws+744);
-}
+	i8 v1434 = (i8)(intptr_t)(ws+674);
+	i1 v1435 = *(i1*)(intptr_t)v1434;
+	i1 v1436 = (i1)+88;
+	if (v1435==v1436) goto c02_0155; else goto c02_0156;
 
-// AddRef workspace at ws+728 length ws+32
-void f82(i8 p1458 /* calls */, i8 p1459 /* subr */) {
-	*(i8*)(intptr_t)(ws+728) = p1459; /*subr */
-	*(i8*)(intptr_t)(ws+736) = p1458; /*calls */
+c02_0155:;
 
-	i8 v1460 = (i8)(intptr_t)(ws+728);
-	i8 v1461 = *(i8*)(intptr_t)v1460;
-	i8 v1462 = v1461+(+184);
-	i2 v1463 = *(i2*)(intptr_t)v1462;
-	i8 v1464 = (i8)(intptr_t)(ws+744);
-	*(i2*)(intptr_t)v1464 = v1463;
+	i8 v1437 = (i8)(intptr_t)(ws+664);
+	i8 v1438 = *(i8*)(intptr_t)v1437;
+	i2 v1439;
+	f78(&v1439, v1438);
+	i8 v1440 = (i8)(intptr_t)(ws+672);
+	*(i2*)(intptr_t)v1440 = v1439;
 
-	i8 v1465 = (i8)(intptr_t)(ws+744);
-	i2 v1466 = *(i2*)(intptr_t)v1465;
-	i2 v1467 = v1466+(+1);
-	i8 v1468 = (i8)(intptr_t)(ws+728);
-	i8 v1469 = *(i8*)(intptr_t)v1468;
-	i8 v1470 = v1469+(+184);
-	*(i2*)(intptr_t)v1470 = v1467;
+	i8 v1441 = (i8)(intptr_t)(ws+664);
+	i8 v1442 = *(i8*)(intptr_t)v1441;
+	i8 v1443 = (i8)(intptr_t)(ws+672);
+	i2 v1444 = *(i2*)(intptr_t)v1443;
+	i8 v1445;
+	f82(&v1445, v1444, v1442);
+	i8 v1446 = (i8)(intptr_t)(ws+688);
+	*(i8*)(intptr_t)v1446 = v1445;
 
-	i8 v1471 = (i8)(intptr_t)(ws+728);
-	i8 v1472 = *(i8*)(intptr_t)v1471;
-	i8 v1473 = v1472+(+16);
-	i8 v1474 = (i8)(intptr_t)(ws+752);
-	*(i8*)(intptr_t)v1474 = v1473;
+	i8 v1447 = (i8)(intptr_t)(ws+664);
+	i8 v1448 = *(i8*)(intptr_t)v1447;
+	i8 v1449 = (i8)(intptr_t)(ws+676);
+	i2 v1450 = *(i2*)(intptr_t)v1449;
+	i1 v1451 = v1450;
+	i1 v1452 = v1451+(-4);
+	i8 v1453;
+	f79(&v1453, v1452, v1448);
+	i8 v1454 = (i8)(intptr_t)(ws+704);
+	*(i8*)(intptr_t)v1454 = v1453;
+
+	i8 v1455 = (i8)(intptr_t)(ws+704);
+	i8 v1456 = *(i8*)(intptr_t)v1455;
+	i8 v1457;
+	f84(&v1457, v1456);
+	i8 v1458 = (i8)(intptr_t)(ws+712);
+	*(i8*)(intptr_t)v1458 = v1457;
+
+	i8 v1459 = (i8)(intptr_t)(ws+688);
+	i8 v1460 = *(i8*)(intptr_t)v1459;
+	i8 v1461 = v1460+(+160);
+	i8 v1462 = *(i8*)(intptr_t)v1461;
+	i8 v1463 = (i8)+0;
+	if (v1462==v1463) goto c02_015b; else goto c02_015a;
 
 c02_015a:;
 
-	i8 v1475 = (i8)(intptr_t)(ws+744);
-	i2 v1476 = *(i2*)(intptr_t)v1475;
-	i2 v1477 = (i2)+16;
-	if (v1476<v1477) goto c02_015d; else goto c02_015c;
+	i8 v1464 = (i8)(intptr_t)c02_s000e;
+	f55(v1464);
+
+	goto c02_0157;
+
+c02_015b:;
+
+c02_0157:;
+
+	i8 v1465 = (i8)(intptr_t)(ws+712);
+	i8 v1466 = *(i8*)(intptr_t)v1465;
+	i8 v1467 = (i8)(intptr_t)(ws+688);
+	i8 v1468 = *(i8*)(intptr_t)v1467;
+	i8 v1469 = v1468+(+160);
+	*(i8*)(intptr_t)v1469 = v1466;
+
+	goto c02_013e;
+
+c02_0156:;
+
+	i8 v1470 = (i8)(intptr_t)c02_s000f;
+	f11(v1470);
+
+	i8 v1471 = (i8)(intptr_t)(ws+674);
+	i1 v1472 = *(i1*)(intptr_t)v1471;
+	f8(v1472);
+
+	i8 v1473 = (i8)(intptr_t)c02_s0010;
+	f11(v1473);
+
+	f6();
+
+c02_013e:;
+
+	i8 v1474 = (i8)(intptr_t)(ws+664);
+	i8 v1475 = *(i8*)(intptr_t)v1474;
+	i8 v1476 = (i8)(intptr_t)(ws+680);
+	i4 v1477 = *(i4*)(intptr_t)v1476;
+	i8 v1478 = (i8)(intptr_t)(ws+676);
+	i2 v1479 = *(i2*)(intptr_t)v1478;
+	i4 v1480 = v1479;
+	i4 v1481 = v1477+v1480;
+	f44(v1481, v1475);
+
+	goto c02_013c;
+
+c02_013d:;
+
+endsub:;
+	*p1303 = *(i8*)(intptr_t)(ws+664);
+}
+const i1 c02_s0011[] = { 0x65,0x72,0x72,0x6f,0x72,0x3a,0x20,0x6d,0x61,0x6c,0x66,0x6f,0x72,0x6d,0x65,0x64,0x20,0x63,0x6f,0x6f,0x66,0x69,0x6c,0x65,0x3a,0x20,0 };
+
+// MalformedError workspace at ws+704 length ws+8
+void f87(i8 p1483 /* s */) {
+	*(i8*)(intptr_t)(ws+704) = p1483; /*s */
+
+	i8 v1484 = (i8)(intptr_t)c02_s0011;
+	f11(v1484);
+
+	i8 v1485 = (i8)(intptr_t)(ws+704);
+	i8 v1486 = *(i8*)(intptr_t)v1485;
+	f11(v1486);
+
+	f12();
+
+	f6();
+
+endsub:;
+}
+const i1 c02_s0012[] = { 0x75,0x6e,0x65,0x78,0x70,0x65,0x63,0x74,0x65,0x64,0x20,0x65,0x6e,0x64,0x20,0x6f,0x66,0x20,0x63,0x68,0x75,0x6e,0x6b,0 };
+
+// UnexpectedEndOfChunk workspace at ws+704 length ws+0
+void f88(void) {
+
+	i8 v1487 = (i8)(intptr_t)c02_s0012;
+	f87(v1487);
+
+endsub:;
+}
+const i1 c02_s0013[] = { 0x63,0x68,0x75,0x6e,0x6b,0x20,0x73,0x69,0x7a,0x65,0x20,0x69,0x6e,0x63,0x6f,0x6e,0x73,0x69,0x73,0x74,0x65,0x6e,0x74,0 };
+
+// GetC workspace at ws+696 length ws+0
+void f89(void) {
+
+	i8 v1488 = (i8)(intptr_t)(ws+666);
+	i2 v1489 = *(i2*)(intptr_t)v1488;
+	i2 v1490 = (i2)+0;
+	if (v1489==v1490) goto c02_015f; else goto c02_0160;
+
+c02_015f:;
+
+	i8 v1491 = (i8)(intptr_t)c02_s0013;
+	f87(v1491);
+
+	goto c02_015c;
+
+c02_0160:;
 
 c02_015c:;
 
-	i8 v1478 = (i8)(intptr_t)(ws+752);
-	i8 v1479 = *(i8*)(intptr_t)v1478;
-	i8 v1480 = *(i8*)(intptr_t)v1479;
-	i8 v1481 = (i8)+0;
-	if (v1480==v1481) goto c02_0161; else goto c02_0162;
+	i8 v1492 = (i8)(intptr_t)(ws+666);
+	i2 v1493 = *(i2*)(intptr_t)v1492;
+	i2 v1494 = v1493+(-1);
+	i8 v1495 = (i8)(intptr_t)(ws+666);
+	*(i2*)(intptr_t)v1495 = v1494;
 
-c02_0161:;
-
-	i8 v1482 = (i8)+136;
-	i8 v1483;
-	f33(&v1483, v1482);
-	i8 v1484 = (i8)(intptr_t)(ws+752);
-	i8 v1485 = *(i8*)(intptr_t)v1484;
-	*(i8*)(intptr_t)v1485 = v1483;
-
-	goto c02_015e;
-
-c02_0162:;
-
-c02_015e:;
-
-	i8 v1486 = (i8)(intptr_t)(ws+752);
-	i8 v1487 = *(i8*)(intptr_t)v1486;
-	i8 v1488 = *(i8*)(intptr_t)v1487;
-	i8 v1489 = (i8)(intptr_t)(ws+752);
-	*(i8*)(intptr_t)v1489 = v1488;
-
-	i8 v1490 = (i8)(intptr_t)(ws+744);
-	i2 v1491 = *(i2*)(intptr_t)v1490;
-	i2 v1492 = v1491+(-16);
-	i8 v1493 = (i8)(intptr_t)(ws+744);
-	*(i2*)(intptr_t)v1493 = v1492;
-
-	goto c02_015a;
-
-c02_015d:;
-
-	i8 v1494 = (i8)(intptr_t)(ws+736);
-	i8 v1495 = *(i8*)(intptr_t)v1494;
-	i8 v1496 = (i8)(intptr_t)(ws+752);
+	i8 v1496 = (i8)(intptr_t)(ws+640);
 	i8 v1497 = *(i8*)(intptr_t)v1496;
-	i8 v1498 = v1497+(+8);
-	i8 v1499 = (i8)(intptr_t)(ws+744);
-	i2 v1500 = *(i2*)(intptr_t)v1499;
-	i1 v1501 = v1500;
-	i8 v1502 = v1501;
-	i1 v1503 = (i1)+3;
-	i8 v1504 = ((i8)v1502)<<v1503;
-	i8 v1505 = v1498+v1504;
-	*(i8*)(intptr_t)v1505 = v1495;
+	i1 v1498;
+	f74(&v1498, v1497);
+	i8 v1499 = (i8)(intptr_t)(ws+664);
+	*(i1*)(intptr_t)v1499 = v1498;
 
 endsub:;
 }
 
-// FindSub workspace at ws+760 length ws+32
-void f83(i8* p1506 /* ptr */, i2 p1507 /* id */, i8 p1508 /* coo */) {
-	*(i8*)(intptr_t)(ws+760) = p1508; /*coo */
-	*(i2*)(intptr_t)(ws+768) = p1507; /*id */
+// ReadH2 workspace at ws+696 length ws+1
+void f91(i1* p1506 /* result */) {
 
-	i8 v1509 = (i8)(intptr_t)(ws+760);
-	i8 v1510 = *(i8*)(intptr_t)v1509;
-	i8 v1511 = v1510+(+528);
-	i8 v1512 = (i8)(intptr_t)(ws+784);
-	*(i8*)(intptr_t)v1512 = v1511;
+	i8 v1507 = (i8)(intptr_t)(ws+666);
+	i2 v1508 = *(i2*)(intptr_t)v1507;
+	i2 v1509 = (i2)+2;
+	if (v1508<v1509) goto c02_0164; else goto c02_0165;
+
+c02_0164:;
+
+	f88();
+
+	goto c02_0161;
 
 c02_0165:;
 
-	i8 v1513 = (i8)(intptr_t)(ws+768);
-	i2 v1514 = *(i2*)(intptr_t)v1513;
-	i2 v1515 = (i2)+16;
-	if (v1514<v1515) goto c02_0168; else goto c02_0167;
+c02_0161:;
 
-c02_0167:;
+	i8 v1510 = (i8)(intptr_t)(ws+666);
+	i2 v1511 = *(i2*)(intptr_t)v1510;
+	i2 v1512 = v1511+(-2);
+	i8 v1513 = (i8)(intptr_t)(ws+666);
+	*(i2*)(intptr_t)v1513 = v1512;
 
-	i8 v1516 = (i8)(intptr_t)(ws+784);
-	i8 v1517 = *(i8*)(intptr_t)v1516;
-	i8 v1518 = *(i8*)(intptr_t)v1517;
-	i8 v1519 = (i8)+0;
-	if (v1518==v1519) goto c02_016c; else goto c02_016d;
+	i8 v1514 = (i8)(intptr_t)(ws+640);
+	i8 v1515 = *(i8*)(intptr_t)v1514;
+	i1 v1516;
+	f77(&v1516, v1515);
+	i8 v1517 = (i8)(intptr_t)(ws+696);
+	*(i1*)(intptr_t)v1517 = v1516;
 
-c02_016c:;
+endsub:;
+	*p1506 = *(i1*)(intptr_t)(ws+696);
+}
 
-	i8 v1520 = (i8)+136;
-	i8 v1521;
-	f33(&v1521, v1520);
-	i8 v1522 = (i8)(intptr_t)(ws+784);
-	i8 v1523 = *(i8*)(intptr_t)v1522;
-	*(i8*)(intptr_t)v1523 = v1521;
+// ReadH4 workspace at ws+696 length ws+2
+void f92(i2* p1518 /* result */) {
 
-	goto c02_0169;
-
-c02_016d:;
+	i8 v1519 = (i8)(intptr_t)(ws+666);
+	i2 v1520 = *(i2*)(intptr_t)v1519;
+	i2 v1521 = (i2)+4;
+	if (v1520<v1521) goto c02_0169; else goto c02_016a;
 
 c02_0169:;
 
-	i8 v1524 = (i8)(intptr_t)(ws+784);
-	i8 v1525 = *(i8*)(intptr_t)v1524;
-	i8 v1526 = *(i8*)(intptr_t)v1525;
-	i8 v1527 = (i8)(intptr_t)(ws+784);
-	*(i8*)(intptr_t)v1527 = v1526;
+	f88();
 
-	i8 v1528 = (i8)(intptr_t)(ws+768);
-	i2 v1529 = *(i2*)(intptr_t)v1528;
-	i2 v1530 = v1529+(-16);
-	i8 v1531 = (i8)(intptr_t)(ws+768);
-	*(i2*)(intptr_t)v1531 = v1530;
+	goto c02_0166;
 
-	goto c02_0165;
+c02_016a:;
 
-c02_0168:;
+c02_0166:;
 
-	i8 v1532 = (i8)(intptr_t)(ws+784);
-	i8 v1533 = *(i8*)(intptr_t)v1532;
-	i8 v1534 = v1533+(+8);
-	i8 v1535 = (i8)(intptr_t)(ws+768);
-	i2 v1536 = *(i2*)(intptr_t)v1535;
-	i1 v1537 = v1536;
-	i8 v1538 = v1537;
-	i1 v1539 = (i1)+3;
-	i8 v1540 = ((i8)v1538)<<v1539;
-	i8 v1541 = v1534+v1540;
-	i8 v1542 = (i8)(intptr_t)(ws+776);
-	*(i8*)(intptr_t)v1542 = v1541;
+	i8 v1522 = (i8)(intptr_t)(ws+666);
+	i2 v1523 = *(i2*)(intptr_t)v1522;
+	i2 v1524 = v1523+(-4);
+	i8 v1525 = (i8)(intptr_t)(ws+666);
+	*(i2*)(intptr_t)v1525 = v1524;
+
+	i8 v1526 = (i8)(intptr_t)(ws+640);
+	i8 v1527 = *(i8*)(intptr_t)v1526;
+	i2 v1528;
+	f78(&v1528, v1527);
+	i8 v1529 = (i8)(intptr_t)(ws+696);
+	*(i2*)(intptr_t)v1529 = v1528;
 
 endsub:;
-	*p1506 = *(i8*)(intptr_t)(ws+776);
+	*p1518 = *(i2*)(intptr_t)(ws+696);
 }
 
-// FindOrCreateSub workspace at ws+728 length ws+32
-void f84(i8* p1543 /* subroutine */, i2 p1544 /* id */, i8 p1545 /* coo */) {
-	*(i8*)(intptr_t)(ws+728) = p1545; /*coo */
-	*(i2*)(intptr_t)(ws+736) = p1544; /*id */
+// CopySourceChunk workspace at ws+672 length ws+20
+void f93(void) {
 
-	i8 v1546 = (i8)(intptr_t)(ws+728);
-	i8 v1547 = *(i8*)(intptr_t)v1546;
-	i8 v1548 = (i8)(intptr_t)(ws+736);
-	i2 v1549 = *(i2*)(intptr_t)v1548;
-	i8 v1550;
-	f83(&v1550, v1549, v1547);
-	i8 v1551 = (i8)(intptr_t)(ws+752);
-	*(i8*)(intptr_t)v1551 = v1550;
+c02_016d:;
 
-	i8 v1552 = (i8)(intptr_t)(ws+752);
-	i8 v1553 = *(i8*)(intptr_t)v1552;
-	i8 v1554 = *(i8*)(intptr_t)v1553;
-	i8 v1555 = (i8)(intptr_t)(ws+744);
-	*(i8*)(intptr_t)v1555 = v1554;
+	i8 v1530 = (i8)(intptr_t)(ws+666);
+	i2 v1531 = *(i2*)(intptr_t)v1530;
+	i2 v1532 = (i2)+0;
+	if (v1531==v1532) goto c02_0170; else goto c02_016f;
 
-	i8 v1556 = (i8)(intptr_t)(ws+744);
-	i8 v1557 = *(i8*)(intptr_t)v1556;
-	i8 v1558 = (i8)+0;
-	if (v1557==v1558) goto c02_0171; else goto c02_0172;
+c02_016f:;
 
-c02_0171:;
+	f89();
 
-	i8 v1559 = (i8)+189;
-	i8 v1560;
-	f33(&v1560, v1559);
-	i8 v1561 = (i8)(intptr_t)(ws+744);
-	*(i8*)(intptr_t)v1561 = v1560;
+	i8 v1533 = (i8)(intptr_t)(ws+664);
+	i1 v1534 = *(i1*)(intptr_t)v1533;
 
-	i8 v1562 = (i8)(intptr_t)(ws+728);
-	i8 v1563 = *(i8*)(intptr_t)v1562;
-	i8 v1564 = (i8)(intptr_t)(ws+744);
-	i8 v1565 = *(i8*)(intptr_t)v1564;
-	*(i8*)(intptr_t)v1565 = v1563;
+	if (v1534 != +3) goto c02_0172;
 
-	i8 v1566 = (i8)(intptr_t)(ws+40);
-	i8 v1567 = *(i8*)(intptr_t)v1566;
-	i8 v1568 = (i8)(intptr_t)(ws+744);
-	i8 v1569 = *(i8*)(intptr_t)v1568;
-	i8 v1570 = v1569+(+8);
-	*(i8*)(intptr_t)v1570 = v1567;
+	i1 v1535 = (i1)+99;
+	f57(v1535);
 
-	i8 v1571 = (i8)(intptr_t)(ws+744);
-	i8 v1572 = *(i8*)(intptr_t)v1571;
-	i8 v1573 = (i8)(intptr_t)(ws+40);
-	*(i8*)(intptr_t)v1573 = v1572;
+	i8 v1536 = (i8)(intptr_t)(ws+640);
+	i8 v1537 = *(i8*)(intptr_t)v1536;
+	i8 v1538 = v1537+(+672);
+	i2 v1539 = *(i2*)(intptr_t)v1538;
+	i1 v1540 = v1539;
+	f64(v1540);
 
-	i8 v1574 = (i8)(intptr_t)(ws+48);
-	i2 v1575 = *(i2*)(intptr_t)v1574;
-	i8 v1576 = (i8)(intptr_t)(ws+744);
-	i8 v1577 = *(i8*)(intptr_t)v1576;
-	i8 v1578 = v1577+(+186);
-	*(i2*)(intptr_t)v1578 = v1575;
+	i1 v1541 = (i1)+95;
+	f57(v1541);
 
-	i8 v1579 = (i8)(intptr_t)(ws+744);
-	i8 v1580 = *(i8*)(intptr_t)v1579;
-	i8 v1581 = (i8)(intptr_t)(ws+752);
-	i8 v1582 = *(i8*)(intptr_t)v1581;
-	*(i8*)(intptr_t)v1582 = v1580;
-
-	i8 v1583 = (i8)(intptr_t)(ws+48);
-	i2 v1584 = *(i2*)(intptr_t)v1583;
-	i2 v1585 = v1584+(+1);
-	i8 v1586 = (i8)(intptr_t)(ws+48);
-	*(i2*)(intptr_t)v1586 = v1585;
-
-	goto c02_016e;
+	goto c02_0171;
 
 c02_0172:;
 
-c02_016e:;
+	if (v1534 != +4) goto c02_0173;
 
-endsub:;
-	*p1543 = *(i8*)(intptr_t)(ws+744);
-}
+	i8 v1542 = (i8)(intptr_t)(ws+656);
+	i8 v1543 = *(i8*)(intptr_t)v1542;
+	f70(v1543);
 
-// Deref workspace at ws+3096 length ws+24
-void f85(i8* p1587 /* subout */, i8 p1588 /* subin */) {
-	*(i8*)(intptr_t)(ws+3096) = p1588; /*subin */
-
-	i8 v1589 = (i8)(intptr_t)(ws+3096);
-	i8 v1590 = *(i8*)(intptr_t)v1589;
-	i8 v1591 = (i8)(intptr_t)(ws+3104);
-	*(i8*)(intptr_t)v1591 = v1590;
-
-	i8 v1592 = (i8)(intptr_t)(ws+3096);
-	i8 v1593 = *(i8*)(intptr_t)v1592;
-	i8 v1594 = (i8)+0;
-	if (v1593==v1594) goto c02_0177; else goto c02_0176;
-
-c02_0176:;
-
-	i8 v1595 = (i8)(intptr_t)(ws+3096);
-	i8 v1596 = *(i8*)(intptr_t)v1595;
-	i8 v1597 = v1596+(+160);
-	i8 v1598 = *(i8*)(intptr_t)v1597;
-	i8 v1599 = (i8)(intptr_t)(ws+3112);
-	*(i8*)(intptr_t)v1599 = v1598;
-
-	i8 v1600 = (i8)(intptr_t)(ws+3112);
-	i8 v1601 = *(i8*)(intptr_t)v1600;
-	i8 v1602 = (i8)+0;
-	if (v1601==v1602) goto c02_017c; else goto c02_017b;
-
-c02_017b:;
-
-	i8 v1603 = (i8)(intptr_t)(ws+3112);
-	i8 v1604 = *(i8*)(intptr_t)v1603;
-	i8 v1605 = v1604+(+16);
-	i8 v1606 = *(i8*)(intptr_t)v1605;
-	i8 v1607 = (i8)(intptr_t)(ws+3104);
-	*(i8*)(intptr_t)v1607 = v1606;
-
-	goto c02_0178;
-
-c02_017c:;
-
-c02_0178:;
-
-	goto c02_0173;
-
-c02_0177:;
+	goto c02_0171;
 
 c02_0173:;
 
+	if (v1534 != +1) goto c02_0174;
+
+	i2 v1544;
+	f92(&v1544);
+	i8 v1545 = (i8)(intptr_t)(ws+672);
+	*(i2*)(intptr_t)v1545 = v1544;
+
+	i8 v1546 = (i8)(intptr_t)(ws+640);
+	i8 v1547 = *(i8*)(intptr_t)v1546;
+	i8 v1548 = (i8)(intptr_t)(ws+672);
+	i2 v1549 = *(i2*)(intptr_t)v1548;
+	i8 v1550;
+	f82(&v1550, v1549, v1547);
+	i8 v1551 = (i8)(intptr_t)(ws+680);
+	*(i8*)(intptr_t)v1551 = v1550;
+
+	i8 v1552 = (i8)(intptr_t)(ws+680);
+	i8 v1553 = *(i8*)(intptr_t)v1552;
+	i8 v1554;
+	f83(&v1554, v1553);
+	i8 v1555 = (i8)(intptr_t)(ws+680);
+	*(i8*)(intptr_t)v1555 = v1554;
+
+	i8 v1556 = (i8)(intptr_t)(ws+680);
+	i8 v1557 = *(i8*)(intptr_t)v1556;
+	f70(v1557);
+
+	goto c02_0171;
+
+c02_0174:;
+
+	if (v1534 != +2) goto c02_0175;
+
+	i2 v1558;
+	f92(&v1558);
+	i8 v1559 = (i8)(intptr_t)(ws+672);
+	*(i2*)(intptr_t)v1559 = v1558;
+
+	i1 v1560;
+	f91(&v1560);
+	i8 v1561 = (i8)(intptr_t)(ws+688);
+	*(i1*)(intptr_t)v1561 = v1560;
+
+	i2 v1562;
+	f92(&v1562);
+	i8 v1563 = (i8)(intptr_t)(ws+690);
+	*(i2*)(intptr_t)v1563 = v1562;
+
+	i8 v1564 = (i8)(intptr_t)(ws+640);
+	i8 v1565 = *(i8*)(intptr_t)v1564;
+	i8 v1566 = (i8)(intptr_t)(ws+672);
+	i2 v1567 = *(i2*)(intptr_t)v1566;
+	i8 v1568;
+	f82(&v1568, v1567, v1565);
+	i8 v1569 = (i8)(intptr_t)(ws+680);
+	*(i8*)(intptr_t)v1569 = v1568;
+
+	i8 v1570 = (i8)(intptr_t)(ws+680);
+	i8 v1571 = *(i8*)(intptr_t)v1570;
+	i8 v1572;
+	f83(&v1572, v1571);
+	i8 v1573 = (i8)(intptr_t)(ws+680);
+	*(i8*)(intptr_t)v1573 = v1572;
+
+	i8 v1574 = (i8)(intptr_t)(ws+688);
+	i1 v1575 = *(i1*)(intptr_t)v1574;
+	i8 v1576 = (i8)(intptr_t)(ws+680);
+	i8 v1577 = *(i8*)(intptr_t)v1576;
+	i8 v1578 = v1577+(+176);
+	i8 v1579 = (i8)(intptr_t)(ws+688);
+	i1 v1580 = *(i1*)(intptr_t)v1579;
+	i8 v1581 = v1580;
+	i1 v1582 = (i1)+1;
+	i8 v1583 = ((i8)v1581)<<v1582;
+	i8 v1584 = v1578+v1583;
+	i2 v1585 = *(i2*)(intptr_t)v1584;
+	i8 v1586 = (i8)(intptr_t)(ws+690);
+	i2 v1587 = *(i2*)(intptr_t)v1586;
+	i2 v1588 = v1585+v1587;
+	f71(v1588, v1575);
+
+	goto c02_0171;
+
+c02_0175:;
+
+	if (v1534 != +5) goto c02_0176;
+
+	i2 v1589;
+	f92(&v1589);
+	i8 v1590 = (i8)(intptr_t)(ws+672);
+	*(i2*)(intptr_t)v1590 = v1589;
+
+	i1 v1591;
+	f91(&v1591);
+	i8 v1592 = (i8)(intptr_t)(ws+688);
+	*(i1*)(intptr_t)v1592 = v1591;
+
+	i8 v1593 = (i8)(intptr_t)(ws+640);
+	i8 v1594 = *(i8*)(intptr_t)v1593;
+	i8 v1595 = (i8)(intptr_t)(ws+672);
+	i2 v1596 = *(i2*)(intptr_t)v1595;
+	i8 v1597;
+	f82(&v1597, v1596, v1594);
+	i8 v1598 = (i8)(intptr_t)(ws+680);
+	*(i8*)(intptr_t)v1598 = v1597;
+
+	i8 v1599 = (i8)(intptr_t)(ws+680);
+	i8 v1600 = *(i8*)(intptr_t)v1599;
+	i8 v1601;
+	f83(&v1601, v1600);
+	i8 v1602 = (i8)(intptr_t)(ws+680);
+	*(i8*)(intptr_t)v1602 = v1601;
+
+	i8 v1603 = (i8)(intptr_t)(ws+688);
+	i1 v1604 = *(i1*)(intptr_t)v1603;
+	i8 v1605 = (i8)(intptr_t)(ws+680);
+	i8 v1606 = *(i8*)(intptr_t)v1605;
+	i8 v1607 = v1606+(+168);
+	i8 v1608 = (i8)(intptr_t)(ws+688);
+	i1 v1609 = *(i1*)(intptr_t)v1608;
+	i8 v1610 = v1609;
+	i1 v1611 = (i1)+1;
+	i8 v1612 = ((i8)v1610)<<v1611;
+	i8 v1613 = v1607+v1612;
+	i2 v1614 = *(i2*)(intptr_t)v1613;
+	f71(v1614, v1604);
+
+	goto c02_0171;
+
+c02_0176:;
+
+	i8 v1615 = (i8)(intptr_t)(ws+664);
+	i1 v1616 = *(i1*)(intptr_t)v1615;
+	f57(v1616);
+
+c02_0171:;
+
+
+	goto c02_016d;
+
+c02_0170:;
+
 endsub:;
-	*p1587 = *(i8*)(intptr_t)(ws+3104);
 }
 
-// FindOrCreateExternal workspace at ws+728 length ws+16
-void f86(i8* p1608 /* external */, i8 p1609 /* name */) {
-	*(i8*)(intptr_t)(ws+728) = p1609; /*name */
+// WriteSubroutinesToOutputFile workspace at ws+640 length ws+32
+void f86(i8 p1482 /* coo */) {
+	*(i8*)(intptr_t)(ws+640) = p1482; /*coo */
 
-	i8 v1610 = (i8)(intptr_t)(ws+32);
-	i8 v1611 = *(i8*)(intptr_t)v1610;
-	i8 v1612 = (i8)(intptr_t)(ws+736);
-	*(i8*)(intptr_t)v1612 = v1611;
 
-c02_017f:;
 
-	i8 v1613 = (i8)(intptr_t)(ws+736);
-	i8 v1614 = *(i8*)(intptr_t)v1613;
-	i8 v1615 = (i8)+0;
-	if (v1614==v1615) goto c02_0182; else goto c02_0181;
 
-c02_0181:;
 
-	i8 v1616 = (i8)(intptr_t)(ws+736);
-	i8 v1617 = *(i8*)(intptr_t)v1616;
-	i8 v1618 = v1617+(+8);
-	i8 v1619 = *(i8*)(intptr_t)v1618;
-	i8 v1620 = (i8)(intptr_t)(ws+728);
-	i8 v1621 = *(i8*)(intptr_t)v1620;
-	i1 v1622;
-	f25(&v1622, v1621, v1619);
-	i1 v1623 = (i1)+0;
-	if (v1622==v1623) goto c02_0186; else goto c02_0187;
+
+
+
+	i8 v1617 = (i8)(intptr_t)(ws+640);
+	i8 v1618 = *(i8*)(intptr_t)v1617;
+	i4 v1619 = (i4)+0;
+	f44(v1619, v1618);
+
+c02_0177:;
+
+	i2 v1620 = (i2)+255;
+	i8 v1621 = (i8)(intptr_t)(ws+666);
+	*(i2*)(intptr_t)v1621 = v1620;
+
+	f89();
+
+	i2 v1622;
+	f92(&v1622);
+	i8 v1623 = (i8)(intptr_t)(ws+666);
+	*(i2*)(intptr_t)v1623 = v1622;
+
+	i8 v1624 = (i8)(intptr_t)(ws+640);
+	i8 v1625 = *(i8*)(intptr_t)v1624;
+	i4 v1626;
+	f45(&v1626, v1625);
+	i8 v1627 = (i8)(intptr_t)(ws+666);
+	i2 v1628 = *(i2*)(intptr_t)v1627;
+	i4 v1629 = v1628;
+	i4 v1630 = v1626+v1629;
+	i8 v1631 = (i8)(intptr_t)(ws+668);
+	*(i4*)(intptr_t)v1631 = v1630;
+
+	i8 v1632 = (i8)(intptr_t)(ws+664);
+	i1 v1633 = *(i1*)(intptr_t)v1632;
+	i1 v1634 = (i1)+69;
+	if (v1633==v1634) goto c02_017c; else goto c02_017d;
+
+c02_017c:;
+
+	goto c02_0178;
+
+	goto c02_0179;
+
+c02_017d:;
+
+	i8 v1635 = (i8)(intptr_t)(ws+664);
+	i1 v1636 = *(i1*)(intptr_t)v1635;
+	i1 v1637 = (i1)+83;
+	if (v1636==v1637) goto c02_0180; else goto c02_0181;
+
+c02_0180:;
+
+	i2 v1638;
+	f92(&v1638);
+	i8 v1639 = (i8)(intptr_t)(ws+648);
+	*(i2*)(intptr_t)v1639 = v1638;
+
+	i8 v1640 = (i8)(intptr_t)(ws+640);
+	i8 v1641 = *(i8*)(intptr_t)v1640;
+	i8 v1642 = (i8)(intptr_t)(ws+648);
+	i2 v1643 = *(i2*)(intptr_t)v1642;
+	i8 v1644;
+	f82(&v1644, v1643, v1641);
+	i8 v1645 = (i8)(intptr_t)(ws+656);
+	*(i8*)(intptr_t)v1645 = v1644;
+
+	i8 v1646 = (i8)(intptr_t)(ws+656);
+	i8 v1647 = *(i8*)(intptr_t)v1646;
+	i8 v1648;
+	f83(&v1648, v1647);
+	i8 v1649 = (i8)(intptr_t)(ws+656);
+	*(i8*)(intptr_t)v1649 = v1648;
+
+	i8 v1650 = (i8)(intptr_t)(ws+656);
+	i8 v1651 = *(i8*)(intptr_t)v1650;
+	i8 v1652 = v1651+(+188);
+	i1 v1653 = *(i1*)(intptr_t)v1652;
+	i1 v1654 = v1653&(+1);
+	i1 v1655 = (i1)+0;
+	if (v1654==v1655) goto c02_0186; else goto c02_0185;
+
+c02_0185:;
+
+	f93();
+
+	goto c02_0182;
 
 c02_0186:;
 
-	goto endsub;
-
-	goto c02_0183;
-
-c02_0187:;
-
-c02_0183:;
-
-	i8 v1624 = (i8)(intptr_t)(ws+736);
-	i8 v1625 = *(i8*)(intptr_t)v1624;
-	i8 v1626 = *(i8*)(intptr_t)v1625;
-	i8 v1627 = (i8)(intptr_t)(ws+736);
-	*(i8*)(intptr_t)v1627 = v1626;
-
-	goto c02_017f;
-
 c02_0182:;
 
-	i8 v1628 = (i8)+24;
-	i8 v1629;
-	f33(&v1629, v1628);
-	i8 v1630 = (i8)(intptr_t)(ws+736);
-	*(i8*)(intptr_t)v1630 = v1629;
+	goto c02_0179;
 
-	i8 v1631 = (i8)(intptr_t)(ws+32);
-	i8 v1632 = *(i8*)(intptr_t)v1631;
-	i8 v1633 = (i8)(intptr_t)(ws+736);
-	i8 v1634 = *(i8*)(intptr_t)v1633;
-	*(i8*)(intptr_t)v1634 = v1632;
+c02_0181:;
 
-	i8 v1635 = (i8)(intptr_t)(ws+728);
-	i8 v1636 = *(i8*)(intptr_t)v1635;
-	i8 v1637;
-	f37(&v1637, v1636);
-	i8 v1638 = (i8)(intptr_t)(ws+736);
-	i8 v1639 = *(i8*)(intptr_t)v1638;
-	i8 v1640 = v1639+(+8);
-	*(i8*)(intptr_t)v1640 = v1637;
+c02_0179:;
 
-	i8 v1641 = (i8)(intptr_t)(ws+736);
-	i8 v1642 = *(i8*)(intptr_t)v1641;
-	i8 v1643 = (i8)(intptr_t)(ws+32);
-	*(i8*)(intptr_t)v1643 = v1642;
+	i8 v1656 = (i8)(intptr_t)(ws+640);
+	i8 v1657 = *(i8*)(intptr_t)v1656;
+	i8 v1658 = (i8)(intptr_t)(ws+668);
+	i4 v1659 = *(i4*)(intptr_t)v1658;
+	f44(v1659, v1657);
+
+	goto c02_0177;
+
+c02_0178:;
 
 endsub:;
-	*p1608 = *(i8*)(intptr_t)(ws+736);
 }
-const i1 c02_s0018[] = { 0x6d,0x75,0x6c,0x74,0x69,0x70,0x6c,0x65,0x20,0x65,0x78,0x74,0x65,0x72,0x6e,0x61,0x6c,0x20,0x64,0x65,0x63,0x6c,0x61,0x72,0x61,0x74,0x69,0x6f,0x6e,0x73,0 };
-const i1 c02_s0019[] = { 0x65,0x72,0x72,0x6f,0x72,0x3a,0x20,0x75,0x6e,0x73,0x75,0x70,0x70,0x6f,0x72,0x74,0x65,0x64,0x20,0x72,0x65,0x63,0x6f,0x72,0x64,0x20,0x27,0 };
-const i1 c02_s001a[] = { 0x27,0x20,0x69,0x6e,0x20,0x63,0x6f,0x6f,0x66,0x69,0x6c,0x65,0x0a,0 };
 
-// OpenAndLoadCoo workspace at ws+664 length ws+64
-void f87(i8* p1644 /* coo */, i8 p1645 /* filename */) {
-	*(i8*)(intptr_t)(ws+664) = p1645; /*filename */
+// WriteAllSubroutinesToOutputFile workspace at ws+632 length ws+8
+void f94(i8 p1660 /* coos */) {
+	*(i8*)(intptr_t)(ws+632) = p1660; /*coos */
 
-	i8 v1646 = (i8)+674;
-	i8 v1647;
-	f33(&v1647, v1646);
-	i8 v1648 = (i8)(intptr_t)(ws+672);
-	*(i8*)(intptr_t)v1648 = v1647;
+c02_0189:;
 
-	i8 v1649 = (i8)(intptr_t)(ws+48);
-	i2 v1650 = *(i2*)(intptr_t)v1649;
-	i8 v1651 = (i8)(intptr_t)(ws+672);
-	i8 v1652 = *(i8*)(intptr_t)v1651;
-	i8 v1653 = v1652+(+672);
-	*(i2*)(intptr_t)v1653 = v1650;
-
-	i8 v1654 = (i8)(intptr_t)(ws+48);
-	i2 v1655 = *(i2*)(intptr_t)v1654;
-	i2 v1656 = v1655+(+1);
-	i8 v1657 = (i8)(intptr_t)(ws+48);
-	*(i2*)(intptr_t)v1657 = v1656;
-
-	i8 v1658 = (i8)(intptr_t)(ws+672);
-	i8 v1659 = *(i8*)(intptr_t)v1658;
-	i8 v1660 = (i8)(intptr_t)(ws+664);
-	i8 v1661 = *(i8*)(intptr_t)v1660;
-	i1 v1662;
-	f42(&v1662, v1661, v1659);
-	i1 v1663 = (i1)+0;
+	i8 v1661 = (i8)(intptr_t)(ws+632);
+	i8 v1662 = *(i8*)(intptr_t)v1661;
+	i8 v1663 = (i8)+0;
 	if (v1662==v1663) goto c02_018c; else goto c02_018b;
 
 c02_018b:;
 
-	i8 v1664 = (i8)(intptr_t)(ws+664);
+	i8 v1664 = (i8)(intptr_t)(ws+632);
 	i8 v1665 = *(i8*)(intptr_t)v1664;
-	f58(v1665);
+	f86(v1665);
 
-	goto c02_0188;
+	i8 v1666 = (i8)(intptr_t)(ws+632);
+	i8 v1667 = *(i8*)(intptr_t)v1666;
+	i8 v1668 = v1667+(+664);
+	i8 v1669 = *(i8*)(intptr_t)v1668;
+	i8 v1670 = (i8)(intptr_t)(ws+632);
+	*(i8*)(intptr_t)v1670 = v1669;
+
+	goto c02_0189;
 
 c02_018c:;
 
-c02_0188:;
+endsub:;
+}
+const i1 c02_s0014[] = { 0x63,0x6f,0x6e,0x66,0x6c,0x69,0x63,0x74,0x69,0x6e,0x67,0x20,0x65,0x78,0x74,0x65,0x72,0x6e,0x61,0x6c,0x73,0 };
+const i1 c02_s0015[] = { 0x65,0x72,0x72,0x6f,0x72,0x3a,0x20,0x65,0x78,0x74,0x65,0x72,0x6e,0x61,0x6c,0x20,0x27,0 };
+const i1 c02_s0016[] = { 0x27,0x20,0x75,0x6e,0x72,0x65,0x73,0x6f,0x6c,0x76,0x65,0x64,0x0a,0 };
+const i1 c02_s0017[] = { 0x61,0x62,0x6f,0x72,0x74,0x69,0x6e,0x67,0 };
 
-c02_018d:;
+// ResolveExternals workspace at ws+632 length ws+24
+void f95(void) {
 
-	i8 v1666 = (i8)(intptr_t)(ws+672);
-	i8 v1667 = *(i8*)(intptr_t)v1666;
-	i1 v1668;
-	f76(&v1668, v1667);
-	i8 v1669 = (i8)(intptr_t)(ws+682);
-	*(i1*)(intptr_t)v1669 = v1668;
+	i1 v1671 = (i1)+0;
+	i8 v1672 = (i8)(intptr_t)(ws+640);
+	*(i1*)(intptr_t)v1672 = v1671;
 
-	i8 v1670 = (i8)(intptr_t)(ws+672);
-	i8 v1671 = *(i8*)(intptr_t)v1670;
-	i2 v1672;
-	f80(&v1672, v1671);
-	i8 v1673 = (i8)(intptr_t)(ws+684);
-	*(i2*)(intptr_t)v1673 = v1672;
-
-	i8 v1674 = (i8)(intptr_t)(ws+672);
-	i8 v1675 = *(i8*)(intptr_t)v1674;
-	i4 v1676;
-	f47(&v1676, v1675);
-	i8 v1677 = (i8)(intptr_t)(ws+688);
-	*(i4*)(intptr_t)v1677 = v1676;
-
-	i8 v1678 = (i8)(intptr_t)(ws+682);
-	i1 v1679 = *(i1*)(intptr_t)v1678;
-	i1 v1680 = (i1)+69;
-	if (v1679==v1680) goto c02_0192; else goto c02_0193;
-
-c02_0192:;
-
-	goto c02_018e;
-
-	goto c02_018f;
-
-c02_0193:;
-
-	i8 v1681 = (i8)(intptr_t)(ws+682);
-	i1 v1682 = *(i1*)(intptr_t)v1681;
-	i1 v1683 = (i1)+83;
-	if (v1682==v1683) goto c02_0196; else goto c02_0197;
-
-c02_0196:;
-
-	i8 v1684 = (i8)(intptr_t)(ws+672);
-	i8 v1685 = *(i8*)(intptr_t)v1684;
-	i2 v1686;
-	f80(&v1686, v1685);
-	i8 v1687 = (i8)(intptr_t)(ws+680);
-	*(i2*)(intptr_t)v1687 = v1686;
-
-	i8 v1688 = (i8)(intptr_t)(ws+672);
-	i8 v1689 = *(i8*)(intptr_t)v1688;
-	i8 v1690 = (i8)(intptr_t)(ws+680);
-	i2 v1691 = *(i2*)(intptr_t)v1690;
-	i8 v1692;
-	f84(&v1692, v1691, v1689);
-	i8 v1693 = (i8)(intptr_t)(ws+696);
-	*(i8*)(intptr_t)v1693 = v1692;
-
-	i8 v1694 = (i8)(intptr_t)(ws+696);
-	i8 v1695 = *(i8*)(intptr_t)v1694;
-	i8 v1696 = v1695+(+188);
-	i1 v1697 = *(i1*)(intptr_t)v1696;
-	i1 v1698 = v1697|(+2);
-	i8 v1699 = (i8)(intptr_t)(ws+696);
-	i8 v1700 = *(i8*)(intptr_t)v1699;
-	i8 v1701 = v1700+(+188);
-	*(i1*)(intptr_t)v1701 = v1698;
-
-	goto c02_018f;
-
-c02_0197:;
-
-	i8 v1702 = (i8)(intptr_t)(ws+682);
-	i1 v1703 = *(i1*)(intptr_t)v1702;
-	i1 v1704 = (i1)+82;
-	if (v1703==v1704) goto c02_019a; else goto c02_019b;
-
-c02_019a:;
-
-	i8 v1705 = (i8)(intptr_t)(ws+672);
-	i8 v1706 = *(i8*)(intptr_t)v1705;
-	i2 v1707;
-	f80(&v1707, v1706);
-	i8 v1708 = (i8)(intptr_t)(ws+704);
-	*(i2*)(intptr_t)v1708 = v1707;
-
-	i8 v1709 = (i8)(intptr_t)(ws+672);
-	i8 v1710 = *(i8*)(intptr_t)v1709;
-	i2 v1711;
-	f80(&v1711, v1710);
-	i8 v1712 = (i8)(intptr_t)(ws+706);
-	*(i2*)(intptr_t)v1712 = v1711;
-
-	i8 v1713 = (i8)(intptr_t)(ws+672);
-	i8 v1714 = *(i8*)(intptr_t)v1713;
-	i8 v1715 = (i8)(intptr_t)(ws+704);
-	i2 v1716 = *(i2*)(intptr_t)v1715;
-	i8 v1717;
-	f84(&v1717, v1716, v1714);
-	i8 v1718 = (i8)(intptr_t)(ws+672);
-	i8 v1719 = *(i8*)(intptr_t)v1718;
-	i8 v1720 = (i8)(intptr_t)(ws+706);
-	i2 v1721 = *(i2*)(intptr_t)v1720;
-	i8 v1722;
-	f84(&v1722, v1721, v1719);
-	f82(v1722, v1717);
-
-	goto c02_018f;
-
-c02_019b:;
-
-	i8 v1723 = (i8)(intptr_t)(ws+682);
-	i1 v1724 = *(i1*)(intptr_t)v1723;
-	i1 v1725 = (i1)+87;
-	if (v1724==v1725) goto c02_019e; else goto c02_019f;
-
-c02_019e:;
-
-	i8 v1726 = (i8)(intptr_t)(ws+672);
-	i8 v1727 = *(i8*)(intptr_t)v1726;
-	i2 v1728;
-	f80(&v1728, v1727);
-	i8 v1729 = (i8)(intptr_t)(ws+680);
-	*(i2*)(intptr_t)v1729 = v1728;
-
-	i8 v1730 = (i8)(intptr_t)(ws+672);
-	i8 v1731 = *(i8*)(intptr_t)v1730;
-	i8 v1732 = (i8)(intptr_t)(ws+680);
-	i2 v1733 = *(i2*)(intptr_t)v1732;
-	i8 v1734;
-	f84(&v1734, v1733, v1731);
-	i8 v1735 = (i8)(intptr_t)(ws+696);
-	*(i8*)(intptr_t)v1735 = v1734;
-
-	i8 v1736 = (i8)(intptr_t)(ws+672);
-	i8 v1737 = *(i8*)(intptr_t)v1736;
-	i1 v1738;
-	f79(&v1738, v1737);
-	i8 v1739 = (i8)(intptr_t)(ws+708);
-	*(i1*)(intptr_t)v1739 = v1738;
-
-	i8 v1740 = (i8)(intptr_t)(ws+672);
-	i8 v1741 = *(i8*)(intptr_t)v1740;
-	i2 v1742;
-	f80(&v1742, v1741);
-	i8 v1743 = (i8)(intptr_t)(ws+696);
-	i8 v1744 = *(i8*)(intptr_t)v1743;
-	i8 v1745 = v1744+(+168);
-	i8 v1746 = (i8)(intptr_t)(ws+708);
-	i1 v1747 = *(i1*)(intptr_t)v1746;
-	i8 v1748 = v1747;
-	i1 v1749 = (i1)+1;
-	i8 v1750 = ((i8)v1748)<<v1749;
-	i8 v1751 = v1745+v1750;
-	*(i2*)(intptr_t)v1751 = v1742;
-
-	goto c02_018f;
-
-c02_019f:;
-
-	i8 v1752 = (i8)(intptr_t)(ws+682);
-	i1 v1753 = *(i1*)(intptr_t)v1752;
-	i1 v1754 = (i1)+78;
-	if (v1753==v1754) goto c02_01a2; else goto c02_01a3;
-
-c02_01a2:;
-
-	i8 v1755 = (i8)(intptr_t)(ws+672);
-	i8 v1756 = *(i8*)(intptr_t)v1755;
-	i2 v1757;
-	f80(&v1757, v1756);
-	i8 v1758 = (i8)(intptr_t)(ws+680);
-	*(i2*)(intptr_t)v1758 = v1757;
-
-	i8 v1759 = (i8)(intptr_t)(ws+672);
-	i8 v1760 = *(i8*)(intptr_t)v1759;
-	i8 v1761 = (i8)(intptr_t)(ws+680);
-	i2 v1762 = *(i2*)(intptr_t)v1761;
-	i8 v1763;
-	f84(&v1763, v1762, v1760);
-	i8 v1764 = (i8)(intptr_t)(ws+696);
-	*(i8*)(intptr_t)v1764 = v1763;
-
-	i8 v1765 = (i8)(intptr_t)(ws+672);
-	i8 v1766 = *(i8*)(intptr_t)v1765;
-	i8 v1767 = (i8)(intptr_t)(ws+684);
-	i2 v1768 = *(i2*)(intptr_t)v1767;
-	i1 v1769 = v1768;
-	i1 v1770 = v1769+(-4);
-	i8 v1771;
-	f81(&v1771, v1770, v1766);
-	i8 v1772 = (i8)(intptr_t)(ws+696);
-	i8 v1773 = *(i8*)(intptr_t)v1772;
-	i8 v1774 = v1773+(+152);
-	*(i8*)(intptr_t)v1774 = v1771;
-
-	goto c02_018f;
-
-c02_01a3:;
-
-	i8 v1775 = (i8)(intptr_t)(ws+682);
-	i1 v1776 = *(i1*)(intptr_t)v1775;
-	i1 v1777 = (i1)+88;
-	if (v1776==v1777) goto c02_01a6; else goto c02_01a7;
-
-c02_01a6:;
-
-	i8 v1778 = (i8)(intptr_t)(ws+672);
-	i8 v1779 = *(i8*)(intptr_t)v1778;
-	i2 v1780;
-	f80(&v1780, v1779);
-	i8 v1781 = (i8)(intptr_t)(ws+680);
-	*(i2*)(intptr_t)v1781 = v1780;
-
-	i8 v1782 = (i8)(intptr_t)(ws+672);
-	i8 v1783 = *(i8*)(intptr_t)v1782;
-	i8 v1784 = (i8)(intptr_t)(ws+680);
-	i2 v1785 = *(i2*)(intptr_t)v1784;
-	i8 v1786;
-	f84(&v1786, v1785, v1783);
-	i8 v1787 = (i8)(intptr_t)(ws+696);
-	*(i8*)(intptr_t)v1787 = v1786;
-
-	i8 v1788 = (i8)(intptr_t)(ws+672);
-	i8 v1789 = *(i8*)(intptr_t)v1788;
-	i8 v1790 = (i8)(intptr_t)(ws+684);
-	i2 v1791 = *(i2*)(intptr_t)v1790;
-	i1 v1792 = v1791;
-	i1 v1793 = v1792+(-4);
-	i8 v1794;
-	f81(&v1794, v1793, v1789);
-	i8 v1795 = (i8)(intptr_t)(ws+712);
-	*(i8*)(intptr_t)v1795 = v1794;
-
-	i8 v1796 = (i8)(intptr_t)(ws+712);
-	i8 v1797 = *(i8*)(intptr_t)v1796;
-	i8 v1798;
-	f86(&v1798, v1797);
-	i8 v1799 = (i8)(intptr_t)(ws+720);
-	*(i8*)(intptr_t)v1799 = v1798;
-
-	i8 v1800 = (i8)(intptr_t)(ws+696);
-	i8 v1801 = *(i8*)(intptr_t)v1800;
-	i8 v1802 = v1801+(+160);
-	i8 v1803 = *(i8*)(intptr_t)v1802;
-	i8 v1804 = (i8)+0;
-	if (v1803==v1804) goto c02_01ac; else goto c02_01ab;
-
-c02_01ab:;
-
-	i8 v1805 = (i8)(intptr_t)c02_s0018;
-	f57(v1805);
-
-	goto c02_01a8;
-
-c02_01ac:;
-
-c02_01a8:;
-
-	i8 v1806 = (i8)(intptr_t)(ws+720);
-	i8 v1807 = *(i8*)(intptr_t)v1806;
-	i8 v1808 = (i8)(intptr_t)(ws+696);
-	i8 v1809 = *(i8*)(intptr_t)v1808;
-	i8 v1810 = v1809+(+160);
-	*(i8*)(intptr_t)v1810 = v1807;
-
-	goto c02_018f;
-
-c02_01a7:;
-
-	i8 v1811 = (i8)(intptr_t)c02_s0019;
-	f11(v1811);
-
-	i8 v1812 = (i8)(intptr_t)(ws+682);
-	i1 v1813 = *(i1*)(intptr_t)v1812;
-	f8(v1813);
-
-	i8 v1814 = (i8)(intptr_t)c02_s001a;
-	f11(v1814);
-
-	f6();
+	i8 v1673 = (i8)(intptr_t)(ws+32);
+	i8 v1674 = *(i8*)(intptr_t)v1673;
+	i8 v1675 = (i8)(intptr_t)(ws+648);
+	*(i8*)(intptr_t)v1675 = v1674;
 
 c02_018f:;
 
-	i8 v1815 = (i8)(intptr_t)(ws+672);
-	i8 v1816 = *(i8*)(intptr_t)v1815;
-	i8 v1817 = (i8)(intptr_t)(ws+688);
-	i4 v1818 = *(i4*)(intptr_t)v1817;
-	i8 v1819 = (i8)(intptr_t)(ws+684);
-	i2 v1820 = *(i2*)(intptr_t)v1819;
-	i4 v1821 = v1820;
-	i4 v1822 = v1818+v1821;
-	f46(v1822, v1816);
+	i8 v1676 = (i8)(intptr_t)(ws+648);
+	i8 v1677 = *(i8*)(intptr_t)v1676;
+	i8 v1678 = (i8)+0;
+	if (v1677==v1678) goto c02_0192; else goto c02_0191;
 
-	goto c02_018d;
+c02_0191:;
 
-c02_018e:;
+	i8 v1679 = (i8)(intptr_t)(ws+648);
+	i8 v1680 = *(i8*)(intptr_t)v1679;
+	i8 v1681 = v1680+(+188);
+	i1 v1682 = *(i1*)(intptr_t)v1681;
+	i1 v1683 = v1682&(+2);
+	i1 v1684 = (i1)+0;
+	if (v1683==v1684) goto c02_0197; else goto c02_0196;
 
-endsub:;
-	*p1644 = *(i8*)(intptr_t)(ws+672);
-}
-const i1 c02_s001b[] = { 0x65,0x72,0x72,0x6f,0x72,0x3a,0x20,0x6d,0x61,0x6c,0x66,0x6f,0x72,0x6d,0x65,0x64,0x20,0x63,0x6f,0x6f,0x66,0x69,0x6c,0x65,0x3a,0x20,0 };
+c02_0196:;
 
-// MalformedError workspace at ws+712 length ws+8
-void f89(i8 p1824 /* s */) {
-	*(i8*)(intptr_t)(ws+712) = p1824; /*s */
+	i8 v1685 = (i8)(intptr_t)(ws+648);
+	i8 v1686 = *(i8*)(intptr_t)v1685;
+	i8 v1687 = v1686+(+160);
+	i8 v1688 = *(i8*)(intptr_t)v1687;
+	i8 v1689 = (i8)(intptr_t)(ws+632);
+	*(i8*)(intptr_t)v1689 = v1688;
 
-	i8 v1825 = (i8)(intptr_t)c02_s001b;
-	f11(v1825);
+	i8 v1690 = (i8)(intptr_t)(ws+632);
+	i8 v1691 = *(i8*)(intptr_t)v1690;
+	i8 v1692 = (i8)+0;
+	if (v1691==v1692) goto c02_019c; else goto c02_019b;
 
-	i8 v1826 = (i8)(intptr_t)(ws+712);
-	i8 v1827 = *(i8*)(intptr_t)v1826;
-	f11(v1827);
+c02_019b:;
 
-	f12();
+	i8 v1693 = (i8)(intptr_t)(ws+632);
+	i8 v1694 = *(i8*)(intptr_t)v1693;
+	i8 v1695 = v1694+(+16);
+	i8 v1696 = *(i8*)(intptr_t)v1695;
+	i8 v1697 = (i8)+0;
+	if (v1696==v1697) goto c02_01a3; else goto c02_01a4;
 
-	f6();
+c02_01a4:;
 
-endsub:;
-}
-const i1 c02_s001c[] = { 0x75,0x6e,0x65,0x78,0x70,0x65,0x63,0x74,0x65,0x64,0x20,0x65,0x6e,0x64,0x20,0x6f,0x66,0x20,0x63,0x68,0x75,0x6e,0x6b,0 };
+	i8 v1698 = (i8)(intptr_t)(ws+632);
+	i8 v1699 = *(i8*)(intptr_t)v1698;
+	i8 v1700 = v1699+(+16);
+	i8 v1701 = *(i8*)(intptr_t)v1700;
+	i8 v1702 = (i8)(intptr_t)(ws+648);
+	i8 v1703 = *(i8*)(intptr_t)v1702;
+	if (v1701==v1703) goto c02_01a3; else goto c02_01a2;
 
-// UnexpectedEndOfChunk workspace at ws+712 length ws+0
-void f90(void) {
+c02_01a2:;
 
-	i8 v1828 = (i8)(intptr_t)c02_s001c;
-	f89(v1828);
+	i8 v1704 = (i8)(intptr_t)c02_s0014;
+	f55(v1704);
 
-endsub:;
-}
-const i1 c02_s001d[] = { 0x63,0x68,0x75,0x6e,0x6b,0x20,0x73,0x69,0x7a,0x65,0x20,0x69,0x6e,0x63,0x6f,0x6e,0x73,0x69,0x73,0x74,0x65,0x6e,0x74,0 };
+	goto c02_019d;
 
-// GetC workspace at ws+704 length ws+0
-void f91(void) {
+c02_01a3:;
 
-	i8 v1829 = (i8)(intptr_t)(ws+674);
-	i2 v1830 = *(i2*)(intptr_t)v1829;
-	i2 v1831 = (i2)+0;
-	if (v1830==v1831) goto c02_01b0; else goto c02_01b1;
+c02_019d:;
 
-c02_01b0:;
+	i8 v1705 = (i8)(intptr_t)(ws+648);
+	i8 v1706 = *(i8*)(intptr_t)v1705;
+	i8 v1707 = (i8)(intptr_t)(ws+632);
+	i8 v1708 = *(i8*)(intptr_t)v1707;
+	i8 v1709 = v1708+(+16);
+	*(i8*)(intptr_t)v1709 = v1706;
 
-	i8 v1832 = (i8)(intptr_t)c02_s001d;
-	f89(v1832);
+	goto c02_0198;
 
-	goto c02_01ad;
+c02_019c:;
 
-c02_01b1:;
+c02_0198:;
 
-c02_01ad:;
+	goto c02_0193;
 
-	i8 v1833 = (i8)(intptr_t)(ws+674);
-	i2 v1834 = *(i2*)(intptr_t)v1833;
-	i2 v1835 = v1834+(-1);
-	i8 v1836 = (i8)(intptr_t)(ws+674);
-	*(i2*)(intptr_t)v1836 = v1835;
+c02_0197:;
 
-	i8 v1837 = (i8)(intptr_t)(ws+648);
-	i8 v1838 = *(i8*)(intptr_t)v1837;
-	i1 v1839;
-	f76(&v1839, v1838);
-	i8 v1840 = (i8)(intptr_t)(ws+672);
-	*(i1*)(intptr_t)v1840 = v1839;
+c02_0193:;
 
-endsub:;
-}
+	i8 v1710 = (i8)(intptr_t)(ws+648);
+	i8 v1711 = *(i8*)(intptr_t)v1710;
+	i8 v1712 = v1711+(+8);
+	i8 v1713 = *(i8*)(intptr_t)v1712;
+	i8 v1714 = (i8)(intptr_t)(ws+648);
+	*(i8*)(intptr_t)v1714 = v1713;
 
-// ReadH2 workspace at ws+704 length ws+1
-void f93(i1* p1847 /* result */) {
+	goto c02_018f;
 
-	i8 v1848 = (i8)(intptr_t)(ws+674);
-	i2 v1849 = *(i2*)(intptr_t)v1848;
-	i2 v1850 = (i2)+2;
-	if (v1849<v1850) goto c02_01b5; else goto c02_01b6;
+c02_0192:;
 
-c02_01b5:;
+	i8 v1715 = (i8)(intptr_t)(ws+32);
+	i8 v1716 = *(i8*)(intptr_t)v1715;
+	i8 v1717 = (i8)(intptr_t)(ws+648);
+	*(i8*)(intptr_t)v1717 = v1716;
 
-	f90();
+c02_01a7:;
 
-	goto c02_01b2;
+	i8 v1718 = (i8)(intptr_t)(ws+648);
+	i8 v1719 = *(i8*)(intptr_t)v1718;
+	i8 v1720 = (i8)+0;
+	if (v1719==v1720) goto c02_01aa; else goto c02_01a9;
 
-c02_01b6:;
+c02_01a9:;
+
+	i8 v1721 = (i8)(intptr_t)(ws+648);
+	i8 v1722 = *(i8*)(intptr_t)v1721;
+	i8 v1723 = v1722+(+160);
+	i8 v1724 = *(i8*)(intptr_t)v1723;
+	i8 v1725 = (i8)(intptr_t)(ws+632);
+	*(i8*)(intptr_t)v1725 = v1724;
+
+	i8 v1726 = (i8)(intptr_t)(ws+632);
+	i8 v1727 = *(i8*)(intptr_t)v1726;
+	i8 v1728 = (i8)+0;
+	if (v1727==v1728) goto c02_01b1; else goto c02_01b2;
 
 c02_01b2:;
 
-	i8 v1851 = (i8)(intptr_t)(ws+674);
-	i2 v1852 = *(i2*)(intptr_t)v1851;
-	i2 v1853 = v1852+(-2);
-	i8 v1854 = (i8)(intptr_t)(ws+674);
-	*(i2*)(intptr_t)v1854 = v1853;
+	i8 v1729 = (i8)(intptr_t)(ws+632);
+	i8 v1730 = *(i8*)(intptr_t)v1729;
+	i8 v1731 = v1730+(+16);
+	i8 v1732 = *(i8*)(intptr_t)v1731;
+	i8 v1733 = (i8)+0;
+	if (v1732==v1733) goto c02_01b0; else goto c02_01b1;
 
-	i8 v1855 = (i8)(intptr_t)(ws+648);
-	i8 v1856 = *(i8*)(intptr_t)v1855;
-	i1 v1857;
-	f79(&v1857, v1856);
-	i8 v1858 = (i8)(intptr_t)(ws+704);
-	*(i1*)(intptr_t)v1858 = v1857;
+c02_01b0:;
 
-endsub:;
-	*p1847 = *(i1*)(intptr_t)(ws+704);
-}
+	i8 v1734 = (i8)(intptr_t)c02_s0015;
+	f11(v1734);
 
-// ReadH4 workspace at ws+704 length ws+2
-void f94(i2* p1859 /* result */) {
+	i8 v1735 = (i8)(intptr_t)(ws+632);
+	i8 v1736 = *(i8*)(intptr_t)v1735;
+	i8 v1737 = v1736+(+8);
+	i8 v1738 = *(i8*)(intptr_t)v1737;
+	f11(v1738);
 
-	i8 v1860 = (i8)(intptr_t)(ws+674);
-	i2 v1861 = *(i2*)(intptr_t)v1860;
-	i2 v1862 = (i2)+4;
-	if (v1861<v1862) goto c02_01ba; else goto c02_01bb;
+	i8 v1739 = (i8)(intptr_t)c02_s0016;
+	f11(v1739);
 
-c02_01ba:;
+	i1 v1740 = (i1)+1;
+	i8 v1741 = (i8)(intptr_t)(ws+640);
+	*(i1*)(intptr_t)v1741 = v1740;
 
-	f90();
+	goto c02_01ab;
 
-	goto c02_01b7;
+c02_01b1:;
 
-c02_01bb:;
+c02_01ab:;
+
+	i8 v1742 = (i8)(intptr_t)(ws+648);
+	i8 v1743 = *(i8*)(intptr_t)v1742;
+	i8 v1744 = v1743+(+8);
+	i8 v1745 = *(i8*)(intptr_t)v1744;
+	i8 v1746 = (i8)(intptr_t)(ws+648);
+	*(i8*)(intptr_t)v1746 = v1745;
+
+	goto c02_01a7;
+
+c02_01aa:;
+
+	i8 v1747 = (i8)(intptr_t)(ws+640);
+	i1 v1748 = *(i1*)(intptr_t)v1747;
+	i1 v1749 = (i1)+0;
+	if (v1748==v1749) goto c02_01b7; else goto c02_01b6;
+
+c02_01b6:;
+
+	i8 v1750 = (i8)(intptr_t)c02_s0017;
+	f55(v1750);
+
+	goto c02_01b3;
 
 c02_01b7:;
 
-	i8 v1863 = (i8)(intptr_t)(ws+674);
-	i2 v1864 = *(i2*)(intptr_t)v1863;
-	i2 v1865 = v1864+(-4);
-	i8 v1866 = (i8)(intptr_t)(ws+674);
-	*(i2*)(intptr_t)v1866 = v1865;
-
-	i8 v1867 = (i8)(intptr_t)(ws+648);
-	i8 v1868 = *(i8*)(intptr_t)v1867;
-	i2 v1869;
-	f80(&v1869, v1868);
-	i8 v1870 = (i8)(intptr_t)(ws+704);
-	*(i2*)(intptr_t)v1870 = v1869;
+c02_01b3:;
 
 endsub:;
-	*p1859 = *(i2*)(intptr_t)(ws+704);
 }
+const i1 c02_s0018[] = { 0x65,0x72,0x72,0x6f,0x72,0x3a,0x20,0x64,0x65,0x70,0x65,0x6e,0x64,0x65,0x6e,0x63,0x79,0x20,0x67,0x72,0x61,0x70,0x68,0x20,0x6f,0x76,0x65,0x72,0x66,0x6c,0x6f,0x77,0x0a,0 };
 
-// CopySourceChunk workspace at ws+680 length ws+20
-void f95(void) {
+// push workspace at ws+3088 length ws+10
+void f97(i8 p1771 /* subr */) {
+	*(i8*)(intptr_t)(ws+3088) = p1771; /*subr */
 
-c02_01be:;
-
-	i8 v1871 = (i8)(intptr_t)(ws+674);
-	i2 v1872 = *(i2*)(intptr_t)v1871;
-	i2 v1873 = (i2)+0;
-	if (v1872==v1873) goto c02_01c1; else goto c02_01c0;
+	i8 v1772 = (i8)(intptr_t)(ws+3040);
+	i2 v1773 = *(i2*)(intptr_t)v1772;
+	i8 v1774 = (i8)(intptr_t)(ws+3096);
+	*(i2*)(intptr_t)v1774 = v1773;
 
 c02_01c0:;
 
-	f91();
-
-	i8 v1874 = (i8)(intptr_t)(ws+672);
-	i1 v1875 = *(i1*)(intptr_t)v1874;
-
-	if (v1875 != +3) goto c02_01c3;
-
-	i1 v1876 = (i1)+99;
-	f59(v1876);
-
-	i8 v1877 = (i8)(intptr_t)(ws+648);
-	i8 v1878 = *(i8*)(intptr_t)v1877;
-	i8 v1879 = v1878+(+672);
-	i2 v1880 = *(i2*)(intptr_t)v1879;
-	i1 v1881 = v1880;
-	f66(v1881);
-
-	i1 v1882 = (i1)+95;
-	f59(v1882);
-
-	goto c02_01c2;
-
-c02_01c3:;
-
-	if (v1875 != +4) goto c02_01c4;
-
-	i8 v1883 = (i8)(intptr_t)(ws+664);
-	i8 v1884 = *(i8*)(intptr_t)v1883;
-	i8 v1885 = v1884+(+186);
-	i2 v1886 = *(i2*)(intptr_t)v1885;
-	f72(v1886);
-
-	goto c02_01c2;
-
-c02_01c4:;
-
-	if (v1875 != +1) goto c02_01c5;
-
-	i2 v1887;
-	f94(&v1887);
-	i8 v1888 = (i8)(intptr_t)(ws+680);
-	*(i2*)(intptr_t)v1888 = v1887;
-
-	i8 v1889 = (i8)(intptr_t)(ws+648);
-	i8 v1890 = *(i8*)(intptr_t)v1889;
-	i8 v1891 = (i8)(intptr_t)(ws+680);
-	i2 v1892 = *(i2*)(intptr_t)v1891;
-	i8 v1893;
-	f84(&v1893, v1892, v1890);
-	i8 v1894 = (i8)(intptr_t)(ws+688);
-	*(i8*)(intptr_t)v1894 = v1893;
-
-	i8 v1895 = (i8)(intptr_t)(ws+688);
-	i8 v1896 = *(i8*)(intptr_t)v1895;
-	i8 v1897;
-	f85(&v1897, v1896);
-	i8 v1898 = (i8)(intptr_t)(ws+688);
-	*(i8*)(intptr_t)v1898 = v1897;
-
-	i8 v1899 = (i8)(intptr_t)(ws+688);
-	i8 v1900 = *(i8*)(intptr_t)v1899;
-	i8 v1901 = v1900+(+186);
-	i2 v1902 = *(i2*)(intptr_t)v1901;
-	f72(v1902);
-
-	goto c02_01c2;
-
-c02_01c5:;
-
-	if (v1875 != +2) goto c02_01c6;
-
-	i2 v1903;
-	f94(&v1903);
-	i8 v1904 = (i8)(intptr_t)(ws+680);
-	*(i2*)(intptr_t)v1904 = v1903;
-
-	i1 v1905;
-	f93(&v1905);
-	i8 v1906 = (i8)(intptr_t)(ws+696);
-	*(i1*)(intptr_t)v1906 = v1905;
-
-	i2 v1907;
-	f94(&v1907);
-	i8 v1908 = (i8)(intptr_t)(ws+698);
-	*(i2*)(intptr_t)v1908 = v1907;
-
-	i8 v1909 = (i8)(intptr_t)(ws+648);
-	i8 v1910 = *(i8*)(intptr_t)v1909;
-	i8 v1911 = (i8)(intptr_t)(ws+680);
-	i2 v1912 = *(i2*)(intptr_t)v1911;
-	i8 v1913;
-	f84(&v1913, v1912, v1910);
-	i8 v1914 = (i8)(intptr_t)(ws+688);
-	*(i8*)(intptr_t)v1914 = v1913;
-
-	i8 v1915 = (i8)(intptr_t)(ws+688);
-	i8 v1916 = *(i8*)(intptr_t)v1915;
-	i8 v1917;
-	f85(&v1917, v1916);
-	i8 v1918 = (i8)(intptr_t)(ws+688);
-	*(i8*)(intptr_t)v1918 = v1917;
-
-	i8 v1919 = (i8)(intptr_t)(ws+696);
-	i1 v1920 = *(i1*)(intptr_t)v1919;
-	i8 v1921 = (i8)(intptr_t)(ws+688);
-	i8 v1922 = *(i8*)(intptr_t)v1921;
-	i8 v1923 = v1922+(+176);
-	i8 v1924 = (i8)(intptr_t)(ws+696);
-	i1 v1925 = *(i1*)(intptr_t)v1924;
-	i8 v1926 = v1925;
-	i1 v1927 = (i1)+1;
-	i8 v1928 = ((i8)v1926)<<v1927;
-	i8 v1929 = v1923+v1928;
-	i2 v1930 = *(i2*)(intptr_t)v1929;
-	i8 v1931 = (i8)(intptr_t)(ws+698);
-	i2 v1932 = *(i2*)(intptr_t)v1931;
-	i2 v1933 = v1930+v1932;
-	f73(v1933, v1920);
-
-	goto c02_01c2;
-
-c02_01c6:;
-
-	if (v1875 != +5) goto c02_01c7;
-
-	i2 v1934;
-	f94(&v1934);
-	i8 v1935 = (i8)(intptr_t)(ws+680);
-	*(i2*)(intptr_t)v1935 = v1934;
-
-	i1 v1936;
-	f93(&v1936);
-	i8 v1937 = (i8)(intptr_t)(ws+696);
-	*(i1*)(intptr_t)v1937 = v1936;
-
-	i8 v1938 = (i8)(intptr_t)(ws+648);
-	i8 v1939 = *(i8*)(intptr_t)v1938;
-	i8 v1940 = (i8)(intptr_t)(ws+680);
-	i2 v1941 = *(i2*)(intptr_t)v1940;
-	i8 v1942;
-	f84(&v1942, v1941, v1939);
-	i8 v1943 = (i8)(intptr_t)(ws+688);
-	*(i8*)(intptr_t)v1943 = v1942;
-
-	i8 v1944 = (i8)(intptr_t)(ws+688);
-	i8 v1945 = *(i8*)(intptr_t)v1944;
-	i8 v1946;
-	f85(&v1946, v1945);
-	i8 v1947 = (i8)(intptr_t)(ws+688);
-	*(i8*)(intptr_t)v1947 = v1946;
-
-	i8 v1948 = (i8)(intptr_t)(ws+696);
-	i1 v1949 = *(i1*)(intptr_t)v1948;
-	i8 v1950 = (i8)(intptr_t)(ws+688);
-	i8 v1951 = *(i8*)(intptr_t)v1950;
-	i8 v1952 = v1951+(+168);
-	i8 v1953 = (i8)(intptr_t)(ws+696);
-	i1 v1954 = *(i1*)(intptr_t)v1953;
-	i8 v1955 = v1954;
-	i1 v1956 = (i1)+1;
-	i8 v1957 = ((i8)v1955)<<v1956;
-	i8 v1958 = v1952+v1957;
-	i2 v1959 = *(i2*)(intptr_t)v1958;
-	f73(v1959, v1949);
-
-	goto c02_01c2;
-
-c02_01c7:;
-
-	i8 v1960 = (i8)(intptr_t)(ws+672);
-	i1 v1961 = *(i1*)(intptr_t)v1960;
-	f59(v1961);
+	i8 v1775 = (i8)(intptr_t)(ws+3096);
+	i2 v1776 = *(i2*)(intptr_t)v1775;
+	i2 v1777 = (i2)+0;
+	if (v1776==v1777) goto c02_01c3; else goto c02_01c2;
 
 c02_01c2:;
 
+	i8 v1778 = (i8)(intptr_t)(ws+3096);
+	i2 v1779 = *(i2*)(intptr_t)v1778;
+	i2 v1780 = v1779+(-1);
+	i8 v1781 = (i8)(intptr_t)(ws+3096);
+	*(i2*)(intptr_t)v1781 = v1780;
 
-	goto c02_01be;
+	i8 v1782 = (i8)(intptr_t)(ws+640);
+	i8 v1783 = (i8)(intptr_t)(ws+3096);
+	i2 v1784 = *(i2*)(intptr_t)v1783;
+	i8 v1785 = v1784;
+	i1 v1786 = (i1)+3;
+	i8 v1787 = ((i8)v1785)<<v1786;
+	i8 v1788 = v1782+v1787;
+	i8 v1789 = *(i8*)(intptr_t)v1788;
+	i8 v1790 = (i8)(intptr_t)(ws+3088);
+	i8 v1791 = *(i8*)(intptr_t)v1790;
+	if (v1789==v1791) goto c02_01c7; else goto c02_01c8;
 
-c02_01c1:;
+c02_01c7:;
 
-endsub:;
-}
+	goto endsub;
 
-// WriteSubroutinesToOutputFile workspace at ws+648 length ws+32
-void f88(i8 p1823 /* coo */) {
-	*(i8*)(intptr_t)(ws+648) = p1823; /*coo */
-
-
-
-
-
-
-
-
-	i8 v1962 = (i8)(intptr_t)(ws+648);
-	i8 v1963 = *(i8*)(intptr_t)v1962;
-	i4 v1964 = (i4)+0;
-	f46(v1964, v1963);
+	goto c02_01c4;
 
 c02_01c8:;
 
-	i2 v1965 = (i2)+255;
-	i8 v1966 = (i8)(intptr_t)(ws+674);
-	*(i2*)(intptr_t)v1966 = v1965;
+c02_01c4:;
 
-	f91();
+	goto c02_01c0;
 
-	i2 v1967;
-	f94(&v1967);
-	i8 v1968 = (i8)(intptr_t)(ws+674);
-	*(i2*)(intptr_t)v1968 = v1967;
+c02_01c3:;
 
-	i8 v1969 = (i8)(intptr_t)(ws+648);
-	i8 v1970 = *(i8*)(intptr_t)v1969;
-	i4 v1971;
-	f47(&v1971, v1970);
-	i8 v1972 = (i8)(intptr_t)(ws+674);
-	i2 v1973 = *(i2*)(intptr_t)v1972;
-	i4 v1974 = v1973;
-	i4 v1975 = v1971+v1974;
-	i8 v1976 = (i8)(intptr_t)(ws+676);
-	*(i4*)(intptr_t)v1976 = v1975;
+	i8 v1792 = (i8)(intptr_t)(ws+3040);
+	i2 v1793 = *(i2*)(intptr_t)v1792;
+	i2 v1794 = (i2)+300;
+	if (v1793==v1794) goto c02_01cc; else goto c02_01cd;
 
-	i8 v1977 = (i8)(intptr_t)(ws+672);
-	i1 v1978 = *(i1*)(intptr_t)v1977;
-	i1 v1979 = (i1)+69;
-	if (v1978==v1979) goto c02_01cd; else goto c02_01ce;
+c02_01cc:;
 
-c02_01cd:;
+	i8 v1795 = (i8)(intptr_t)c02_s0018;
+	f11(v1795);
+
+	f6();
 
 	goto c02_01c9;
 
-	goto c02_01ca;
-
-c02_01ce:;
-
-	i8 v1980 = (i8)(intptr_t)(ws+672);
-	i1 v1981 = *(i1*)(intptr_t)v1980;
-	i1 v1982 = (i1)+83;
-	if (v1981==v1982) goto c02_01d1; else goto c02_01d2;
-
-c02_01d1:;
-
-	i2 v1983;
-	f94(&v1983);
-	i8 v1984 = (i8)(intptr_t)(ws+656);
-	*(i2*)(intptr_t)v1984 = v1983;
-
-	i8 v1985 = (i8)(intptr_t)(ws+648);
-	i8 v1986 = *(i8*)(intptr_t)v1985;
-	i8 v1987 = (i8)(intptr_t)(ws+656);
-	i2 v1988 = *(i2*)(intptr_t)v1987;
-	i8 v1989;
-	f84(&v1989, v1988, v1986);
-	i8 v1990 = (i8)(intptr_t)(ws+664);
-	*(i8*)(intptr_t)v1990 = v1989;
-
-	i8 v1991 = (i8)(intptr_t)(ws+664);
-	i8 v1992 = *(i8*)(intptr_t)v1991;
-	i8 v1993;
-	f85(&v1993, v1992);
-	i8 v1994 = (i8)(intptr_t)(ws+664);
-	*(i8*)(intptr_t)v1994 = v1993;
-
-	i8 v1995 = (i8)(intptr_t)(ws+664);
-	i8 v1996 = *(i8*)(intptr_t)v1995;
-	i8 v1997 = v1996+(+188);
-	i1 v1998 = *(i1*)(intptr_t)v1997;
-	i1 v1999 = v1998&(+1);
-	i1 v2000 = (i1)+0;
-	if (v1999==v2000) goto c02_01d7; else goto c02_01d6;
-
-c02_01d6:;
-
-	f95();
-
-	goto c02_01d3;
-
-c02_01d7:;
-
-c02_01d3:;
-
-	goto c02_01ca;
-
-c02_01d2:;
-
-c02_01ca:;
-
-	i8 v2001 = (i8)(intptr_t)(ws+648);
-	i8 v2002 = *(i8*)(intptr_t)v2001;
-	i8 v2003 = (i8)(intptr_t)(ws+676);
-	i4 v2004 = *(i4*)(intptr_t)v2003;
-	f46(v2004, v2002);
-
-	goto c02_01c8;
+c02_01cd:;
 
 c02_01c9:;
 
+	i8 v1796 = (i8)(intptr_t)(ws+3088);
+	i8 v1797 = *(i8*)(intptr_t)v1796;
+	i8 v1798 = (i8)(intptr_t)(ws+640);
+	i8 v1799 = (i8)(intptr_t)(ws+3040);
+	i2 v1800 = *(i2*)(intptr_t)v1799;
+	i8 v1801 = v1800;
+	i1 v1802 = (i1)+3;
+	i8 v1803 = ((i8)v1801)<<v1802;
+	i8 v1804 = v1798+v1803;
+	*(i8*)(intptr_t)v1804 = v1797;
+
+	i8 v1805 = (i8)(intptr_t)(ws+3040);
+	i2 v1806 = *(i2*)(intptr_t)v1805;
+	i2 v1807 = v1806+(+1);
+	i8 v1808 = (i8)(intptr_t)(ws+3040);
+	*(i2*)(intptr_t)v1808 = v1807;
+
 endsub:;
 }
+const i1 c02_s0019[] = { 0x57,0x6f,0x72,0x6b,0x73,0x70,0x61,0x63,0x65,0x20,0x73,0x69,0x7a,0x65,0x73,0x3a,0x0a,0 };
+const i1 c02_s001a[] = { 0x20,0x20,0x23,0 };
+const i1 c02_s001b[] = { 0x3a,0x20,0 };
+const i1 c02_s001c[] = { 0x20,0x62,0x79,0x74,0x65,0x73,0x0a,0 };
 
-// WriteAllSubroutinesToOutputFile workspace at ws+640 length ws+8
-void f96(i8 p2005 /* coos */) {
-	*(i8*)(intptr_t)(ws+640) = p2005; /*coos */
+// PlaceSubroutines workspace at ws+632 length ws+2452
+void f96(i8 p1751 /* subroutine */) {
+	*(i8*)(intptr_t)(ws+632) = p1751; /*subroutine */
 
-c02_01da:;
+	i2 v1752 = (i2)+0;
+	i8 v1753 = (i8)(intptr_t)(ws+3040);
+	*(i2*)(intptr_t)v1753 = v1752;
 
-	i8 v2006 = (i8)(intptr_t)(ws+640);
-	i8 v2007 = *(i8*)(intptr_t)v2006;
-	i8 v2008 = (i8)+0;
-	if (v2007==v2008) goto c02_01dd; else goto c02_01dc;
+	i1 v1754 = (i1)+0;
+	i8 v1755 = (i8)(intptr_t)(ws+3042);
+	*(i1*)(intptr_t)v1755 = v1754;
 
-c02_01dc:;
+c02_01ba:;
 
-	i8 v2009 = (i8)(intptr_t)(ws+640);
-	i8 v2010 = *(i8*)(intptr_t)v2009;
-	f88(v2010);
+	i8 v1756 = (i8)(intptr_t)(ws+3042);
+	i1 v1757 = *(i1*)(intptr_t)v1756;
+	i1 v1758 = (i1)+4;
+	if (v1757==v1758) goto c02_01bd; else goto c02_01bc;
 
-	i8 v2011 = (i8)(intptr_t)(ws+640);
-	i8 v2012 = *(i8*)(intptr_t)v2011;
-	i8 v2013 = v2012+(+664);
-	i8 v2014 = *(i8*)(intptr_t)v2013;
-	i8 v2015 = (i8)(intptr_t)(ws+640);
-	*(i8*)(intptr_t)v2015 = v2014;
+c02_01bc:;
 
-	goto c02_01da;
+	i2 v1759 = (i2)+0;
+	i8 v1760 = (i8)(intptr_t)(ws+568);
+	i8 v1761 = (i8)(intptr_t)(ws+3042);
+	i1 v1762 = *(i1*)(intptr_t)v1761;
+	i8 v1763 = v1762;
+	i1 v1764 = (i1)+1;
+	i8 v1765 = ((i8)v1763)<<v1764;
+	i8 v1766 = v1760+v1765;
+	*(i2*)(intptr_t)v1766 = v1759;
+
+	i8 v1767 = (i8)(intptr_t)(ws+3042);
+	i1 v1768 = *(i1*)(intptr_t)v1767;
+	i1 v1769 = v1768+(+1);
+	i8 v1770 = (i8)(intptr_t)(ws+3042);
+	*(i1*)(intptr_t)v1770 = v1769;
+
+	goto c02_01ba;
+
+c02_01bd:;
+
+
+	i8 v1809 = (i8)(intptr_t)(ws+632);
+	i8 v1810 = *(i8*)(intptr_t)v1809;
+	f97(v1810);
+
+c02_01d0:;
+
+	i8 v1811 = (i8)(intptr_t)(ws+3040);
+	i2 v1812 = *(i2*)(intptr_t)v1811;
+	i2 v1813 = (i2)+0;
+	if (v1812==v1813) goto c02_01d3; else goto c02_01d2;
+
+c02_01d2:;
+
+	i8 v1814 = (i8)(intptr_t)(ws+3040);
+	i2 v1815 = *(i2*)(intptr_t)v1814;
+	i2 v1816 = v1815+(-1);
+	i8 v1817 = (i8)(intptr_t)(ws+3040);
+	*(i2*)(intptr_t)v1817 = v1816;
+
+	i8 v1818 = (i8)(intptr_t)(ws+640);
+	i8 v1819 = (i8)(intptr_t)(ws+3040);
+	i2 v1820 = *(i2*)(intptr_t)v1819;
+	i8 v1821 = v1820;
+	i1 v1822 = (i1)+3;
+	i8 v1823 = ((i8)v1821)<<v1822;
+	i8 v1824 = v1818+v1823;
+	i8 v1825 = *(i8*)(intptr_t)v1824;
+	i8 v1826 = (i8)(intptr_t)(ws+632);
+	*(i8*)(intptr_t)v1826 = v1825;
+
+	i8 v1827 = (i8)(intptr_t)(ws+632);
+	i8 v1828 = *(i8*)(intptr_t)v1827;
+	i8 v1829 = v1828+(+188);
+	i1 v1830 = *(i1*)(intptr_t)v1829;
+	i1 v1831 = v1830|(+1);
+	i8 v1832 = (i8)(intptr_t)(ws+632);
+	i8 v1833 = *(i8*)(intptr_t)v1832;
+	i8 v1834 = v1833+(+188);
+	*(i1*)(intptr_t)v1834 = v1831;
+
+	i1 v1835 = (i1)+0;
+	i8 v1836 = (i8)(intptr_t)(ws+3042);
+	*(i1*)(intptr_t)v1836 = v1835;
+
+c02_01d6:;
+
+	i8 v1837 = (i8)(intptr_t)(ws+3042);
+	i1 v1838 = *(i1*)(intptr_t)v1837;
+	i1 v1839 = (i1)+4;
+	if (v1838==v1839) goto c02_01d9; else goto c02_01d8;
+
+c02_01d8:;
+
+	i8 v1840 = (i8)(intptr_t)(ws+632);
+	i8 v1841 = *(i8*)(intptr_t)v1840;
+	i8 v1842 = v1841+(+176);
+	i8 v1843 = (i8)(intptr_t)(ws+3042);
+	i1 v1844 = *(i1*)(intptr_t)v1843;
+	i8 v1845 = v1844;
+	i1 v1846 = (i1)+1;
+	i8 v1847 = ((i8)v1845)<<v1846;
+	i8 v1848 = v1842+v1847;
+	i2 v1849 = *(i2*)(intptr_t)v1848;
+	i8 v1850 = (i8)(intptr_t)(ws+632);
+	i8 v1851 = *(i8*)(intptr_t)v1850;
+	i8 v1852 = v1851+(+168);
+	i8 v1853 = (i8)(intptr_t)(ws+3042);
+	i1 v1854 = *(i1*)(intptr_t)v1853;
+	i8 v1855 = v1854;
+	i1 v1856 = (i1)+1;
+	i8 v1857 = ((i8)v1855)<<v1856;
+	i8 v1858 = v1852+v1857;
+	i2 v1859 = *(i2*)(intptr_t)v1858;
+	i2 v1860 = v1849+v1859;
+	i8 v1861 = (i8)(intptr_t)(ws+3052);
+	*(i2*)(intptr_t)v1861 = v1860;
+
+	i8 v1862 = (i8)(intptr_t)(ws+3052);
+	i2 v1863 = *(i2*)(intptr_t)v1862;
+	i1 v1864 = (i1)+8;
+	i2 v1865;
+	f68(&v1865, v1864, v1863);
+	i8 v1866 = (i8)(intptr_t)(ws+3044);
+	i8 v1867 = (i8)(intptr_t)(ws+3042);
+	i1 v1868 = *(i1*)(intptr_t)v1867;
+	i8 v1869 = v1868;
+	i1 v1870 = (i1)+1;
+	i8 v1871 = ((i8)v1869)<<v1870;
+	i8 v1872 = v1866+v1871;
+	*(i2*)(intptr_t)v1872 = v1865;
+
+	i8 v1873 = (i8)(intptr_t)(ws+568);
+	i8 v1874 = (i8)(intptr_t)(ws+3042);
+	i1 v1875 = *(i1*)(intptr_t)v1874;
+	i8 v1876 = v1875;
+	i1 v1877 = (i1)+1;
+	i8 v1878 = ((i8)v1876)<<v1877;
+	i8 v1879 = v1873+v1878;
+	i2 v1880 = *(i2*)(intptr_t)v1879;
+	i8 v1881 = (i8)(intptr_t)(ws+3052);
+	i2 v1882 = *(i2*)(intptr_t)v1881;
+	if (v1880<v1882) goto c02_01dd; else goto c02_01de;
 
 c02_01dd:;
 
-endsub:;
-}
-const i1 c02_s001e[] = { 0x63,0x6f,0x6e,0x66,0x6c,0x69,0x63,0x74,0x69,0x6e,0x67,0x20,0x65,0x78,0x74,0x65,0x72,0x6e,0x61,0x6c,0x73,0 };
-const i1 c02_s001f[] = { 0x65,0x72,0x72,0x6f,0x72,0x3a,0x20,0x65,0x78,0x74,0x65,0x72,0x6e,0x61,0x6c,0x20,0x27,0 };
-const i1 c02_s0020[] = { 0x27,0x20,0x75,0x6e,0x72,0x65,0x73,0x6f,0x6c,0x76,0x65,0x64,0x0a,0 };
-const i1 c02_s0021[] = { 0x61,0x62,0x6f,0x72,0x74,0x69,0x6e,0x67,0 };
+	i8 v1883 = (i8)(intptr_t)(ws+3052);
+	i2 v1884 = *(i2*)(intptr_t)v1883;
+	i8 v1885 = (i8)(intptr_t)(ws+568);
+	i8 v1886 = (i8)(intptr_t)(ws+3042);
+	i1 v1887 = *(i1*)(intptr_t)v1886;
+	i8 v1888 = v1887;
+	i1 v1889 = (i1)+1;
+	i8 v1890 = ((i8)v1888)<<v1889;
+	i8 v1891 = v1885+v1890;
+	*(i2*)(intptr_t)v1891 = v1884;
 
-// ResolveExternals workspace at ws+640 length ws+24
-void f97(void) {
+	goto c02_01da;
 
-	i1 v2016 = (i1)+0;
-	i8 v2017 = (i8)(intptr_t)(ws+648);
-	*(i1*)(intptr_t)v2017 = v2016;
+c02_01de:;
 
-	i8 v2018 = (i8)(intptr_t)(ws+40);
-	i8 v2019 = *(i8*)(intptr_t)v2018;
-	i8 v2020 = (i8)(intptr_t)(ws+656);
-	*(i8*)(intptr_t)v2020 = v2019;
+c02_01da:;
 
-c02_01e0:;
+	i8 v1892 = (i8)(intptr_t)(ws+3042);
+	i1 v1893 = *(i1*)(intptr_t)v1892;
+	i1 v1894 = v1893+(+1);
+	i8 v1895 = (i8)(intptr_t)(ws+3042);
+	*(i1*)(intptr_t)v1895 = v1894;
 
-	i8 v2021 = (i8)(intptr_t)(ws+656);
-	i8 v2022 = *(i8*)(intptr_t)v2021;
-	i8 v2023 = (i8)+0;
-	if (v2022==v2023) goto c02_01e3; else goto c02_01e2;
+	goto c02_01d6;
 
-c02_01e2:;
+c02_01d9:;
 
-	i8 v2024 = (i8)(intptr_t)(ws+656);
-	i8 v2025 = *(i8*)(intptr_t)v2024;
-	i8 v2026 = v2025+(+188);
-	i1 v2027 = *(i1*)(intptr_t)v2026;
-	i1 v2028 = v2027&(+2);
-	i1 v2029 = (i1)+0;
-	if (v2028==v2029) goto c02_01e8; else goto c02_01e7;
+	i8 v1896 = (i8)(intptr_t)(ws+632);
+	i8 v1897 = *(i8*)(intptr_t)v1896;
+	i8 v1898 = v1897+(+16);
+	i8 v1899 = (i8)(intptr_t)(ws+3056);
+	*(i8*)(intptr_t)v1899 = v1898;
 
-c02_01e7:;
+c02_01e1:;
 
-	i8 v2030 = (i8)(intptr_t)(ws+656);
-	i8 v2031 = *(i8*)(intptr_t)v2030;
-	i8 v2032 = v2031+(+160);
-	i8 v2033 = *(i8*)(intptr_t)v2032;
-	i8 v2034 = (i8)(intptr_t)(ws+640);
-	*(i8*)(intptr_t)v2034 = v2033;
-
-	i8 v2035 = (i8)(intptr_t)(ws+640);
-	i8 v2036 = *(i8*)(intptr_t)v2035;
-	i8 v2037 = (i8)+0;
-	if (v2036==v2037) goto c02_01ed; else goto c02_01ec;
-
-c02_01ec:;
-
-	i8 v2038 = (i8)(intptr_t)(ws+640);
-	i8 v2039 = *(i8*)(intptr_t)v2038;
-	i8 v2040 = v2039+(+16);
-	i8 v2041 = *(i8*)(intptr_t)v2040;
-	i8 v2042 = (i8)+0;
-	if (v2041==v2042) goto c02_01f4; else goto c02_01f5;
-
-c02_01f5:;
-
-	i8 v2043 = (i8)(intptr_t)(ws+640);
-	i8 v2044 = *(i8*)(intptr_t)v2043;
-	i8 v2045 = v2044+(+16);
-	i8 v2046 = *(i8*)(intptr_t)v2045;
-	i8 v2047 = (i8)(intptr_t)(ws+656);
-	i8 v2048 = *(i8*)(intptr_t)v2047;
-	if (v2046==v2048) goto c02_01f4; else goto c02_01f3;
-
-c02_01f3:;
-
-	i8 v2049 = (i8)(intptr_t)c02_s001e;
-	f57(v2049);
-
-	goto c02_01ee;
-
-c02_01f4:;
-
-c02_01ee:;
-
-	i8 v2050 = (i8)(intptr_t)(ws+656);
-	i8 v2051 = *(i8*)(intptr_t)v2050;
-	i8 v2052 = (i8)(intptr_t)(ws+640);
-	i8 v2053 = *(i8*)(intptr_t)v2052;
-	i8 v2054 = v2053+(+16);
-	*(i8*)(intptr_t)v2054 = v2051;
-
-	goto c02_01e9;
-
-c02_01ed:;
-
-c02_01e9:;
-
-	goto c02_01e4;
-
-c02_01e8:;
-
-c02_01e4:;
-
-	i8 v2055 = (i8)(intptr_t)(ws+656);
-	i8 v2056 = *(i8*)(intptr_t)v2055;
-	i8 v2057 = v2056+(+8);
-	i8 v2058 = *(i8*)(intptr_t)v2057;
-	i8 v2059 = (i8)(intptr_t)(ws+656);
-	*(i8*)(intptr_t)v2059 = v2058;
-
-	goto c02_01e0;
+	i8 v1900 = (i8)(intptr_t)(ws+3056);
+	i8 v1901 = *(i8*)(intptr_t)v1900;
+	i8 v1902 = (i8)+0;
+	if (v1901==v1902) goto c02_01e4; else goto c02_01e3;
 
 c02_01e3:;
 
-	i8 v2060 = (i8)(intptr_t)(ws+40);
-	i8 v2061 = *(i8*)(intptr_t)v2060;
-	i8 v2062 = (i8)(intptr_t)(ws+656);
-	*(i8*)(intptr_t)v2062 = v2061;
+	i1 v1903 = (i1)+0;
+	i8 v1904 = (i8)(intptr_t)(ws+3064);
+	*(i1*)(intptr_t)v1904 = v1903;
 
-c02_01f8:;
+c02_01e7:;
 
-	i8 v2063 = (i8)(intptr_t)(ws+656);
-	i8 v2064 = *(i8*)(intptr_t)v2063;
-	i8 v2065 = (i8)+0;
-	if (v2064==v2065) goto c02_01fb; else goto c02_01fa;
+	i8 v1905 = (i8)(intptr_t)(ws+3064);
+	i1 v1906 = *(i1*)(intptr_t)v1905;
+	i1 v1907 = (i1)+16;
+	if (v1906==v1907) goto c02_01ea; else goto c02_01e9;
+
+c02_01e9:;
+
+	i8 v1908 = (i8)(intptr_t)(ws+3056);
+	i8 v1909 = *(i8*)(intptr_t)v1908;
+	i8 v1910 = v1909+(+8);
+	i8 v1911 = (i8)(intptr_t)(ws+3064);
+	i1 v1912 = *(i1*)(intptr_t)v1911;
+	i8 v1913 = v1912;
+	i1 v1914 = (i1)+3;
+	i8 v1915 = ((i8)v1913)<<v1914;
+	i8 v1916 = v1910+v1915;
+	i8 v1917 = *(i8*)(intptr_t)v1916;
+	i8 v1918 = (i8)(intptr_t)(ws+3072);
+	*(i8*)(intptr_t)v1918 = v1917;
+
+	i8 v1919 = (i8)(intptr_t)(ws+3064);
+	i1 v1920 = *(i1*)(intptr_t)v1919;
+	i1 v1921 = v1920+(+1);
+	i8 v1922 = (i8)(intptr_t)(ws+3064);
+	*(i1*)(intptr_t)v1922 = v1921;
+
+	i8 v1923 = (i8)(intptr_t)(ws+3072);
+	i8 v1924 = *(i8*)(intptr_t)v1923;
+	i8 v1925 = (i8)+0;
+	if (v1924==v1925) goto c02_01ee; else goto c02_01ef;
+
+c02_01ee:;
+
+	goto c02_01ea;
+
+	goto c02_01eb;
+
+c02_01ef:;
+
+c02_01eb:;
+
+	i8 v1926 = (i8)(intptr_t)(ws+3072);
+	i8 v1927 = *(i8*)(intptr_t)v1926;
+	i8 v1928;
+	f83(&v1928, v1927);
+	i8 v1929 = (i8)(intptr_t)(ws+3072);
+	*(i8*)(intptr_t)v1929 = v1928;
+
+	i1 v1930 = (i1)+0;
+	i8 v1931 = (i8)(intptr_t)(ws+3042);
+	*(i1*)(intptr_t)v1931 = v1930;
+
+c02_01f2:;
+
+	i8 v1932 = (i8)(intptr_t)(ws+3042);
+	i1 v1933 = *(i1*)(intptr_t)v1932;
+	i1 v1934 = (i1)+4;
+	if (v1933==v1934) goto c02_01f5; else goto c02_01f4;
+
+c02_01f4:;
+
+	i8 v1935 = (i8)(intptr_t)(ws+3072);
+	i8 v1936 = *(i8*)(intptr_t)v1935;
+	i8 v1937 = v1936+(+176);
+	i8 v1938 = (i8)(intptr_t)(ws+3042);
+	i1 v1939 = *(i1*)(intptr_t)v1938;
+	i8 v1940 = v1939;
+	i1 v1941 = (i1)+1;
+	i8 v1942 = ((i8)v1940)<<v1941;
+	i8 v1943 = v1937+v1942;
+	i2 v1944 = *(i2*)(intptr_t)v1943;
+	i8 v1945 = (i8)(intptr_t)(ws+3080);
+	*(i2*)(intptr_t)v1945 = v1944;
+
+	i8 v1946 = (i8)(intptr_t)(ws+3044);
+	i8 v1947 = (i8)(intptr_t)(ws+3042);
+	i1 v1948 = *(i1*)(intptr_t)v1947;
+	i8 v1949 = v1948;
+	i1 v1950 = (i1)+1;
+	i8 v1951 = ((i8)v1949)<<v1950;
+	i8 v1952 = v1946+v1951;
+	i2 v1953 = *(i2*)(intptr_t)v1952;
+	i8 v1954 = (i8)(intptr_t)(ws+3082);
+	*(i2*)(intptr_t)v1954 = v1953;
+
+	i8 v1955 = (i8)(intptr_t)(ws+3080);
+	i2 v1956 = *(i2*)(intptr_t)v1955;
+	i8 v1957 = (i8)(intptr_t)(ws+3082);
+	i2 v1958 = *(i2*)(intptr_t)v1957;
+	if (v1956<v1958) goto c02_01f9; else goto c02_01fa;
+
+c02_01f9:;
+
+	i8 v1959 = (i8)(intptr_t)(ws+3082);
+	i2 v1960 = *(i2*)(intptr_t)v1959;
+	i8 v1961 = (i8)(intptr_t)(ws+3072);
+	i8 v1962 = *(i8*)(intptr_t)v1961;
+	i8 v1963 = v1962+(+176);
+	i8 v1964 = (i8)(intptr_t)(ws+3042);
+	i1 v1965 = *(i1*)(intptr_t)v1964;
+	i8 v1966 = v1965;
+	i1 v1967 = (i1)+1;
+	i8 v1968 = ((i8)v1966)<<v1967;
+	i8 v1969 = v1963+v1968;
+	*(i2*)(intptr_t)v1969 = v1960;
+
+	i8 v1970 = (i8)(intptr_t)(ws+3072);
+	i8 v1971 = *(i8*)(intptr_t)v1970;
+	f97(v1971);
+
+	goto c02_01f6;
 
 c02_01fa:;
 
-	i8 v2066 = (i8)(intptr_t)(ws+656);
-	i8 v2067 = *(i8*)(intptr_t)v2066;
-	i8 v2068 = v2067+(+160);
-	i8 v2069 = *(i8*)(intptr_t)v2068;
-	i8 v2070 = (i8)(intptr_t)(ws+640);
-	*(i8*)(intptr_t)v2070 = v2069;
+c02_01f6:;
 
-	i8 v2071 = (i8)(intptr_t)(ws+640);
-	i8 v2072 = *(i8*)(intptr_t)v2071;
-	i8 v2073 = (i8)+0;
-	if (v2072==v2073) goto c02_0202; else goto c02_0203;
+	i8 v1972 = (i8)(intptr_t)(ws+3042);
+	i1 v1973 = *(i1*)(intptr_t)v1972;
+	i1 v1974 = v1973+(+1);
+	i8 v1975 = (i8)(intptr_t)(ws+3042);
+	*(i1*)(intptr_t)v1975 = v1974;
 
-c02_0203:;
+	goto c02_01f2;
 
-	i8 v2074 = (i8)(intptr_t)(ws+640);
-	i8 v2075 = *(i8*)(intptr_t)v2074;
-	i8 v2076 = v2075+(+16);
-	i8 v2077 = *(i8*)(intptr_t)v2076;
-	i8 v2078 = (i8)+0;
-	if (v2077==v2078) goto c02_0201; else goto c02_0202;
+c02_01f5:;
 
-c02_0201:;
+	i8 v1976 = (i8)(intptr_t)(ws+3072);
+	i8 v1977 = *(i8*)(intptr_t)v1976;
+	i8 v1978 = v1977+(+188);
+	i1 v1979 = *(i1*)(intptr_t)v1978;
+	i1 v1980 = v1979&(+1);
+	i1 v1981 = (i1)+0;
+	if (v1980==v1981) goto c02_01fe; else goto c02_01ff;
 
-	i8 v2079 = (i8)(intptr_t)c02_s001f;
-	f11(v2079);
+c02_01fe:;
 
-	i8 v2080 = (i8)(intptr_t)(ws+640);
-	i8 v2081 = *(i8*)(intptr_t)v2080;
-	i8 v2082 = v2081+(+8);
-	i8 v2083 = *(i8*)(intptr_t)v2082;
-	f11(v2083);
+	i8 v1982 = (i8)(intptr_t)(ws+3072);
+	i8 v1983 = *(i8*)(intptr_t)v1982;
+	f97(v1983);
 
-	i8 v2084 = (i8)(intptr_t)c02_s0020;
-	f11(v2084);
+	i8 v1984 = (i8)(intptr_t)(ws+3072);
+	i8 v1985 = *(i8*)(intptr_t)v1984;
+	i8 v1986 = v1985+(+188);
+	i1 v1987 = *(i1*)(intptr_t)v1986;
+	i1 v1988 = v1987|(+1);
+	i8 v1989 = (i8)(intptr_t)(ws+3072);
+	i8 v1990 = *(i8*)(intptr_t)v1989;
+	i8 v1991 = v1990+(+188);
+	*(i1*)(intptr_t)v1991 = v1988;
 
-	i1 v2085 = (i1)+1;
-	i8 v2086 = (i8)(intptr_t)(ws+648);
-	*(i1*)(intptr_t)v2086 = v2085;
+	goto c02_01fb;
 
-	goto c02_01fc;
-
-c02_0202:;
-
-c02_01fc:;
-
-	i8 v2087 = (i8)(intptr_t)(ws+656);
-	i8 v2088 = *(i8*)(intptr_t)v2087;
-	i8 v2089 = v2088+(+8);
-	i8 v2090 = *(i8*)(intptr_t)v2089;
-	i8 v2091 = (i8)(intptr_t)(ws+656);
-	*(i8*)(intptr_t)v2091 = v2090;
-
-	goto c02_01f8;
+c02_01ff:;
 
 c02_01fb:;
 
-	i8 v2092 = (i8)(intptr_t)(ws+648);
-	i1 v2093 = *(i1*)(intptr_t)v2092;
-	i1 v2094 = (i1)+0;
-	if (v2093==v2094) goto c02_0208; else goto c02_0207;
+	goto c02_01e7;
 
-c02_0207:;
+c02_01ea:;
 
-	i8 v2095 = (i8)(intptr_t)c02_s0021;
-	f57(v2095);
+	i8 v1992 = (i8)(intptr_t)(ws+3056);
+	i8 v1993 = *(i8*)(intptr_t)v1992;
+	i8 v1994 = *(i8*)(intptr_t)v1993;
+	i8 v1995 = (i8)(intptr_t)(ws+3056);
+	*(i8*)(intptr_t)v1995 = v1994;
 
-	goto c02_0204;
+	goto c02_01e1;
 
-c02_0208:;
+c02_01e4:;
+
+	goto c02_01d0;
+
+c02_01d3:;
+
+	i8 v1996 = (i8)(intptr_t)c02_s0019;
+	f11(v1996);
+
+	i1 v1997 = (i1)+0;
+	i8 v1998 = (i8)(intptr_t)(ws+3042);
+	*(i1*)(intptr_t)v1998 = v1997;
+
+c02_0202:;
+
+	i8 v1999 = (i8)(intptr_t)(ws+3042);
+	i1 v2000 = *(i1*)(intptr_t)v1999;
+	i1 v2001 = (i1)+4;
+	if (v2000==v2001) goto c02_0205; else goto c02_0204;
 
 c02_0204:;
 
+	i8 v2002 = (i8)(intptr_t)c02_s001a;
+	f11(v2002);
+
+	i8 v2003 = (i8)(intptr_t)(ws+3042);
+	i1 v2004 = *(i1*)(intptr_t)v2003;
+	f17(v2004);
+
+	i8 v2005 = (i8)(intptr_t)c02_s001b;
+	f11(v2005);
+
+	i8 v2006 = (i8)(intptr_t)(ws+568);
+	i8 v2007 = (i8)(intptr_t)(ws+3042);
+	i1 v2008 = *(i1*)(intptr_t)v2007;
+	i8 v2009 = v2008;
+	i1 v2010 = (i1)+1;
+	i8 v2011 = ((i8)v2009)<<v2010;
+	i8 v2012 = v2006+v2011;
+	i2 v2013 = *(i2*)(intptr_t)v2012;
+	f16(v2013);
+
+	i8 v2014 = (i8)(intptr_t)c02_s001c;
+	f11(v2014);
+
+	i8 v2015 = (i8)(intptr_t)(ws+3042);
+	i1 v2016 = *(i1*)(intptr_t)v2015;
+	i1 v2017 = v2016+(+1);
+	i8 v2018 = (i8)(intptr_t)(ws+3042);
+	*(i1*)(intptr_t)v2018 = v2017;
+
+	goto c02_0202;
+
+c02_0205:;
+
 endsub:;
 }
-const i1 c02_s0022[] = { 0x65,0x72,0x72,0x6f,0x72,0x3a,0x20,0x64,0x65,0x70,0x65,0x6e,0x64,0x65,0x6e,0x63,0x79,0x20,0x67,0x72,0x61,0x70,0x68,0x20,0x6f,0x76,0x65,0x72,0x66,0x6c,0x6f,0x77,0x0a,0 };
+const i1 c02_s001d[] = { 0x43,0x4f,0x57,0x4c,0x49,0x4e,0x4b,0x3a,0x20,0 };
+const i1 c02_s001e[] = { 0x6b,0x42,0x20,0x66,0x72,0x65,0x65,0x0a,0 };
+const i1 c02_s001f[] = { 0x53,0x79,0x6e,0x74,0x61,0x78,0x20,0x65,0x72,0x72,0x6f,0x72,0x0a,0 };
 
-// push workspace at ws+3096 length ws+10
-void f99(i8 p2116 /* subr */) {
-	*(i8*)(intptr_t)(ws+3096) = p2116; /*subr */
+// SyntaxError workspace at ws+632 length ws+0
+void f98(void) {
 
-	i8 v2117 = (i8)(intptr_t)(ws+3048);
-	i2 v2118 = *(i2*)(intptr_t)v2117;
-	i8 v2119 = (i8)(intptr_t)(ws+3104);
-	*(i2*)(intptr_t)v2119 = v2118;
+	i8 v2035 = (i8)(intptr_t)c02_s001f;
+	f55(v2035);
 
-c02_0211:;
+endsub:;
+}
+const i1 c02_s0020[] = { 0x41,0x64,0x64,0x69,0x6e,0x67,0x20,0x69,0x6e,0x70,0x75,0x74,0x20,0x66,0x69,0x6c,0x65,0x3a,0x20,0 };
 
-	i8 v2120 = (i8)(intptr_t)(ws+3104);
-	i2 v2121 = *(i2*)(intptr_t)v2120;
-	i2 v2122 = (i2)+0;
-	if (v2121==v2122) goto c02_0214; else goto c02_0213;
+// AddInputFile workspace at ws+632 length ws+24
+void f99(i8 p2036 /* filename */) {
+	*(i8*)(intptr_t)(ws+632) = p2036; /*filename */
+
+	i8 v2037 = (i8)(intptr_t)c02_s0020;
+	f11(v2037);
+
+	i8 v2038 = (i8)(intptr_t)(ws+632);
+	i8 v2039 = *(i8*)(intptr_t)v2038;
+	f11(v2039);
+
+	f12();
+
+	i8 v2040 = (i8)(intptr_t)(ws+632);
+	i8 v2041 = *(i8*)(intptr_t)v2040;
+	i8 v2042;
+	f85(&v2042, v2041);
+	i8 v2043 = (i8)(intptr_t)(ws+640);
+	*(i8*)(intptr_t)v2043 = v2042;
+
+	i8 v2044 = (i8)(intptr_t)(ws+592);
+	i8 v2045 = *(i8*)(intptr_t)v2044;
+	i8 v2046 = (i8)+0;
+	if (v2045==v2046) goto c02_0209; else goto c02_020a;
+
+c02_0209:;
+
+	i8 v2047 = (i8)(intptr_t)(ws+640);
+	i8 v2048 = *(i8*)(intptr_t)v2047;
+	i8 v2049 = (i8)(intptr_t)(ws+592);
+	*(i8*)(intptr_t)v2049 = v2048;
+
+	i8 v2050 = (i8)(intptr_t)(ws+640);
+	i8 v2051 = *(i8*)(intptr_t)v2050;
+	i8 v2052 = (i8)(intptr_t)(ws+584);
+	*(i8*)(intptr_t)v2052 = v2051;
+
+	goto c02_0206;
+
+c02_020a:;
+
+	i8 v2053 = (i8)(intptr_t)(ws+640);
+	i8 v2054 = *(i8*)(intptr_t)v2053;
+	i8 v2055 = (i8)(intptr_t)(ws+584);
+	i8 v2056 = *(i8*)(intptr_t)v2055;
+	i8 v2057 = v2056+(+664);
+	*(i8*)(intptr_t)v2057 = v2054;
+
+	i8 v2058 = (i8)(intptr_t)(ws+640);
+	i8 v2059 = *(i8*)(intptr_t)v2058;
+	i8 v2060 = (i8)(intptr_t)(ws+584);
+	*(i8*)(intptr_t)v2060 = v2059;
+
+c02_0206:;
+
+	i8 v2061 = (i8)(intptr_t)(ws+640);
+	i8 v2062 = *(i8*)(intptr_t)v2061;
+	i2 v2063 = (i2)+0;
+	i8 v2064;
+	f81(&v2064, v2063, v2062);
+	i8 v2065 = *(i8*)(intptr_t)v2064;
+	i8 v2066 = (i8)(intptr_t)(ws+648);
+	*(i8*)(intptr_t)v2066 = v2065;
+
+	i8 v2067 = (i8)(intptr_t)(ws+648);
+	i8 v2068 = *(i8*)(intptr_t)v2067;
+	i8 v2069 = (i8)+0;
+	if (v2068==v2069) goto c02_020f; else goto c02_020e;
+
+c02_020e:;
+
+	i8 v2070 = (i8)(intptr_t)(ws+608);
+	i8 v2071 = *(i8*)(intptr_t)v2070;
+	i8 v2072 = (i8)+0;
+	if (v2071==v2072) goto c02_0213; else goto c02_0214;
 
 c02_0213:;
 
-	i8 v2123 = (i8)(intptr_t)(ws+3104);
-	i2 v2124 = *(i2*)(intptr_t)v2123;
-	i2 v2125 = v2124+(-1);
-	i8 v2126 = (i8)(intptr_t)(ws+3104);
-	*(i2*)(intptr_t)v2126 = v2125;
+	i8 v2073 = (i8)(intptr_t)(ws+648);
+	i8 v2074 = *(i8*)(intptr_t)v2073;
+	i8 v2075 = (i8)(intptr_t)(ws+608);
+	*(i8*)(intptr_t)v2075 = v2074;
 
-	i8 v2127 = (i8)(intptr_t)(ws+648);
-	i8 v2128 = (i8)(intptr_t)(ws+3104);
-	i2 v2129 = *(i2*)(intptr_t)v2128;
-	i8 v2130 = v2129;
-	i1 v2131 = (i1)+3;
-	i8 v2132 = ((i8)v2130)<<v2131;
-	i8 v2133 = v2127+v2132;
-	i8 v2134 = *(i8*)(intptr_t)v2133;
-	i8 v2135 = (i8)(intptr_t)(ws+3096);
-	i8 v2136 = *(i8*)(intptr_t)v2135;
-	if (v2134==v2136) goto c02_0218; else goto c02_0219;
+	goto c02_0210;
+
+c02_0214:;
+
+c02_0210:;
+
+	goto c02_020b;
+
+c02_020f:;
+
+c02_020b:;
+
+	i8 v2076 = (i8)(intptr_t)(ws+616);
+	i8 v2077 = *(i8*)(intptr_t)v2076;
+	i8 v2078 = (i8)+0;
+	if (v2077==v2078) goto c02_0219; else goto c02_0218;
 
 c02_0218:;
 
-	goto endsub;
+	i8 v2079 = (i8)(intptr_t)(ws+616);
+	i8 v2080 = *(i8*)(intptr_t)v2079;
+	i8 v2081 = (i8)(intptr_t)(ws+648);
+	i8 v2082 = *(i8*)(intptr_t)v2081;
+	f80(v2082, v2080);
 
 	goto c02_0215;
 
@@ -3720,616 +3992,22 @@ c02_0219:;
 
 c02_0215:;
 
-	goto c02_0211;
-
-c02_0214:;
-
-	i8 v2137 = (i8)(intptr_t)(ws+3048);
-	i2 v2138 = *(i2*)(intptr_t)v2137;
-	i2 v2139 = (i2)+300;
-	if (v2138==v2139) goto c02_021d; else goto c02_021e;
-
-c02_021d:;
-
-	i8 v2140 = (i8)(intptr_t)c02_s0022;
-	f11(v2140);
-
-	f6();
-
-	goto c02_021a;
-
-c02_021e:;
-
-c02_021a:;
-
-	i8 v2141 = (i8)(intptr_t)(ws+3096);
-	i8 v2142 = *(i8*)(intptr_t)v2141;
-	i8 v2143 = (i8)(intptr_t)(ws+648);
-	i8 v2144 = (i8)(intptr_t)(ws+3048);
-	i2 v2145 = *(i2*)(intptr_t)v2144;
-	i8 v2146 = v2145;
-	i1 v2147 = (i1)+3;
-	i8 v2148 = ((i8)v2146)<<v2147;
-	i8 v2149 = v2143+v2148;
-	*(i8*)(intptr_t)v2149 = v2142;
-
-	i8 v2150 = (i8)(intptr_t)(ws+3048);
-	i2 v2151 = *(i2*)(intptr_t)v2150;
-	i2 v2152 = v2151+(+1);
-	i8 v2153 = (i8)(intptr_t)(ws+3048);
-	*(i2*)(intptr_t)v2153 = v2152;
+	i8 v2083 = (i8)(intptr_t)(ws+648);
+	i8 v2084 = *(i8*)(intptr_t)v2083;
+	i8 v2085 = (i8)(intptr_t)(ws+616);
+	*(i8*)(intptr_t)v2085 = v2084;
 
 endsub:;
 }
-const i1 c02_s0023[] = { 0x57,0x6f,0x72,0x6b,0x73,0x70,0x61,0x63,0x65,0x20,0x73,0x69,0x7a,0x65,0x73,0x3a,0x0a,0 };
-const i1 c02_s0024[] = { 0x20,0x20,0x23,0 };
-const i1 c02_s0025[] = { 0x3a,0x20,0 };
-const i1 c02_s0026[] = { 0x20,0x62,0x79,0x74,0x65,0x73,0x0a,0 };
-
-// PlaceSubroutines workspace at ws+640 length ws+2452
-void f98(i8 p2096 /* subroutine */) {
-	*(i8*)(intptr_t)(ws+640) = p2096; /*subroutine */
-
-	i2 v2097 = (i2)+0;
-	i8 v2098 = (i8)(intptr_t)(ws+3048);
-	*(i2*)(intptr_t)v2098 = v2097;
-
-	i1 v2099 = (i1)+0;
-	i8 v2100 = (i8)(intptr_t)(ws+3050);
-	*(i1*)(intptr_t)v2100 = v2099;
-
-c02_020b:;
-
-	i8 v2101 = (i8)(intptr_t)(ws+3050);
-	i1 v2102 = *(i1*)(intptr_t)v2101;
-	i1 v2103 = (i1)+4;
-	if (v2102==v2103) goto c02_020e; else goto c02_020d;
-
-c02_020d:;
-
-	i2 v2104 = (i2)+0;
-	i8 v2105 = (i8)(intptr_t)(ws+576);
-	i8 v2106 = (i8)(intptr_t)(ws+3050);
-	i1 v2107 = *(i1*)(intptr_t)v2106;
-	i8 v2108 = v2107;
-	i1 v2109 = (i1)+1;
-	i8 v2110 = ((i8)v2108)<<v2109;
-	i8 v2111 = v2105+v2110;
-	*(i2*)(intptr_t)v2111 = v2104;
-
-	i8 v2112 = (i8)(intptr_t)(ws+3050);
-	i1 v2113 = *(i1*)(intptr_t)v2112;
-	i1 v2114 = v2113+(+1);
-	i8 v2115 = (i8)(intptr_t)(ws+3050);
-	*(i1*)(intptr_t)v2115 = v2114;
-
-	goto c02_020b;
-
-c02_020e:;
-
-
-	i8 v2154 = (i8)(intptr_t)(ws+640);
-	i8 v2155 = *(i8*)(intptr_t)v2154;
-	f99(v2155);
-
-c02_0221:;
-
-	i8 v2156 = (i8)(intptr_t)(ws+3048);
-	i2 v2157 = *(i2*)(intptr_t)v2156;
-	i2 v2158 = (i2)+0;
-	if (v2157==v2158) goto c02_0224; else goto c02_0223;
-
-c02_0223:;
-
-	i8 v2159 = (i8)(intptr_t)(ws+3048);
-	i2 v2160 = *(i2*)(intptr_t)v2159;
-	i2 v2161 = v2160+(-1);
-	i8 v2162 = (i8)(intptr_t)(ws+3048);
-	*(i2*)(intptr_t)v2162 = v2161;
-
-	i8 v2163 = (i8)(intptr_t)(ws+648);
-	i8 v2164 = (i8)(intptr_t)(ws+3048);
-	i2 v2165 = *(i2*)(intptr_t)v2164;
-	i8 v2166 = v2165;
-	i1 v2167 = (i1)+3;
-	i8 v2168 = ((i8)v2166)<<v2167;
-	i8 v2169 = v2163+v2168;
-	i8 v2170 = *(i8*)(intptr_t)v2169;
-	i8 v2171 = (i8)(intptr_t)(ws+640);
-	*(i8*)(intptr_t)v2171 = v2170;
-
-	i8 v2172 = (i8)(intptr_t)(ws+640);
-	i8 v2173 = *(i8*)(intptr_t)v2172;
-	i8 v2174 = v2173+(+188);
-	i1 v2175 = *(i1*)(intptr_t)v2174;
-	i1 v2176 = v2175|(+1);
-	i8 v2177 = (i8)(intptr_t)(ws+640);
-	i8 v2178 = *(i8*)(intptr_t)v2177;
-	i8 v2179 = v2178+(+188);
-	*(i1*)(intptr_t)v2179 = v2176;
-
-	i1 v2180 = (i1)+0;
-	i8 v2181 = (i8)(intptr_t)(ws+3050);
-	*(i1*)(intptr_t)v2181 = v2180;
-
-c02_0227:;
-
-	i8 v2182 = (i8)(intptr_t)(ws+3050);
-	i1 v2183 = *(i1*)(intptr_t)v2182;
-	i1 v2184 = (i1)+4;
-	if (v2183==v2184) goto c02_022a; else goto c02_0229;
-
-c02_0229:;
-
-	i8 v2185 = (i8)(intptr_t)(ws+640);
-	i8 v2186 = *(i8*)(intptr_t)v2185;
-	i8 v2187 = v2186+(+176);
-	i8 v2188 = (i8)(intptr_t)(ws+3050);
-	i1 v2189 = *(i1*)(intptr_t)v2188;
-	i8 v2190 = v2189;
-	i1 v2191 = (i1)+1;
-	i8 v2192 = ((i8)v2190)<<v2191;
-	i8 v2193 = v2187+v2192;
-	i2 v2194 = *(i2*)(intptr_t)v2193;
-	i8 v2195 = (i8)(intptr_t)(ws+640);
-	i8 v2196 = *(i8*)(intptr_t)v2195;
-	i8 v2197 = v2196+(+168);
-	i8 v2198 = (i8)(intptr_t)(ws+3050);
-	i1 v2199 = *(i1*)(intptr_t)v2198;
-	i8 v2200 = v2199;
-	i1 v2201 = (i1)+1;
-	i8 v2202 = ((i8)v2200)<<v2201;
-	i8 v2203 = v2197+v2202;
-	i2 v2204 = *(i2*)(intptr_t)v2203;
-	i2 v2205 = v2194+v2204;
-	i8 v2206 = (i8)(intptr_t)(ws+3060);
-	*(i2*)(intptr_t)v2206 = v2205;
-
-	i8 v2207 = (i8)(intptr_t)(ws+3060);
-	i2 v2208 = *(i2*)(intptr_t)v2207;
-	i1 v2209 = (i1)+8;
-	i2 v2210;
-	f70(&v2210, v2209, v2208);
-	i8 v2211 = (i8)(intptr_t)(ws+3052);
-	i8 v2212 = (i8)(intptr_t)(ws+3050);
-	i1 v2213 = *(i1*)(intptr_t)v2212;
-	i8 v2214 = v2213;
-	i1 v2215 = (i1)+1;
-	i8 v2216 = ((i8)v2214)<<v2215;
-	i8 v2217 = v2211+v2216;
-	*(i2*)(intptr_t)v2217 = v2210;
-
-	i8 v2218 = (i8)(intptr_t)(ws+576);
-	i8 v2219 = (i8)(intptr_t)(ws+3050);
-	i1 v2220 = *(i1*)(intptr_t)v2219;
-	i8 v2221 = v2220;
-	i1 v2222 = (i1)+1;
-	i8 v2223 = ((i8)v2221)<<v2222;
-	i8 v2224 = v2218+v2223;
-	i2 v2225 = *(i2*)(intptr_t)v2224;
-	i8 v2226 = (i8)(intptr_t)(ws+3060);
-	i2 v2227 = *(i2*)(intptr_t)v2226;
-	if (v2225<v2227) goto c02_022e; else goto c02_022f;
-
-c02_022e:;
-
-	i8 v2228 = (i8)(intptr_t)(ws+3060);
-	i2 v2229 = *(i2*)(intptr_t)v2228;
-	i8 v2230 = (i8)(intptr_t)(ws+576);
-	i8 v2231 = (i8)(intptr_t)(ws+3050);
-	i1 v2232 = *(i1*)(intptr_t)v2231;
-	i8 v2233 = v2232;
-	i1 v2234 = (i1)+1;
-	i8 v2235 = ((i8)v2233)<<v2234;
-	i8 v2236 = v2230+v2235;
-	*(i2*)(intptr_t)v2236 = v2229;
-
-	goto c02_022b;
-
-c02_022f:;
-
-c02_022b:;
-
-	i8 v2237 = (i8)(intptr_t)(ws+3050);
-	i1 v2238 = *(i1*)(intptr_t)v2237;
-	i1 v2239 = v2238+(+1);
-	i8 v2240 = (i8)(intptr_t)(ws+3050);
-	*(i1*)(intptr_t)v2240 = v2239;
-
-	goto c02_0227;
-
-c02_022a:;
-
-	i8 v2241 = (i8)(intptr_t)(ws+640);
-	i8 v2242 = *(i8*)(intptr_t)v2241;
-	i8 v2243 = v2242+(+16);
-	i8 v2244 = (i8)(intptr_t)(ws+3064);
-	*(i8*)(intptr_t)v2244 = v2243;
-
-c02_0232:;
-
-	i8 v2245 = (i8)(intptr_t)(ws+3064);
-	i8 v2246 = *(i8*)(intptr_t)v2245;
-	i8 v2247 = (i8)+0;
-	if (v2246==v2247) goto c02_0235; else goto c02_0234;
-
-c02_0234:;
-
-	i1 v2248 = (i1)+0;
-	i8 v2249 = (i8)(intptr_t)(ws+3072);
-	*(i1*)(intptr_t)v2249 = v2248;
-
-c02_0238:;
-
-	i8 v2250 = (i8)(intptr_t)(ws+3072);
-	i1 v2251 = *(i1*)(intptr_t)v2250;
-	i1 v2252 = (i1)+16;
-	if (v2251==v2252) goto c02_023b; else goto c02_023a;
-
-c02_023a:;
-
-	i8 v2253 = (i8)(intptr_t)(ws+3064);
-	i8 v2254 = *(i8*)(intptr_t)v2253;
-	i8 v2255 = v2254+(+8);
-	i8 v2256 = (i8)(intptr_t)(ws+3072);
-	i1 v2257 = *(i1*)(intptr_t)v2256;
-	i8 v2258 = v2257;
-	i1 v2259 = (i1)+3;
-	i8 v2260 = ((i8)v2258)<<v2259;
-	i8 v2261 = v2255+v2260;
-	i8 v2262 = *(i8*)(intptr_t)v2261;
-	i8 v2263 = (i8)(intptr_t)(ws+3080);
-	*(i8*)(intptr_t)v2263 = v2262;
-
-	i8 v2264 = (i8)(intptr_t)(ws+3072);
-	i1 v2265 = *(i1*)(intptr_t)v2264;
-	i1 v2266 = v2265+(+1);
-	i8 v2267 = (i8)(intptr_t)(ws+3072);
-	*(i1*)(intptr_t)v2267 = v2266;
-
-	i8 v2268 = (i8)(intptr_t)(ws+3080);
-	i8 v2269 = *(i8*)(intptr_t)v2268;
-	i8 v2270 = (i8)+0;
-	if (v2269==v2270) goto c02_023f; else goto c02_0240;
-
-c02_023f:;
-
-	goto c02_023b;
-
-	goto c02_023c;
-
-c02_0240:;
-
-c02_023c:;
-
-	i8 v2271 = (i8)(intptr_t)(ws+3080);
-	i8 v2272 = *(i8*)(intptr_t)v2271;
-	i8 v2273;
-	f85(&v2273, v2272);
-	i8 v2274 = (i8)(intptr_t)(ws+3080);
-	*(i8*)(intptr_t)v2274 = v2273;
-
-	i1 v2275 = (i1)+0;
-	i8 v2276 = (i8)(intptr_t)(ws+3050);
-	*(i1*)(intptr_t)v2276 = v2275;
-
-c02_0243:;
-
-	i8 v2277 = (i8)(intptr_t)(ws+3050);
-	i1 v2278 = *(i1*)(intptr_t)v2277;
-	i1 v2279 = (i1)+4;
-	if (v2278==v2279) goto c02_0246; else goto c02_0245;
-
-c02_0245:;
-
-	i8 v2280 = (i8)(intptr_t)(ws+3080);
-	i8 v2281 = *(i8*)(intptr_t)v2280;
-	i8 v2282 = v2281+(+176);
-	i8 v2283 = (i8)(intptr_t)(ws+3050);
-	i1 v2284 = *(i1*)(intptr_t)v2283;
-	i8 v2285 = v2284;
-	i1 v2286 = (i1)+1;
-	i8 v2287 = ((i8)v2285)<<v2286;
-	i8 v2288 = v2282+v2287;
-	i2 v2289 = *(i2*)(intptr_t)v2288;
-	i8 v2290 = (i8)(intptr_t)(ws+3088);
-	*(i2*)(intptr_t)v2290 = v2289;
-
-	i8 v2291 = (i8)(intptr_t)(ws+3052);
-	i8 v2292 = (i8)(intptr_t)(ws+3050);
-	i1 v2293 = *(i1*)(intptr_t)v2292;
-	i8 v2294 = v2293;
-	i1 v2295 = (i1)+1;
-	i8 v2296 = ((i8)v2294)<<v2295;
-	i8 v2297 = v2291+v2296;
-	i2 v2298 = *(i2*)(intptr_t)v2297;
-	i8 v2299 = (i8)(intptr_t)(ws+3090);
-	*(i2*)(intptr_t)v2299 = v2298;
-
-	i8 v2300 = (i8)(intptr_t)(ws+3088);
-	i2 v2301 = *(i2*)(intptr_t)v2300;
-	i8 v2302 = (i8)(intptr_t)(ws+3090);
-	i2 v2303 = *(i2*)(intptr_t)v2302;
-	if (v2301<v2303) goto c02_024a; else goto c02_024b;
-
-c02_024a:;
-
-	i8 v2304 = (i8)(intptr_t)(ws+3090);
-	i2 v2305 = *(i2*)(intptr_t)v2304;
-	i8 v2306 = (i8)(intptr_t)(ws+3080);
-	i8 v2307 = *(i8*)(intptr_t)v2306;
-	i8 v2308 = v2307+(+176);
-	i8 v2309 = (i8)(intptr_t)(ws+3050);
-	i1 v2310 = *(i1*)(intptr_t)v2309;
-	i8 v2311 = v2310;
-	i1 v2312 = (i1)+1;
-	i8 v2313 = ((i8)v2311)<<v2312;
-	i8 v2314 = v2308+v2313;
-	*(i2*)(intptr_t)v2314 = v2305;
-
-	i8 v2315 = (i8)(intptr_t)(ws+3080);
-	i8 v2316 = *(i8*)(intptr_t)v2315;
-	f99(v2316);
-
-	goto c02_0247;
-
-c02_024b:;
-
-c02_0247:;
-
-	i8 v2317 = (i8)(intptr_t)(ws+3050);
-	i1 v2318 = *(i1*)(intptr_t)v2317;
-	i1 v2319 = v2318+(+1);
-	i8 v2320 = (i8)(intptr_t)(ws+3050);
-	*(i1*)(intptr_t)v2320 = v2319;
-
-	goto c02_0243;
-
-c02_0246:;
-
-	i8 v2321 = (i8)(intptr_t)(ws+3080);
-	i8 v2322 = *(i8*)(intptr_t)v2321;
-	i8 v2323 = v2322+(+188);
-	i1 v2324 = *(i1*)(intptr_t)v2323;
-	i1 v2325 = v2324&(+1);
-	i1 v2326 = (i1)+0;
-	if (v2325==v2326) goto c02_024f; else goto c02_0250;
-
-c02_024f:;
-
-	i8 v2327 = (i8)(intptr_t)(ws+3080);
-	i8 v2328 = *(i8*)(intptr_t)v2327;
-	f99(v2328);
-
-	i8 v2329 = (i8)(intptr_t)(ws+3080);
-	i8 v2330 = *(i8*)(intptr_t)v2329;
-	i8 v2331 = v2330+(+188);
-	i1 v2332 = *(i1*)(intptr_t)v2331;
-	i1 v2333 = v2332|(+1);
-	i8 v2334 = (i8)(intptr_t)(ws+3080);
-	i8 v2335 = *(i8*)(intptr_t)v2334;
-	i8 v2336 = v2335+(+188);
-	*(i1*)(intptr_t)v2336 = v2333;
-
-	goto c02_024c;
-
-c02_0250:;
-
-c02_024c:;
-
-	goto c02_0238;
-
-c02_023b:;
-
-	i8 v2337 = (i8)(intptr_t)(ws+3064);
-	i8 v2338 = *(i8*)(intptr_t)v2337;
-	i8 v2339 = *(i8*)(intptr_t)v2338;
-	i8 v2340 = (i8)(intptr_t)(ws+3064);
-	*(i8*)(intptr_t)v2340 = v2339;
-
-	goto c02_0232;
-
-c02_0235:;
-
-	goto c02_0221;
-
-c02_0224:;
-
-	i8 v2341 = (i8)(intptr_t)c02_s0023;
-	f11(v2341);
-
-	i1 v2342 = (i1)+0;
-	i8 v2343 = (i8)(intptr_t)(ws+3050);
-	*(i1*)(intptr_t)v2343 = v2342;
-
-c02_0253:;
-
-	i8 v2344 = (i8)(intptr_t)(ws+3050);
-	i1 v2345 = *(i1*)(intptr_t)v2344;
-	i1 v2346 = (i1)+4;
-	if (v2345==v2346) goto c02_0256; else goto c02_0255;
-
-c02_0255:;
-
-	i8 v2347 = (i8)(intptr_t)c02_s0024;
-	f11(v2347);
-
-	i8 v2348 = (i8)(intptr_t)(ws+3050);
-	i1 v2349 = *(i1*)(intptr_t)v2348;
-	f17(v2349);
-
-	i8 v2350 = (i8)(intptr_t)c02_s0025;
-	f11(v2350);
-
-	i8 v2351 = (i8)(intptr_t)(ws+576);
-	i8 v2352 = (i8)(intptr_t)(ws+3050);
-	i1 v2353 = *(i1*)(intptr_t)v2352;
-	i8 v2354 = v2353;
-	i1 v2355 = (i1)+1;
-	i8 v2356 = ((i8)v2354)<<v2355;
-	i8 v2357 = v2351+v2356;
-	i2 v2358 = *(i2*)(intptr_t)v2357;
-	f16(v2358);
-
-	i8 v2359 = (i8)(intptr_t)c02_s0026;
-	f11(v2359);
-
-	i8 v2360 = (i8)(intptr_t)(ws+3050);
-	i1 v2361 = *(i1*)(intptr_t)v2360;
-	i1 v2362 = v2361+(+1);
-	i8 v2363 = (i8)(intptr_t)(ws+3050);
-	*(i1*)(intptr_t)v2363 = v2362;
-
-	goto c02_0253;
-
-c02_0256:;
-
-endsub:;
-}
-const i1 c02_s0027[] = { 0x43,0x4f,0x57,0x4c,0x49,0x4e,0x4b,0x3a,0x20,0 };
-const i1 c02_s0028[] = { 0x6b,0x42,0x20,0x66,0x72,0x65,0x65,0x0a,0 };
-const i1 c02_s0029[] = { 0x53,0x79,0x6e,0x74,0x61,0x78,0x20,0x65,0x72,0x72,0x6f,0x72,0x0a,0 };
-
-// SyntaxError workspace at ws+640 length ws+0
-void f100(void) {
-
-	i8 v2380 = (i8)(intptr_t)c02_s0029;
-	f57(v2380);
-
-endsub:;
-}
-const i1 c02_s002a[] = { 0x41,0x64,0x64,0x69,0x6e,0x67,0x20,0x69,0x6e,0x70,0x75,0x74,0x20,0x66,0x69,0x6c,0x65,0x3a,0x20,0 };
-
-// AddInputFile workspace at ws+640 length ws+24
-void f101(i8 p2381 /* filename */) {
-	*(i8*)(intptr_t)(ws+640) = p2381; /*filename */
-
-	i8 v2382 = (i8)(intptr_t)c02_s002a;
-	f11(v2382);
-
-	i8 v2383 = (i8)(intptr_t)(ws+640);
-	i8 v2384 = *(i8*)(intptr_t)v2383;
-	f11(v2384);
-
-	f12();
-
-	i8 v2385 = (i8)(intptr_t)(ws+640);
-	i8 v2386 = *(i8*)(intptr_t)v2385;
-	i8 v2387;
-	f87(&v2387, v2386);
-	i8 v2388 = (i8)(intptr_t)(ws+648);
-	*(i8*)(intptr_t)v2388 = v2387;
-
-	i8 v2389 = (i8)(intptr_t)(ws+600);
-	i8 v2390 = *(i8*)(intptr_t)v2389;
-	i8 v2391 = (i8)+0;
-	if (v2390==v2391) goto c02_025a; else goto c02_025b;
-
-c02_025a:;
-
-	i8 v2392 = (i8)(intptr_t)(ws+648);
-	i8 v2393 = *(i8*)(intptr_t)v2392;
-	i8 v2394 = (i8)(intptr_t)(ws+600);
-	*(i8*)(intptr_t)v2394 = v2393;
-
-	i8 v2395 = (i8)(intptr_t)(ws+648);
-	i8 v2396 = *(i8*)(intptr_t)v2395;
-	i8 v2397 = (i8)(intptr_t)(ws+592);
-	*(i8*)(intptr_t)v2397 = v2396;
-
-	goto c02_0257;
-
-c02_025b:;
-
-	i8 v2398 = (i8)(intptr_t)(ws+648);
-	i8 v2399 = *(i8*)(intptr_t)v2398;
-	i8 v2400 = (i8)(intptr_t)(ws+592);
-	i8 v2401 = *(i8*)(intptr_t)v2400;
-	i8 v2402 = v2401+(+664);
-	*(i8*)(intptr_t)v2402 = v2399;
-
-	i8 v2403 = (i8)(intptr_t)(ws+648);
-	i8 v2404 = *(i8*)(intptr_t)v2403;
-	i8 v2405 = (i8)(intptr_t)(ws+592);
-	*(i8*)(intptr_t)v2405 = v2404;
-
-c02_0257:;
-
-	i8 v2406 = (i8)(intptr_t)(ws+648);
-	i8 v2407 = *(i8*)(intptr_t)v2406;
-	i2 v2408 = (i2)+0;
-	i8 v2409;
-	f83(&v2409, v2408, v2407);
-	i8 v2410 = *(i8*)(intptr_t)v2409;
-	i8 v2411 = (i8)(intptr_t)(ws+656);
-	*(i8*)(intptr_t)v2411 = v2410;
-
-	i8 v2412 = (i8)(intptr_t)(ws+656);
-	i8 v2413 = *(i8*)(intptr_t)v2412;
-	i8 v2414 = (i8)+0;
-	if (v2413==v2414) goto c02_0260; else goto c02_025f;
-
-c02_025f:;
-
-	i8 v2415 = (i8)(intptr_t)(ws+616);
-	i8 v2416 = *(i8*)(intptr_t)v2415;
-	i8 v2417 = (i8)+0;
-	if (v2416==v2417) goto c02_0264; else goto c02_0265;
-
-c02_0264:;
-
-	i8 v2418 = (i8)(intptr_t)(ws+656);
-	i8 v2419 = *(i8*)(intptr_t)v2418;
-	i8 v2420 = (i8)(intptr_t)(ws+616);
-	*(i8*)(intptr_t)v2420 = v2419;
-
-	goto c02_0261;
-
-c02_0265:;
-
-c02_0261:;
-
-	goto c02_025c;
-
-c02_0260:;
-
-c02_025c:;
-
-	i8 v2421 = (i8)(intptr_t)(ws+624);
-	i8 v2422 = *(i8*)(intptr_t)v2421;
-	i8 v2423 = (i8)+0;
-	if (v2422==v2423) goto c02_026a; else goto c02_0269;
-
-c02_0269:;
-
-	i8 v2424 = (i8)(intptr_t)(ws+624);
-	i8 v2425 = *(i8*)(intptr_t)v2424;
-	i8 v2426 = (i8)(intptr_t)(ws+656);
-	i8 v2427 = *(i8*)(intptr_t)v2426;
-	f82(v2427, v2425);
-
-	goto c02_0266;
-
-c02_026a:;
-
-c02_0266:;
-
-	i8 v2428 = (i8)(intptr_t)(ws+656);
-	i8 v2429 = *(i8*)(intptr_t)v2428;
-	i8 v2430 = (i8)(intptr_t)(ws+624);
-	*(i8*)(intptr_t)v2430 = v2429;
-
-endsub:;
-}
-const i1 c02_s002b[] = { 0x2d,0x6f,0 };
-const i1 c02_s002c[] = { 0x4e,0x6f,0x20,0x6d,0x61,0x69,0x6e,0x20,0x73,0x75,0x62,0x72,0x6f,0x75,0x74,0x69,0x6e,0x65,0x20,0x69,0x6e,0x20,0x61,0x6e,0x79,0x20,0x63,0x6f,0x6f,0x66,0x69,0x6c,0x65,0 };
-const i1 c02_s002d[] = { 0x4e,0x6f,0x20,0x6f,0x75,0x74,0x70,0x75,0x74,0x20,0x66,0x69,0x6c,0x65,0x6e,0x61,0x6d,0x65,0x20,0x73,0x70,0x65,0x63,0x69,0x66,0x69,0x65,0x64,0 };
-const i1 c02_s002e[] = { 0x41,0x6e,0x61,0x6c,0x79,0x73,0x69,0x6e,0x67,0x2e,0x2e,0x2e,0x0a,0 };
-const i1 c02_s002f[] = { 0x57,0x72,0x69,0x74,0x69,0x6e,0x67,0x20,0x6f,0x75,0x74,0x70,0x75,0x74,0x20,0x66,0x69,0x6c,0x65,0x2e,0x2e,0x2e,0x0a,0 };
-const i1 c02_s0030[] = { 0x64,0x6f,0x6e,0x65,0x3a,0x20,0 };
-const i1 c02_s0031[] = { 0x6b,0x42,0x20,0x66,0x72,0x65,0x65,0x0a,0 };
-
-// __main workspace at ws+0 length ws+640
+const i1 c02_s0021[] = { 0x2d,0x6f,0 };
+const i1 c02_s0022[] = { 0x4e,0x6f,0x20,0x6d,0x61,0x69,0x6e,0x20,0x73,0x75,0x62,0x72,0x6f,0x75,0x74,0x69,0x6e,0x65,0x20,0x69,0x6e,0x20,0x61,0x6e,0x79,0x20,0x63,0x6f,0x6f,0x66,0x69,0x6c,0x65,0 };
+const i1 c02_s0023[] = { 0x4e,0x6f,0x20,0x6f,0x75,0x74,0x70,0x75,0x74,0x20,0x66,0x69,0x6c,0x65,0x6e,0x61,0x6d,0x65,0x20,0x73,0x70,0x65,0x63,0x69,0x66,0x69,0x65,0x64,0 };
+const i1 c02_s0024[] = { 0x41,0x6e,0x61,0x6c,0x79,0x73,0x69,0x6e,0x67,0x2e,0x2e,0x2e,0x0a,0 };
+const i1 c02_s0025[] = { 0x57,0x72,0x69,0x74,0x69,0x6e,0x67,0x20,0x6f,0x75,0x74,0x70,0x75,0x74,0x20,0x66,0x69,0x6c,0x65,0x2e,0x2e,0x2e,0x0a,0 };
+const i1 c02_s0026[] = { 0x64,0x6f,0x6e,0x65,0x3a,0x20,0 };
+const i1 c02_s0027[] = { 0x6b,0x42,0x20,0x66,0x72,0x65,0x65,0x0a,0 };
+
+// __main workspace at ws+0 length ws+632
 void f3(void) {
 
 	
@@ -4369,25 +4047,8 @@ void f3(void) {
 
 
 
-	i8 v486 = (i8)(intptr_t)(ws+0);
-	i8 v487 = *(i8*)(intptr_t)v486;
-	i8 v488 = (i8)(intptr_t)(ws+24);
-	*(i8*)(intptr_t)v488 = v487;
 
-	i8 v489 = (i8)+0;
-	i8 v490 = (i8)(intptr_t)(ws+24);
-	i8 v491 = *(i8*)(intptr_t)v490;
-	*(i8*)(intptr_t)v491 = v489;
 
-	i8 v492 = (i8)(intptr_t)(ws+8);
-	i8 v493 = *(i8*)(intptr_t)v492;
-	i8 v494 = (i8)(intptr_t)(ws+0);
-	i8 v495 = *(i8*)(intptr_t)v494;
-	i8 v496 = v493-v495;
-	i8 v497 = (i8)(intptr_t)(ws+24);
-	i8 v498 = *(i8*)(intptr_t)v497;
-	i8 v499 = v498+(+8);
-	*(i8*)(intptr_t)v499 = v496;
 
 
 
@@ -4408,22 +4069,22 @@ void f3(void) {
 
 
 
+	i8 v792 = (i8)+0;
+	i8 v793 = (i8)(intptr_t)(ws+24);
+	*(i8*)(intptr_t)v793 = v792;
 
+	i8 v794 = (i8)+0;
+	i8 v795 = (i8)(intptr_t)(ws+32);
+	*(i8*)(intptr_t)v795 = v794;
 
+	i2 v796 = (i2)+1;
+	i8 v797 = (i8)(intptr_t)(ws+40);
+	*(i2*)(intptr_t)v797 = v796;
 
 
 
-	i8 v1138 = (i8)+0;
-	i8 v1139 = (i8)(intptr_t)(ws+32);
-	*(i8*)(intptr_t)v1139 = v1138;
 
-	i8 v1140 = (i8)+0;
-	i8 v1141 = (i8)(intptr_t)(ws+40);
-	*(i8*)(intptr_t)v1141 = v1140;
 
-	i2 v1142 = (i2)+1;
-	i8 v1143 = (i8)(intptr_t)(ws+48);
-	*(i2*)(intptr_t)v1143 = v1142;
 
 
 
@@ -4441,18 +4102,18 @@ void f3(void) {
 
 
 
+	i1 v997 = (i1)+1;
+	i8 v998 = (i8)(intptr_t)(ws+576);
+	*(i1*)(intptr_t)v998 = v997;
 
+	i1 v999 = (i1)+0;
+	i8 v1000 = (i8)(intptr_t)(ws+577);
+	*(i1*)(intptr_t)v1000 = v999;
 
 
 
 
-	i1 v1338 = (i1)+1;
-	i8 v1339 = (i8)(intptr_t)(ws+584);
-	*(i1*)(intptr_t)v1339 = v1338;
 
-	i1 v1340 = (i1)+0;
-	i8 v1341 = (i8)(intptr_t)(ws+585);
-	*(i1*)(intptr_t)v1341 = v1340;
 
 
 
@@ -4465,191 +4126,186 @@ void f3(void) {
 
 
 
+	i8 v2019 = (i8)(intptr_t)c02_s001d;
+	f11(v2019);
 
+	i8 v2020;
+	f35(&v2020);
+	i1 v2021 = (i1)+10;
+	i8 v2022 = ((i8)v2020)>>v2021;
+	i2 v2023 = v2022;
+	f16(v2023);
 
+	i8 v2024 = (i8)(intptr_t)c02_s001e;
+	f11(v2024);
 
+	i8 v2025 = (i8)+0;
+	i8 v2026 = (i8)(intptr_t)(ws+584);
+	*(i8*)(intptr_t)v2026 = v2025;
 
+	i8 v2027 = (i8)+0;
+	i8 v2028 = (i8)(intptr_t)(ws+592);
+	*(i8*)(intptr_t)v2028 = v2027;
 
-	i8 v2364 = (i8)(intptr_t)c02_s0027;
-	f11(v2364);
-
-	i8 v2365;
-	f36(&v2365);
-	i1 v2366 = (i1)+10;
-	i8 v2367 = ((i8)v2365)>>v2366;
-	i2 v2368 = v2367;
-	f16(v2368);
-
-	i8 v2369 = (i8)(intptr_t)c02_s0028;
-	f11(v2369);
-
-	i8 v2370 = (i8)+0;
-	i8 v2371 = (i8)(intptr_t)(ws+592);
-	*(i8*)(intptr_t)v2371 = v2370;
-
-	i8 v2372 = (i8)+0;
-	i8 v2373 = (i8)(intptr_t)(ws+600);
-	*(i8*)(intptr_t)v2373 = v2372;
-
-	i8 v2374 = (i8)+0;
-	i8 v2375 = (i8)(intptr_t)(ws+608);
-	*(i8*)(intptr_t)v2375 = v2374;
-
-	i8 v2376 = (i8)+0;
-	i8 v2377 = (i8)(intptr_t)(ws+616);
-	*(i8*)(intptr_t)v2377 = v2376;
-
-	i8 v2378 = (i8)+0;
-	i8 v2379 = (i8)(intptr_t)(ws+624);
-	*(i8*)(intptr_t)v2379 = v2378;
+	i8 v2029 = (i8)+0;
+	i8 v2030 = (i8)(intptr_t)(ws+600);
+	*(i8*)(intptr_t)v2030 = v2029;
+
+	i8 v2031 = (i8)+0;
+	i8 v2032 = (i8)(intptr_t)(ws+608);
+	*(i8*)(intptr_t)v2032 = v2031;
+
+	i8 v2033 = (i8)+0;
+	i8 v2034 = (i8)(intptr_t)(ws+616);
+	*(i8*)(intptr_t)v2034 = v2033;
 
 
 
 	f23();
 
-c02_026b:;
+c02_021a:;
 
-	i8 v2431;
-	f24(&v2431);
-	i8 v2432 = (i8)(intptr_t)(ws+632);
-	*(i8*)(intptr_t)v2432 = v2431;
+	i8 v2086;
+	f24(&v2086);
+	i8 v2087 = (i8)(intptr_t)(ws+624);
+	*(i8*)(intptr_t)v2087 = v2086;
 
-	i8 v2433 = (i8)(intptr_t)(ws+632);
-	i8 v2434 = *(i8*)(intptr_t)v2433;
-	i8 v2435 = (i8)+0;
-	if (v2434==v2435) goto c02_0270; else goto c02_0271;
+	i8 v2088 = (i8)(intptr_t)(ws+624);
+	i8 v2089 = *(i8*)(intptr_t)v2088;
+	i8 v2090 = (i8)+0;
+	if (v2089==v2090) goto c02_021f; else goto c02_0220;
 
-c02_0270:;
+c02_021f:;
 
-	goto c02_026c;
+	goto c02_021b;
 
-	goto c02_026d;
+	goto c02_021c;
 
-c02_0271:;
+c02_0220:;
 
-c02_026d:;
+c02_021c:;
 
-	i8 v2436 = (i8)(intptr_t)(ws+632);
-	i8 v2437 = *(i8*)(intptr_t)v2436;
-	i8 v2438 = (i8)(intptr_t)c02_s002b;
-	i1 v2439;
-	f27(&v2439, v2438, v2437);
-	i1 v2440 = (i1)+0;
-	if (v2439==v2440) goto c02_0275; else goto c02_0276;
+	i8 v2091 = (i8)(intptr_t)(ws+624);
+	i8 v2092 = *(i8*)(intptr_t)v2091;
+	i8 v2093 = (i8)(intptr_t)c02_s0021;
+	i1 v2094;
+	f27(&v2094, v2093, v2092);
+	i1 v2095 = (i1)+0;
+	if (v2094==v2095) goto c02_0224; else goto c02_0225;
 
-c02_0275:;
+c02_0224:;
 
-	i8 v2441;
-	f24(&v2441);
-	i8 v2442 = (i8)(intptr_t)(ws+608);
-	*(i8*)(intptr_t)v2442 = v2441;
+	i8 v2096;
+	f24(&v2096);
+	i8 v2097 = (i8)(intptr_t)(ws+600);
+	*(i8*)(intptr_t)v2097 = v2096;
 
-	goto c02_0272;
+	goto c02_0221;
 
-c02_0276:;
+c02_0225:;
 
-	i8 v2443 = (i8)(intptr_t)(ws+632);
-	i8 v2444 = *(i8*)(intptr_t)v2443;
-	i1 v2445 = *(i1*)(intptr_t)v2444;
-	i1 v2446 = (i1)+45;
-	if (v2445==v2446) goto c02_0279; else goto c02_027a;
+	i8 v2098 = (i8)(intptr_t)(ws+624);
+	i8 v2099 = *(i8*)(intptr_t)v2098;
+	i1 v2100 = *(i1*)(intptr_t)v2099;
+	i1 v2101 = (i1)+45;
+	if (v2100==v2101) goto c02_0228; else goto c02_0229;
 
-c02_0279:;
+c02_0228:;
 
-	f100();
+	f98();
 
-	goto c02_0272;
+	goto c02_0221;
 
-c02_027a:;
+c02_0229:;
 
-	i8 v2447 = (i8)(intptr_t)(ws+632);
-	i8 v2448 = *(i8*)(intptr_t)v2447;
-	f101(v2448);
+	i8 v2102 = (i8)(intptr_t)(ws+624);
+	i8 v2103 = *(i8*)(intptr_t)v2102;
+	f99(v2103);
 
-c02_0272:;
+c02_0221:;
 
-	goto c02_026b;
+	goto c02_021a;
 
-c02_026c:;
+c02_021b:;
 
-	i8 v2449 = (i8)(intptr_t)(ws+616);
-	i8 v2450 = *(i8*)(intptr_t)v2449;
-	i8 v2451 = (i8)+0;
-	if (v2450==v2451) goto c02_027e; else goto c02_027f;
+	i8 v2104 = (i8)(intptr_t)(ws+608);
+	i8 v2105 = *(i8*)(intptr_t)v2104;
+	i8 v2106 = (i8)+0;
+	if (v2105==v2106) goto c02_022d; else goto c02_022e;
 
-c02_027e:;
+c02_022d:;
 
-	i8 v2452 = (i8)(intptr_t)c02_s002c;
-	f57(v2452);
+	i8 v2107 = (i8)(intptr_t)c02_s0022;
+	f55(v2107);
 
-	goto c02_027b;
+	goto c02_022a;
 
-c02_027f:;
+c02_022e:;
 
-c02_027b:;
+c02_022a:;
 
-	i8 v2453 = (i8)(intptr_t)(ws+608);
-	i8 v2454 = *(i8*)(intptr_t)v2453;
-	i8 v2455 = (i8)+0;
-	if (v2454==v2455) goto c02_0283; else goto c02_0284;
+	i8 v2108 = (i8)(intptr_t)(ws+600);
+	i8 v2109 = *(i8*)(intptr_t)v2108;
+	i8 v2110 = (i8)+0;
+	if (v2109==v2110) goto c02_0232; else goto c02_0233;
 
-c02_0283:;
+c02_0232:;
 
-	i8 v2456 = (i8)(intptr_t)c02_s002d;
-	f57(v2456);
+	i8 v2111 = (i8)(intptr_t)c02_s0023;
+	f55(v2111);
 
-	goto c02_0280;
+	goto c02_022f;
 
-c02_0284:;
+c02_0233:;
 
-c02_0280:;
+c02_022f:;
 
-	i8 v2457 = (i8)(intptr_t)c02_s002e;
-	f11(v2457);
+	i8 v2112 = (i8)(intptr_t)c02_s0024;
+	f11(v2112);
 
-	f97();
+	f95();
 
-	i8 v2458 = (i8)(intptr_t)(ws+616);
-	i8 v2459 = *(i8*)(intptr_t)v2458;
-	f98(v2459);
+	i8 v2113 = (i8)(intptr_t)(ws+608);
+	i8 v2114 = *(i8*)(intptr_t)v2113;
+	f96(v2114);
 
-	i8 v2460 = (i8)(intptr_t)(ws+608);
-	i8 v2461 = *(i8*)(intptr_t)v2460;
-	f68(v2461);
+	i8 v2115 = (i8)(intptr_t)(ws+600);
+	i8 v2116 = *(i8*)(intptr_t)v2115;
+	f66(v2116);
 
-	i8 v2462 = (i8)(intptr_t)c02_s002f;
-	f11(v2462);
+	i8 v2117 = (i8)(intptr_t)c02_s0025;
+	f11(v2117);
 
-	i8 v2463 = (i8)(intptr_t)(ws+600);
-	i8 v2464 = *(i8*)(intptr_t)v2463;
-	f74(v2464);
+	i8 v2118 = (i8)(intptr_t)(ws+592);
+	i8 v2119 = *(i8*)(intptr_t)v2118;
+	f72(v2119);
 
-	i8 v2465 = (i8)(intptr_t)(ws+600);
-	i8 v2466 = *(i8*)(intptr_t)v2465;
-	f96(v2466);
+	i8 v2120 = (i8)(intptr_t)(ws+592);
+	i8 v2121 = *(i8*)(intptr_t)v2120;
+	f94(v2121);
 
-	i8 v2467 = (i8)(intptr_t)(ws+600);
-	i8 v2468 = *(i8*)(intptr_t)v2467;
-	f75(v2468);
+	i8 v2122 = (i8)(intptr_t)(ws+592);
+	i8 v2123 = *(i8*)(intptr_t)v2122;
+	f73(v2123);
 
-	f69();
+	f67();
 
-	i8 v2469 = (i8)(intptr_t)c02_s0030;
-	f11(v2469);
+	i8 v2124 = (i8)(intptr_t)c02_s0026;
+	f11(v2124);
 
-	i8 v2470;
-	f36(&v2470);
-	i1 v2471 = (i1)+10;
-	i8 v2472 = ((i8)v2470)>>v2471;
-	i2 v2473 = v2472;
-	f16(v2473);
+	i8 v2125;
+	f35(&v2125);
+	i1 v2126 = (i1)+10;
+	i8 v2127 = ((i8)v2125)>>v2126;
+	i2 v2128 = v2127;
+	f16(v2128);
 
-	i8 v2474 = (i8)(intptr_t)c02_s0031;
-	f11(v2474);
+	i8 v2129 = (i8)(intptr_t)c02_s0027;
+	f11(v2129);
 
 endsub:;
 }
 void cmain(void) {
 	f3();
 }
-                                                                                                                                                                                                                                                                                                                                                                  
+                                                                                                                                         

--- a/rt/bbct/argv.coh
+++ b/rt/bbct/argv.coh
@@ -8,7 +8,7 @@ end sub;
 sub ArgvNext(): (arg: [uint8])
 	# No more arguments?
 
-	if argv_pointer == (0 as [uint8]) then
+	if (argv_pointer == (0 as [uint8])) or ([argv_pointer] == 0) then
 		arg := 0 as [uint8];
 		return;
 	end if;

--- a/rt/bbct/cowgol.coh
+++ b/rt/bbct/cowgol.coh
@@ -47,6 +47,7 @@ _ReadArguments();
 
 sub ExitWithError()
 	@asm "brk";
+	@asm ".byte 0, 65, 66, 69, 78, 68, 0";
 end sub;
 
 sub AlignUp(in: intptr): (out: intptr)

--- a/rt/bbct/file.coh
+++ b/rt/bbct/file.coh
@@ -18,6 +18,7 @@ const FCB_BUFFER_SIZE := 256;
 record FCB
 	gbpb: FCB_GBPB;
 	block: uint16;
+    blocks: uint16;
 	bufferptr: uint16; # byte just read
 	dirty: uint8;
 	mode: uint8;
@@ -51,6 +52,19 @@ sub fcb_i_init(fcb: [FCB], filename: [uint8], mode: uint8): (errno: uint8)
     if channel != 0 then
         errno := 0;
     end if;
+    
+    # Fetch the size of the file.
+    #
+	# Nasty hack to get 32 bits in zero page.
+	var ptr1: [uint8];
+	var ptr2: [uint8];
+
+	@asm "lda #2"; # read EXT#
+	@asm "ldx #<", ptr1;
+	@asm "ldy", channel;
+	@asm "jsr $ffda"; # OSARGS
+
+    fcb.blocks := [((@alias &ptr1)+1) as [uint16]];
 end sub;
 
 sub fcb_i_gbpb(fcb: [FCB], a: uint8)
@@ -67,14 +81,20 @@ end sub;
 
 sub fcb_i_blockin(fcb: [FCB])
 	MemSet(&fcb.buffer[0], 0, FCB_BUFFER_SIZE);
-	fcb_i_gbpb(fcb, 3); # read block with pointer
-	fcb.dirty := 0;
+    if fcb.block < fcb.blocks then
+        fcb_i_gbpb(fcb, 3); # read block with pointer
+        fcb.dirty := 0;
+    end if;
 end sub;
 
 sub fcb_i_blockout(fcb: [FCB])
 	if fcb.dirty != 0 then
 		fcb_i_gbpb(fcb, 1); # write block with pointer
 		fcb.dirty := 0;
+
+        if fcb.blocks < (fcb.block+1) then
+            fcb.blocks := fcb.block+1;
+        end if;
 	end if;
 end sub;
 
@@ -124,20 +144,7 @@ sub FCBPos(fcb: [FCB]): (pos: uint32)
 end sub;
 
 sub FCBExt(fcb: [FCB]): (len: uint32)
-	fcb_i_blockout(fcb);
-
-	# Nasty hack to get 32 bytes in zero page.
-	var ptr1: [uint8];
-	var ptr2: [uint8];
-
-	var channel := fcb.gbpb.channel;
-
-	@asm "lda #2"; # read EXT#
-	@asm "ldx #<", ptr1;
-	@asm "ldy", channel;
-	@asm "jsr $ffda"; # OSARGS
-
-	len := [@alias &ptr1 as [uint32]];
+    len := (fcb.blocks as uint32)<<8;
 end sub;
 
 sub fcb_i_nextchar(fcb: [FCB])

--- a/rt/bbct/file.coh
+++ b/rt/bbct/file.coh
@@ -18,7 +18,6 @@ const FCB_BUFFER_SIZE := 256;
 record FCB
 	gbpb: FCB_GBPB;
 	block: uint16;
-    blocks: uint16;
 	bufferptr: uint16; # byte just read
 	dirty: uint8;
 	mode: uint8;
@@ -52,19 +51,6 @@ sub fcb_i_init(fcb: [FCB], filename: [uint8], mode: uint8): (errno: uint8)
     if channel != 0 then
         errno := 0;
     end if;
-    
-    # Fetch the size of the file.
-    #
-	# Nasty hack to get 32 bits in zero page.
-	var ptr1: [uint8];
-	var ptr2: [uint8];
-
-	@asm "lda #2"; # read EXT#
-	@asm "ldx #<", ptr1;
-	@asm "ldy", channel;
-	@asm "jsr $ffda"; # OSARGS
-
-    fcb.blocks := [((@alias &ptr1)+1) as [uint16]];
 end sub;
 
 sub fcb_i_gbpb(fcb: [FCB], a: uint8)
@@ -81,20 +67,14 @@ end sub;
 
 sub fcb_i_blockin(fcb: [FCB])
 	MemSet(&fcb.buffer[0], 0, FCB_BUFFER_SIZE);
-    if fcb.block < fcb.blocks then
-        fcb_i_gbpb(fcb, 3); # read block with pointer
-        fcb.dirty := 0;
-    end if;
+	fcb_i_gbpb(fcb, 3); # read block with pointer
+	fcb.dirty := 0;
 end sub;
 
 sub fcb_i_blockout(fcb: [FCB])
 	if fcb.dirty != 0 then
 		fcb_i_gbpb(fcb, 1); # write block with pointer
 		fcb.dirty := 0;
-
-        if fcb.blocks < (fcb.block+1) then
-            fcb.blocks := fcb.block+1;
-        end if;
 	end if;
 end sub;
 
@@ -102,7 +82,9 @@ sub fcb_i_changeblock(fcb: [FCB], newblock: uint16)
 	if newblock != fcb.block then
 		fcb_i_blockout(fcb);
 		fcb.block := newblock;
-		fcb_i_blockin(fcb);
+        if newblock != 0xffff then
+            fcb_i_blockin(fcb);
+        end if;
 	end if;
 end sub;
 
@@ -144,7 +126,20 @@ sub FCBPos(fcb: [FCB]): (pos: uint32)
 end sub;
 
 sub FCBExt(fcb: [FCB]): (len: uint32)
-    len := (fcb.blocks as uint32)<<8;
+	fcb_i_blockout(fcb);
+
+	# Nasty hack to get 32 bytes in zero page.
+	var ptr1: [uint8];
+	var ptr2: [uint8];
+
+	var channel := fcb.gbpb.channel;
+
+	@asm "lda #2"; # read EXT#
+	@asm "ldx #<", ptr1;
+	@asm "ldy", channel;
+	@asm "jsr $ffda"; # OSARGS
+
+	len := [@alias &ptr1 as [uint32]];
 end sub;
 
 sub fcb_i_nextchar(fcb: [FCB])

--- a/rt/cgen/malloc.coh
+++ b/rt/cgen/malloc.coh
@@ -1,0 +1,23 @@
+# This file overrides the standard allocator with a platform-specific one
+# which calls into the standard C allocator. This makes ncgen and nncgen
+# programs *much* easier to debug using tools like valgrind.
+
+sub Alloc(length: intptr): (block: [uint8])
+	@asm block, "=(i8)calloc(1, (size_t)", length, ");";
+end sub;
+
+sub Free(block: [uint8])
+	@asm "free((void*)", block, ");";
+end sub;
+
+sub StrDup(s: [uint8]): (sout: [uint8])
+	@asm sout, "=(i8)strdup((const char*)", s, ");";
+end sub;
+
+sub CheckMemoryChain()
+end sub;
+
+sub GetFreeMemory(): (i: intptr)
+	i := 0;
+end sub;
+

--- a/rt/malloc.coh
+++ b/rt/malloc.coh
@@ -186,8 +186,10 @@ sub AddFreeBlock(start: [uint8], length: intptr)
 end sub;
 
 sub Free(start: [uint8])
-	var usedblock := @prev (start as [MallocUsedBlock]);
-	AddFreeBlock(usedblock as [uint8], usedblock.size);
+	if start != (0 as [uint8]) then
+		var usedblock := @prev (start as [MallocUsedBlock]);
+		AddFreeBlock(usedblock as [uint8], usedblock.size);
+	end if;
 end sub;
 
 sub GetFreeMemory(): (bytes: intptr)

--- a/rt/malloc.coh
+++ b/rt/malloc.coh
@@ -60,6 +60,9 @@ end sub;
 
 sub Alloc(length: intptr): (block: [uint8])
 	var totallength := AlignUp(length + @bytesof MallocUsedBlock);
+	if totallength < @bytesof MallocFreeBlock then
+		totallength := @bytesof MallocFreeBlock;
+	end if;
 
 	var prev: [MallocFreeBlock] := 0 as [MallocFreeBlock];
 	var p := freeList;

--- a/scripts/quiet
+++ b/scripts/quiet
@@ -3,7 +3,7 @@ stdout=/tmp/$$.stdout
 stderr=/tmp/$$.stderr
 trap "rm -f $stdout $stderr" EXIT
 
-timeout 5s "$@" >$stdout 2>$stderr
+"$@" >$stdout 2>$stderr
 if [ $? = 0 ]; then
 	exit 0
 else

--- a/src/cowcom/allocator.coh
+++ b/src/cowcom/allocator.coh
@@ -13,7 +13,7 @@ end sub;
 
 sub StrDupArrayed(s: string, i: Size): (news: string)
 	var len := StrLen(s);
-	news := Alloc(len + 2);
+	news := Alloc(len + 3);
 	var p := news;
 	MemCopy(s, len, p);
 	p := p + len;

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -159,6 +159,7 @@
     const OC_BPL := 48;
     const OC_ASL := 49;
     const OC_LSR := 50;
+    const OC_AJSR := 51;
 
     sub E_oc(oc: uint8)
         var ocs: string[] := {
@@ -168,7 +169,7 @@
             "clc", "sec", "rts", "jsr", "jmp", "phx", "phy", "plx",
             "ply", "tsx", "txs", "rol", "stz", "cmp", "cpx", "cpy",
             "inx", "iny", "dex", "dey", "inc", "dec", "bra", "bmi",
-            "bpl", "asl", "lsr"
+            "bpl", "asl", "lsr", "ajsr"
         };
 
         E_tab();
@@ -412,7 +413,7 @@
 
     sub E_call(subr: [Subroutine])
         R_flushall();
-        E_oc(OC_JSR);
+        E_oc(OC_AJSR);
         E_subref(subr);
         E_nl();
     end sub;
@@ -1008,25 +1009,18 @@ gen STARTSUB()
         if popped == 0 then
             $ifdef ARCH_65C02
                 E_plx();
-                E_ply();
-                E_inx();
-                E("\tbne *+3\n");
-                E_iny();
             $else
                 E_pla();
                 E_tax();
-                E_pla();
-                E_tay();
-                E_inx();
-                E("\tbne *+3\n");
-                E_iny();
             $endif
+            E_pla();
+            E_inx();
 
             E_stx();
             E_labelref(current_subr.arch.rts_label);
             E_nl();
 
-            E_sty();
+            E_sta();
             E_labelref(current_subr.arch.rts_label);
             E_plusone();
             E_nl();

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -71,9 +71,18 @@
         end if;
     end sub;
 
+    sub is_zp(sym: [Symbol]): (result: uint8)
+        if (sym.vardata.type == int8_type) or (sym.vardata.type == uint8_type)
+                or (IsPtr(sym.vardata.type) != 0) then
+            result := 1;
+        else
+            result := 0;
+        end if;
+    end sub;
+
     sub ArchInitVariable(symbol: [Symbol])
         var wsid: uint8 := VARMEM_WS;
-        if IsPtr(symbol.vardata.type) != 0 then
+        if is_zp(symbol) != 0 then
             wsid := PTRMEM_WS;
         end if;
 
@@ -207,7 +216,7 @@
             E_i16(off as int16);
         else
             var wsid: uint8 := VARMEM_WS;
-            if IsPtr(sym.vardata.type) != 0 then
+            if is_zp(sym) != 0 then
                 wsid := PTRMEM_WS;
             end if;
             E_wsref(sym.vardata.subr.id, wsid, sym.vardata.offset + off);
@@ -563,10 +572,6 @@
     end sub;
 
     sub ArchEndInstruction()
-    end sub;
-
-    sub is_ptr(sym: [Symbol]): (result: uint8)
-        result := IsPtr(sym.vardata.type);
     end sub;
 %}
 
@@ -947,11 +952,11 @@ gen const := CONSTANT():c                        { var op := PushConstOp($c.valu
 gen address := ADDRESS():a                       { var op := PushAddressOp($a.sym, $a.off); }
 gen mem1 := LOAD1(ADDRESS():a)                   { var op := PushSymOp($a.sym, $a.off); }
 gen mem2 := LOAD2(ADDRESS():a)                   { var op := PushSymOp($a.sym, $a.off); }
-gen mem2p := LOAD2(ADDRESS(sym is ptr):a)        { var op := PushSymOp($a.sym, $a.off); }
+gen mem2p := LOAD2(ADDRESS(sym is zp):a)         { var op := PushSymOp($a.sym, $a.off); }
 gen mem4 := LOAD4(ADDRESS():a)                   { var op := PushSymOp($a.sym, $a.off); }
-gen memi1 := LOAD1(LOAD2(ADDRESS(sym is ptr):a)) { var op := PushSymIOp($a.sym, $a.off); }
-gen memi2 := LOAD2(LOAD2(ADDRESS(sym is ptr):a)) { var op := PushSymIOp($a.sym, $a.off); }
-gen memi4 := LOAD4(LOAD2(ADDRESS(sym is ptr):a)) { var op := PushSymIOp($a.sym, $a.off); }
+gen memi1 := LOAD1(LOAD2(ADDRESS(sym is zp):a))  { var op := PushSymIOp($a.sym, $a.off); }
+gen memi2 := LOAD2(LOAD2(ADDRESS(sym is zp):a))  { var op := PushSymIOp($a.sym, $a.off); }
+gen memi4 := LOAD4(LOAD2(ADDRESS(sym is zp):a))  { var op := PushSymIOp($a.sym, $a.off); }
 gen stacki1 := LOAD1(p16)                        { var op := PeekOp(); op.mode := MODE_STACKI; }
 gen stacki2 := LOAD2(p16)                        { var op := PeekOp(); op.mode := MODE_STACKI; }
 gen stacki4 := LOAD4(p16)                        { var op := PeekOp(); op.mode := MODE_STACKI; }
@@ -1298,7 +1303,7 @@ gen a|x|y := LOAD1(ADDRESS():a)
     end if;
 }
 
-gen a := LOAD1(LOAD2(ADDRESS(sym is ptr):a)) uses y
+gen a := LOAD1(LOAD2(ADDRESS(sym is zp):a)) uses y
 {
     $ifndef ARCH_65C02
         E_loadconst(REG_Y, 0);

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -265,6 +265,30 @@
     sub E_txs() E_ocnl(OC_TXS); end sub;
     sub E_not() R_flush(REG_A); E_oc(OC_EOR); E("#255\n"); end sub;
 
+    # Note: big endian on stack!
+    sub E_phax()
+        $ifdef ARCH_65C02
+            E_pha();
+            E_phx();
+        $else
+            E_pha();
+            E_txa();
+            E_pha();
+        $endif
+    end sub;
+
+    # Note: big endian on stack!
+    sub E_plax()
+        $ifdef ARCH_65C02
+            E_plx();
+            E_pla();
+        $else
+            E_pla();
+            E_tax();
+            E_pla();
+        $endif
+    end sub;
+
     sub E_ld(reg: RegId)
         R_flush(reg);
         case reg is
@@ -631,7 +655,7 @@ gen JUMP():j
         next: [Operand];
     end record;
 
-    const OPERAND_STACK_SIZE := 32;
+    const OPERAND_STACK_SIZE := 16;
     var opstack: [Operand][OPERAND_STACK_SIZE];
     var first_operand: [Operand] := 0 as [Operand];
     var opsp: uint8 := 0;
@@ -692,7 +716,8 @@ gen JUMP():j
         op.off := off;
     end sub;
         
-    sub FakeStackPush(reg: RegId, width: uint8): (sid: uint16)
+    sub PushStackOp(reg: RegId, width: uint8): (op: [Operand])
+        var sid: uint16;
         if (reg & REG_P16) != 0 then
             sid := (PTRSTACK_WS<<8) | (ptrsp as uint16);
             ptrsp := ptrsp + width;
@@ -706,36 +731,16 @@ gen JUMP():j
                 current_subr.workspace[VARSTACK_WS] := varsp as Size;
             end if;
         end if;
-    end sub;
 
-    sub PushStackOp(reg: RegId, width: uint8): (op: [Operand])
         op := PushOp();
         op.mode := MODE_STACK;
-        op.stk.sid := FakeStackPush(reg, width);
+        op.stk.sid := sid;
         op.stk.wsid := (op.stk.sid >> 8) as uint8;
         op.stk.width := width;
     end sub;
 
     sub PushV32(): (op: [Operand])
         op := PushStackOp(REG_V32, 4);
-    end sub;
-        
-    sub FakeStackPop(reg: RegId, width: uint8): (sid: uint16)
-        if (reg & REG_P16) != 0 then
-            ptrsp := ptrsp - width;
-            sid := (PTRSTACK_WS<<8) | (ptrsp as uint16);
-        else
-            varsp := varsp - width;
-            sid := (VARSTACK_WS<<8) | (varsp as uint16);
-        end if;
-    end sub;
-
-    sub FakeStackPeek(reg: RegId, width: uint8): (sid: uint16)
-        if (reg & REG_P16) != 0 then
-            sid := (PTRSTACK_WS<<8) | ((ptrsp-width) as uint16);
-        else
-            sid := (VARSTACK_WS<<8) | ((varsp-width) as uint16);
-        end if;
     end sub;
 
     sub PopOp(): (op: [Operand])
@@ -817,6 +822,7 @@ gen JUMP():j
 
     sub DoParamDirect(operand: [Operand], oc: uint8, offset: uint8)
         var m := operand.mode;
+
         if (m == MODE_STACKI) or (m == MODE_SYMBOLI) then
             $ifdef ARCH_65C02
                 if offset != 0 then
@@ -898,14 +904,7 @@ gen JUMP():j
                     when REG_A:  E_pla(); return;
 
                     when REG_XA:
-                        $ifdef ARCH_65C02
-                            E_plx();
-                            E_pla();
-                        $else
-                            E_pla();
-                            E_tax();
-                            E_pla();
-                        $endif
+                        E_plax();
                         return;
                 end case;
 
@@ -922,14 +921,7 @@ gen JUMP():j
             when REG_XA:
                 case dest is
                     when 0:
-                        $ifdef ARCH_65C02
-                            E_pha();
-                            E_phx();
-                        $else
-                            E_pha();
-                            E_txa();
-                            E_pha();
-                        $endif
+                        E_phax();
                         return;
                 end case;
         end case;
@@ -942,34 +934,7 @@ gen JUMP():j
         EndError();
     end sub;
 
-    var cases: uint8 := 0;
     sub ArchEndGroup()
-        # The opstack should be empty at the end of every statement. If it's
-        # not, then that means we've leaked an op somewhere. (Unless we're in
-        # a case...)
-        #if cases == 0 then
-        #    if opsp != 0 then
-        #        StartError();
-        #        print("opstack has ");
-        #        print_i8(opsp);
-        #        print(" left after statement");
-        #        EndError();
-        #    end if;
-        #    if varsp != 0 then
-        #        StartError();
-        #        print("varstack has ");
-        #        print_i8(varsp);
-        #        print(" left after statement");
-        #        EndError();
-        #    end if;
-        #    if ptrsp != 0 then
-        #        StartError();
-        #        print("ptrstack has ");
-        #        print_i8(ptrsp);
-        #        print(" left after statement");
-        #        EndError();
-        #    end if;
-        #end if;
         if inasm == 0 then
             E_nl();
         end if;
@@ -990,6 +955,12 @@ gen memi4 := LOAD4(LOAD2(ADDRESS(sym is ptr):a)) { var op := PushSymIOp($a.sym, 
 gen stacki1 := LOAD1(p16)                        { var op := PeekOp(); op.mode := MODE_STACKI; }
 gen stacki2 := LOAD2(p16)                        { var op := PeekOp(); op.mode := MODE_STACKI; }
 gen stacki4 := LOAD4(p16)                        { var op := PeekOp(); op.mode := MODE_STACKI; }
+
+// ==========================================================================
+//                        STRICTLY NECESSARY RULES
+// ==========================================================================
+
+// These rules are required for the code generator to work at all.
 
 // --- Subroutines ----------------------------------------------------------
 
@@ -1056,7 +1027,7 @@ gen STARTSUB():s
                     PopReturnAddress();
                     E_pla();
                 end if;
-                E_st(REG_A);
+                E_sta();
                 E_symref(param, 0);
                 E_nl();
                 RegCacheLeavesValue(REG_A, param, 0);
@@ -1073,11 +1044,11 @@ gen STARTSUB():s
                         E_pla();
                     $endif
                 end if;
-                E_st(REG_A);
+                E_sta();
                 E_symref(param, 0);
                 E_nl();
 
-                E_st(REG_X);
+                E_stx();
                 E_symref(param, 1);
                 E_nl();
 
@@ -1090,7 +1061,7 @@ gen STARTSUB():s
                 var lid := E_new_label();
                 E_pla();
                 
-                E_st(REG_A);
+                E_sta();
                 E_symref(param, -252);
                 E_y_nl();
 
@@ -1120,7 +1091,7 @@ gen ENDSUB():s
             when 1:
                 cache := RegCacheFindValue(param, 0) & REG_A;
                 if cache == 0 then
-                    E_ld(REG_A);
+                    E_lda();
                     E_symref(param, 0);
                     E_nl();
                 end if;
@@ -1131,23 +1102,23 @@ gen ENDSUB():s
             when 2:
                 if i != (count-1) then
                     # Warning: big endian!
-                    E_ld(REG_A);
+                    E_lda();
                     E_symref(param, 0);
                     E_nl();
                     E_pha();
 
-                    E_ld(REG_A);
+                    E_lda();
                     E_symref(param, 1);
                     E_nl();
                     E_pha();
                 else
                     cache := RegCacheFindValue(param, 0) & REG_XA;
                     if cache == 0 then
-                        E_ld(REG_A);
+                        E_lda();
                         E_symref(param, 0);
                         E_nl();
 
-                        E_ld(REG_X);
+                        E_ldx();
                         E_symref(param, 1);
                         E_nl();
                     end if;
@@ -1160,7 +1131,7 @@ gen ENDSUB():s
                 E_loadconst(REG_Y, -4);
                 var lid := E_new_label();
 
-                E_ld(REG_A);
+                E_lda();
                 E_symref(param, -252);
                 E_y_nl();
                 E_pha();
@@ -1243,14 +1214,7 @@ gen param := ARG2(param, xa, remaining==0);
 gen param := ARG2(param, xa, remaining!=0)
 {
     # big endian on stack
-    $ifdef ARCH_65C02
-        E_pha();
-        E_phx();
-    $else
-        E_pha();
-        E_txa();
-        E_pha();
-    $endif
+    E_phax();
 }
 
 gen param := ARG4(param, in4s) uses y|a
@@ -1323,44 +1287,6 @@ gen STORE1(a|x|y:lhs, ADDRESS():a)
     RegCacheLeavesValue($lhs, $a.sym, $a.off);
 }
 
-$ifdef ARCH_65C02
-    gen STORE1(CONSTANT(value==0), ADDRESS():a)
-    {
-        E_stz();
-        E_symref($a.sym, $a.off);
-        E_nl();
-    }
-$endif
-
-gen STORE1(a, ADD2(ptrs, CONSTANT(value>=0, value<=255):c)) uses y
-{
-    var dest := PopAndDerefOp();
-    E_loadconst(REG_Y, $c.value as uint8);
-    DoParamIndirect_sta(dest);
-}
-
-gen STORE1(a, ADD2(ADDRESS():a, CAST12(x, sext==0)))
-{
-    E_sta();
-    E_symref($a.sym, $a.off);
-    E_x_nl();
-}
-
-$ifdef ARCH_65C02
-    gen STORE1(CONSTANT(value==0), ADD2(ADDRESS():a, CAST12(x, sext==0)))
-    {
-        E_stz();
-        E_symref($a.sym, $a.off);
-        E_x_nl();
-    }
-$endif
-
-gen STORE1(a, ADD2(ptrs, CAST12(y, sext==0)))
-{
-    var dest := PopAndDerefOp();
-    DoParamIndirect_sta(dest);
-}
-
 gen a|x|y := LOAD1(ADDRESS():a)
 {
     var cache := RegCacheFindValue($a.sym, $a.off) & $$;
@@ -1389,26 +1315,6 @@ gen a := LOAD1(LOAD2(ADDRESS(sym is ptr):a)) uses y
     $endif
 }
 
-gen a := LOAD1(ADD2(ptrs, CONSTANT(value>=0, value<=255):c)) uses y
-{
-    var src := PopAndDerefOp();
-    E_loadconst(REG_Y, $c.value as uint8);
-    DoParamIndirect_lda(src);
-}
-
-gen a := LOAD1(ADD2(ADDRESS():a, CAST12(x, sext==0)))
-{
-    E_lda();
-    E_symref($a.sym, $a.off);
-    E_x_nl();
-}
-
-gen a := LOAD1(ADD2(ptrs, CAST12(y, sext==0)))
-{
-    var src := PopAndDerefOp();
-    DoParamIndirect_lda(src);
-}
-
 gen a := LOAD1(ptrs) uses y
 {
     var op := PopAndDerefOp();
@@ -1427,84 +1333,11 @@ gen a := NEG1(a)
     E("\tadc #0\n");
 }
 
-$ifdef ARCH_65C02
-    %{
-        sub SmallAdditionOrSubtraction(oc: uint8, amount: uint8)
-            R_flush(REG_A);
-            while amount != 0 loop
-                E_oc(oc);
-                E_a();
-                E_nl();
-                amount := amount - 1;
-            end loop;
-        end sub;
-    %}
-
-    gen a := ADD1(a, CONSTANT(value>=0, value<=3):c)
-            { SmallAdditionOrSubtraction(OC_INC, $c.value as uint8); }
-    gen a := ADD1(a, CONSTANT(value<0, value>=-3):c)
-            { SmallAdditionOrSubtraction(OC_DEC, -($c.value as int8) as uint8); }
-$endif
-
 gen a := ADD1(a, in1s) uses y { E_clc(); DoParamDirect(PopOp(), OC_ADC, 0); }
 gen a := SUB1(a, in1s) uses y { E_sec(); DoParamDirect(PopOp(), OC_SBC, 0); }
 gen a := OR1 (a, in1s) uses y {          DoParamDirect(PopOp(), OC_ORA, 0); }
 gen a := AND1(a, in1s) uses y {          DoParamDirect(PopOp(), OC_AND, 0); }
 gen a := EOR1(a, in1s) uses y {          DoParamDirect(PopOp(), OC_EOR, 0); }
-
-%{
-    sub is_inc_or_dec(value: Arith): (result: uint8)
-        result := 0;
-        if (value == 1) or (value == -1) then
-            result := 1;
-        end if;
-    end sub;
-%}
-
-gen STORE1(ADD1(LOAD1(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS():a2) uses x cost 100
-{
-    if ($a1.sym == $a2.sym) and ($a1.off == $a2.off) then
-        if $c.value < 0 then
-            E_dec();
-        else
-            E_inc();
-        end if;
-        E_symref($a1.sym, $a1.off);
-        E_nl();
-    else
-        E_ldx();
-        E_symref($a1.sym, $a1.off);
-        E_nl();
-
-        if $c.value < 0 then
-            E_dex();
-        else
-            E_inx();
-        end if;
-
-        E_stx();
-        E_symref($a2.sym, $a2.off);
-        E_nl();
-    end if;
-}
-
-%{
-    sub Shift1(oc: uint8, amount: uint8)
-        while amount != 0 loop
-            E_ocnl(oc);
-            amount := amount - 1;
-        end loop;
-    end sub;
-%}
-
-gen a := LSHIFT1(a, CONSTANT(value<=3):c) { Shift1(OC_ASL, $c.value as uint8); }
-gen a := RSHIFTU1(a, CONSTANT(value<=3):c) { Shift1(OC_LSR, $c.value as uint8); }
-
-gen a := RSHIFTS1(a, CONSTANT(value==1))
-{
-    E("\tcmp #$80\n");
-    E("\tror\n");
-}
 
 gen a := LSHIFT1(a, y)  { E_callhelper("_lshift1"); }
 gen a := RSHIFTU1(a, y) { E_callhelper("_rshiftu1"); }
@@ -1561,27 +1394,6 @@ gen xa := LOAD2(ptrs)
     DoParamDirect_lda(ptr, 0);
 }
 
-gen xa := LOAD2(ADD2(ptrs, CONSTANT(value>=0, value<=254):c)) uses y
-{
-    var src := PopAndDerefOp();
-
-    var off := $c.value as uint8;
-    DoParamDirect_lda(src, off+1);
-    E_tax();
-    DoParamDirect_lda(src, off);
-}
-
-gen xa := LOAD2(ADD2(ADDRESS():a, CAST12(y, sext==0)))
-{
-    E_lda();
-    E_symref($a.sym, $a.off+0);
-    E_y_nl();
-
-    E_ldx();
-    E_symref($a.sym, $a.off+1);
-    E_y_nl();
-}
-
 gen xa := CONSTANT():c
 {
     E_loadconst(REG_A, $c.value as uint8);
@@ -1595,28 +1407,15 @@ gen xa := ADDRESS():a
 
 gen STORE2(xa, ADDRESS():a)
 {
-    E_st(REG_A);
+    E_sta();
     E_symref($a.sym, $a.off);
     E_nl();
 
-    E_st(REG_X);
+    E_stx();
     E_symref($a.sym, $a.off+1);
     E_nl();
     RegCacheLeavesValue(REG_XA, $a.sym, $a.off);
 }
-
-$ifdef ARCH_65C02
-    gen STORE2(CONSTANT(value==0), ADDRESS():a)
-    {
-        E_stz();
-        E_symref($a.sym, $a.off);
-        E_nl();
-
-        E_stz();
-        E_symref($a.sym, $a.off+1);
-        E_nl();
-    }
-$endif
 
 gen STORE2(xa, ptrs) uses y
 {
@@ -1625,99 +1424,6 @@ gen STORE2(xa, ptrs) uses y
     DoParamDirect_sta(op, 0);
     E_txa();
     DoParamDirect_sta(op, 1);
-}
-
-gen STORE2(xa, ADD2(ptrs, CONSTANT(value>=0, value<=254):c)) uses y
-{
-    var dest := PopAndDerefOp();
-
-    var off := $c.value as uint8;
-    DoParamDirect_sta(dest, off+0);
-    E_txa();
-    DoParamDirect_sta(dest, off+1);
-}
-
-gen STORE2(ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c), ADDRESS():a2) uses x|y|a cost 100
-{
-    var lid := AllocLabel();
-    if ($a1.sym == $a2.sym) and ($a1.off == $a2.off) then
-        if $c.value < 0 then
-            E_lda();
-            E_symref($a1.sym, $a1.off);
-            E_nl();
-
-            E_bne(lid);
-
-            E_dec();
-            E_symref($a1.sym, $a1.off+1);
-            E_nl();
-
-            E_label(lid);
-            
-            E_dec();
-            E_symref($a1.sym, $a1.off);
-            E_nl();
-        else
-            E_inc();
-            E_symref($a1.sym, $a1.off);
-            E_nl();
-
-            E_bne(lid);
-
-            E_inc();
-            E_symref($a1.sym, $a1.off+1);
-            E_nl();
-
-            E_label(lid);
-        end if;
-    else
-        $ifdef ARCH_65C02
-            const LOWREG := REG_A;
-        $else
-            const LOWREG := REG_Y;
-        $endif
-
-        var cache := RegCacheFindValue($a1.sym, $a1.off);
-        if cache != REG_XA then
-            E_ldx();
-            E_symref($a1.sym, $a1.off+1);
-            E_nl();
-
-            E_ld(LOWREG);
-            E_symref($a1.sym, $a1.off);
-            E_nl();
-        else
-            $ifdef ARCH_65C02
-                # Highreg is already in A, where we want it.
-            $else
-                E_tay();
-            $endif
-        end if;
-
-        if $c.value < 0 then
-            E_bne(lid);
-            E_dex();
-            E_label(lid);
-            E_decrement(LOWREG);
-        else
-            E_increment(LOWREG);
-            E_bne(lid);
-            E_inx();
-            E_label(lid);
-        end if;
-
-        E_stx();
-        E_symref($a2.sym, $a2.off+1);
-        E_nl();
-
-        E_st(LOWREG);
-        E_symref($a2.sym, $a2.off);
-        E_nl();
-
-        $ifdef ARCH_65C02
-            RegCacheLeavesValue(REG_XA, $a2.sym, $a2.off);
-        $endif
-    end if;
 }
 
 %{
@@ -1785,32 +1491,9 @@ gen xa := AND2(in2s, xa) uses y {          DoXA(OC_AND); }
 gen xa := OR2 (in2s, xa) uses y {          DoXA(OC_ORA); }
 gen xa := EOR2(in2s, xa) uses y {          DoXA(OC_EOR); }
 
-// Because of some quirk of the way the code is generated, this rule helps
-// a lot --- but the same rule for SUB2, AND2 etc actually makes things
-// worse, I think because it prevents one of the pointer indexing rules from
-// firing.
-gen STORE2(ADD2(in2s, xa), ptrs) uses y cost 100 { E_clc(); DoXADest(OC_ADC); }
-
-gen xa := LSHIFT2(CAST12(a, sext==0), CONSTANT(value==1))
-{
-    E_loadconst(REG_X, 0);
-    E("\tasl\n");
-    E("\tbcc *+4\n");
-    E("\tinx\n");
-}
-
 gen xa := LSHIFT2(xa, y) { E_callhelper("_lshift2"); }
 gen xa := RSHIFTU2(xa, y) { E_callhelper("_rshiftu2"); }
 gen xa := RSHIFTS2(xa, y) { E_callhelper("_rshifts2"); }
-
-gen xa := RSHIFTU2(xa, CONSTANT(value==8))
-{
-    E_txa();
-    E_loadconst(REG_X, 0);
-}
-
-gen a := CAST21(RSHIFTU2(xa, CONSTANT(value==8))) { E_txa(); }
-gen a := CAST21(RSHIFTS2(xa, CONSTANT(value==8))) { E_txa(); }
 
 %{
     sub MulOrDiv2(name: string)
@@ -2035,12 +1718,6 @@ gen BEQ0(CONSTANT():lhs, CONSTANT():rhs):b
     end if;
 }
 
-gen BEQ1(a:lhs, CONSTANT(value==0)):b uses a|x
-{
-    E_tax();
-    E_jumps_beq_bne(self.n[0]);
-}
-
 gen BEQ1(a:lhs, in1s:rhs):b
 {
     var rhs := PopOp();
@@ -2055,12 +1732,6 @@ gen BLTU1(a:lhs, in1s:rhs):b
     E_jumps_bcc_bcs(self.n[0]);
 }
 
-gen BLTS1(a, CONSTANT(value==0)):b uses x
-{
-    E_tax();
-    E_jumps_beq_bne(self.n[0]);
-}
-
 gen BLTS1(a:lhs, in1s:rhs):b
 {
     var rhs := PopOp();
@@ -2069,29 +1740,6 @@ gen BLTS1(a:lhs, in1s:rhs):b
     E("\tbvc *+4\n");
     E("\teor #$80\n");
     E_jumps_bmi_bpl(self.n[0]);
-}
-
-gen BEQ2(xa, CONSTANT(value==0)):b uses a|y
-{
-    E_tay();
-    E_bne($b.falselabel);
-    E_txa();
-    E_jumps_beq_bne(self.n[0]);
-}
-
-gen BEQ2(LOAD2(ADDRESS():a), CONSTANT(value==0)):b uses a
-{
-    E_lda();
-    E_symref($a.sym, $a.off);
-    E_nl();
-
-    E_bne($b.falselabel);
-
-    E_lda();
-    E_symref($a.sym, $a.off+1);
-    E_nl();
-
-    E_jumps_beq_bne(self.n[0]);
 }
 
 gen BEQ2(xa:lhs, in2s:rhs):b
@@ -2130,12 +1778,6 @@ gen BLTS2(xa:lhs, in2s:rhs):c
     DoParamDirect(rhs, OC_SBC, 1);
     E("\tbvc *+4\n");
     E("\teor #$80\n");
-    E_jumps_bmi_bpl(self.n[0]);
-}
-
-gen BLTS2(xa, CONSTANT(value==0)):b
-{
-    E_txa();
     E_jumps_bmi_bpl(self.n[0]);
 }
 
@@ -2186,35 +1828,9 @@ gen BLTS2(xa, CONSTANT(value==0)):b
     end sub;
 %}
 
-gen BEQ4(in4s, CONSTANT(value==0)):b uses a|x|y
-{
-    var lhs := PopOp();
-
-    E_loadconst(REG_Y, 3);
-    var lid := E_new_label();
-
-    DoParamIndirect_lda(lhs);
-    E_bne($b.falselabel);
-
-    E_dey();
-    E_bpl(lid);
-
-    if $b.fallthrough != $b.truelabel then
-        E_jmp($b.truelabel);
-    end if;
-}
-
 gen BEQ4(in4s, in4s):b uses a|x|y { DoCmp4EQ(self.n[0]); }
 gen BLTU4(in4s, in4s):b uses a|x|y { DoCmp4LT(self.n[0], 0); }
 gen BLTS4(in4s, in4s):b uses a|x|y { DoCmp4LT(self.n[0], 1); }
-
-gen BLTS4(in4s, CONSTANT(value==0)):b uses a|x|y
-{
-    var lhs := PopOp();
-
-    DoParamDirect_lda(lhs, 3);
-    E_jumps_bmi_bpl(self.n[0]);
-}
 
 // --- Casts ----------------------------------------------------------------
 
@@ -2296,23 +1912,11 @@ gen xa := CAST42(in4s)
 
 // --- Case -----------------------------------------------------------------
 
-%{
-    sub StartCase()
-        cases := cases + 1;
-    end sub;
-
-    sub EndCase()
-        cases := cases - 1;
-    end sub;
-%}
-
-gen STARTCASE1(a) { StartCase(); }
-gen STARTCASE2(xa) { StartCase(); }
+gen STARTCASE1(a);
+gen STARTCASE2(xa);
 
 gen STARTCASE4(v32)
 {
-    StartCase();
-
     var e := GetHelper("_when4");
     var op := PeekOp();
     var sid := op.stk.sid;
@@ -2364,9 +1968,9 @@ gen WHENCASE4():c uses a
     E_bne($c.falselabel);
 }
 
-gen ENDCASE1() { EndCase(); }
-gen ENDCASE2() { EndCase(); }
-gen ENDCASE4() { var op := PopOp(); EndCase(); }
+gen ENDCASE1();
+gen ENDCASE2();
+gen ENDCASE4() { var op := PopOp(); }
 
 // --- Strings --------------------------------------------------------------
 
@@ -2468,6 +2072,387 @@ gen ASMEND()
     E_nl();
     inasm := 0;
 }
+
+// ==========================================================================
+//                               OPTIONAL RULES
+// ==========================================================================
+
+// These rules make the code better, but aren't actually necessary. They can
+// be turned off to try and make a self-hosting compiler.
+
+$ifndef TINY
+
+// --- 65C02 features -------------------------------------------------------
+
+$ifdef ARCH_65C02
+    // The 65C02 can store zero to a memory location without needing to use
+    // a register. It's kinda limited when it comes to addressing modes.
+
+    gen STORE1(CONSTANT(value==0), ADDRESS():a)
+    {
+        E_stz();
+        E_symref($a.sym, $a.off);
+        E_nl();
+    }
+
+    gen STORE1(CONSTANT(value==0), ADD2(ADDRESS():a, CAST12(x, sext==0)))
+    {
+        E_stz();
+        E_symref($a.sym, $a.off);
+        E_x_nl();
+    }
+
+    gen STORE2(CONSTANT(value==0), ADDRESS():a)
+    {
+        E_stz();
+        E_symref($a.sym, $a.off);
+        E_nl();
+
+        E_stz();
+        E_symref($a.sym, $a.off+1);
+        E_nl();
+    }
+
+    // It can also directly increment and decrement the accumulator.
+
+    %{
+        sub SmallAdditionOrSubtraction(oc: uint8, amount: uint8)
+            R_flush(REG_A);
+            while amount != 0 loop
+                E_oc(oc);
+                E_a();
+                E_nl();
+                amount := amount - 1;
+            end loop;
+        end sub;
+    %}
+
+    gen a := ADD1(a, CONSTANT(value>=0, value<=3):c)
+            { SmallAdditionOrSubtraction(OC_INC, $c.value as uint8); }
+    gen a := ADD1(a, CONSTANT(value<0, value>=-3):c)
+            { SmallAdditionOrSubtraction(OC_DEC, -($c.value as int8) as uint8); }
+$endif
+
+// --- Indexed pointers -----------------------------------------------------
+
+// The (zp),y addressing mode gives us a free addition to the pointer when
+// dereferencing.
+
+gen STORE1(a, ADD2(ptrs, CONSTANT(value>=0, value<=255):c)) uses y
+{
+    var dest := PopAndDerefOp();
+    E_loadconst(REG_Y, $c.value as uint8);
+    DoParamIndirect_sta(dest);
+}
+
+gen STORE1(a, ADD2(ADDRESS():a, CAST12(x, sext==0)))
+{
+    E_sta();
+    E_symref($a.sym, $a.off);
+    E_x_nl();
+}
+
+gen STORE1(a, ADD2(ptrs, CAST12(y, sext==0)))
+{
+    var dest := PopAndDerefOp();
+    DoParamIndirect_sta(dest);
+}
+
+gen a := LOAD1(ADD2(ptrs, CONSTANT(value>=0, value<=255):c)) uses y
+{
+    var src := PopAndDerefOp();
+    E_loadconst(REG_Y, $c.value as uint8);
+    DoParamIndirect_lda(src);
+}
+
+gen a := LOAD1(ADD2(ADDRESS():a, CAST12(x, sext==0)))
+{
+    E_lda();
+    E_symref($a.sym, $a.off);
+    E_x_nl();
+}
+
+gen a := LOAD1(ADD2(ptrs, CAST12(y, sext==0)))
+{
+    var src := PopAndDerefOp();
+    DoParamIndirect_lda(src);
+}
+
+gen STORE2(xa, ADD2(ptrs, CONSTANT(value>=0, value<=254):c)) uses y
+{
+    var dest := PopAndDerefOp();
+
+    var off := $c.value as uint8;
+    DoParamDirect_sta(dest, off+0);
+    E_txa();
+    DoParamDirect_sta(dest, off+1);
+}
+
+gen xa := LOAD2(ADD2(ptrs, CONSTANT(value>=0, value<=254):c)) uses y
+{
+    var src := PopAndDerefOp();
+
+    var off := $c.value as uint8;
+    DoParamDirect_lda(src, off+1);
+    E_tax();
+    DoParamDirect_lda(src, off);
+}
+
+gen xa := LOAD2(ADD2(ADDRESS():a, CAST12(y, sext==0)))
+{
+    E_lda();
+    E_symref($a.sym, $a.off+0);
+    E_y_nl();
+
+    E_ldx();
+    E_symref($a.sym, $a.off+1);
+    E_y_nl();
+}
+
+// --- In place increments or decrements ------------------------------------
+
+// Adding or subtracting one to or from a memory location is very common and
+// can be optimised.
+
+%{
+    sub is_inc_or_dec(value: Arith): (result: uint8)
+        result := 0;
+        if (value == 1) or (value == -1) then
+            result := 1;
+        end if;
+    end sub;
+%}
+
+gen STORE1(
+        ADD1(LOAD1(ADDRESS():a1), CONSTANT(value is inc_or_dec):c),
+        ADDRESS():a2) uses x cost 100
+{
+    if ($a1.sym == $a2.sym) and ($a1.off == $a2.off) then
+        if $c.value < 0 then
+            E_dec();
+        else
+            E_inc();
+        end if;
+        E_symref($a1.sym, $a1.off);
+        E_nl();
+    else
+        E_ldx();
+        E_symref($a1.sym, $a1.off);
+        E_nl();
+
+        if $c.value < 0 then
+            E_dex();
+        else
+            E_inx();
+        end if;
+
+        E_stx();
+        E_symref($a2.sym, $a2.off);
+        E_nl();
+    end if;
+}
+
+gen STORE2(
+        ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c),
+        ADDRESS():a2) uses x|y|a cost 100
+{
+    var lid := AllocLabel();
+    if ($a1.sym == $a2.sym) and ($a1.off == $a2.off) then
+        if $c.value < 0 then
+            E_lda();
+            E_symref($a1.sym, $a1.off);
+            E_nl();
+
+            E_bne(lid);
+
+            E_dec();
+            E_symref($a1.sym, $a1.off+1);
+            E_nl();
+
+            E_label(lid);
+            
+            E_dec();
+            E_symref($a1.sym, $a1.off);
+            E_nl();
+        else
+            E_inc();
+            E_symref($a1.sym, $a1.off);
+            E_nl();
+
+            E_bne(lid);
+
+            E_inc();
+            E_symref($a1.sym, $a1.off+1);
+            E_nl();
+
+            E_label(lid);
+        end if;
+    else
+        $ifdef ARCH_65C02
+            const LOWREG := REG_A;
+        $else
+            const LOWREG := REG_Y;
+        $endif
+
+        var cache := RegCacheFindValue($a1.sym, $a1.off);
+        if cache != REG_XA then
+            E_ldx();
+            E_symref($a1.sym, $a1.off+1);
+            E_nl();
+
+            E_ld(LOWREG);
+            E_symref($a1.sym, $a1.off);
+            E_nl();
+        else
+            $ifdef ARCH_65C02
+                # Highreg is already in A, where we want it.
+            $else
+                E_tay();
+            $endif
+        end if;
+
+        if $c.value < 0 then
+            E_bne(lid);
+            E_dex();
+            E_label(lid);
+            E_decrement(LOWREG);
+        else
+            E_increment(LOWREG);
+            E_bne(lid);
+            E_inx();
+            E_label(lid);
+        end if;
+
+        E_stx();
+        E_symref($a2.sym, $a2.off+1);
+        E_nl();
+
+        E_st(LOWREG);
+        E_symref($a2.sym, $a2.off);
+        E_nl();
+
+        $ifdef ARCH_65C02
+            RegCacheLeavesValue(REG_XA, $a2.sym, $a2.off);
+        $endif
+    end if;
+}
+
+// --- Comparisons against zero ---------------------------------------------
+
+gen BEQ1(a:lhs, CONSTANT(value==0)):b uses a|x
+{
+    E_tax();
+    E_jumps_beq_bne(self.n[0]);
+}
+
+gen BLTS1(a, CONSTANT(value==0)):b uses x
+{
+    E_tax();
+    E_jumps_beq_bne(self.n[0]);
+}
+
+gen BEQ2(xa, CONSTANT(value==0)):b uses a|y
+{
+    E_tay();
+    E_bne($b.falselabel);
+    E_txa();
+    E_jumps_beq_bne(self.n[0]);
+}
+
+gen BEQ2(LOAD2(ADDRESS():a), CONSTANT(value==0)):b uses a
+{
+    E_lda();
+    E_symref($a.sym, $a.off);
+    E_nl();
+
+    E_bne($b.falselabel);
+
+    E_lda();
+    E_symref($a.sym, $a.off+1);
+    E_nl();
+
+    E_jumps_beq_bne(self.n[0]);
+}
+
+gen BLTS2(xa, CONSTANT(value==0)):b
+{
+    E_txa();
+    E_jumps_bmi_bpl(self.n[0]);
+}
+
+gen BEQ4(in4s, CONSTANT(value==0)):b uses a|x|y
+{
+    var lhs := PopOp();
+
+    E_loadconst(REG_Y, 3);
+    var lid := E_new_label();
+
+    DoParamIndirect_lda(lhs);
+    E_bne($b.falselabel);
+
+    E_dey();
+    E_bpl(lid);
+
+    if $b.fallthrough != $b.truelabel then
+        E_jmp($b.truelabel);
+    end if;
+}
+
+gen BLTS4(in4s, CONSTANT(value==0)):b uses a|x|y
+{
+    var lhs := PopOp();
+
+    DoParamDirect_lda(lhs, 3);
+    E_jumps_bmi_bpl(self.n[0]);
+}
+
+%{
+    sub Shift1(oc: uint8, amount: uint8)
+        while amount != 0 loop
+            E_ocnl(oc);
+            amount := amount - 1;
+        end loop;
+    end sub;
+%}
+
+// --- Inline shifts --------------------------------------------------------
+
+gen a := LSHIFT1(a, CONSTANT(value<=3):c) { Shift1(OC_ASL, $c.value as uint8); }
+gen a := RSHIFTU1(a, CONSTANT(value<=3):c) { Shift1(OC_LSR, $c.value as uint8); }
+
+gen a := RSHIFTS1(a, CONSTANT(value==1))
+{
+    E("\tcmp #$80\n");
+    E("\tror\n");
+}
+
+gen xa := LSHIFT2(CAST12(a, sext==0), CONSTANT(value==1))
+{
+    E_loadconst(REG_X, 0);
+    E("\tasl\n");
+    E("\tbcc *+4\n");
+    E("\tinx\n");
+}
+
+gen xa := RSHIFTU2(xa, CONSTANT(value==8))
+{
+    E_txa();
+    E_loadconst(REG_X, 0);
+}
+
+gen a := CAST21(RSHIFTU2(xa, CONSTANT(value==8))) { E_txa(); }
+gen a := CAST21(RSHIFTS2(xa, CONSTANT(value==8))) { E_txa(); }
+
+// --- Weird things ---------------------------------------------------------
+
+// Because of some quirk of the way the code is generated, this rule helps a
+// lot as it has xa on the RHS --- but the same rule for SUB2, AND2 etc
+// actually makes things worse, I think because it prevents one of the pointer
+// indexing rules from firing.
+
+gen STORE2(ADD2(in2s, xa), ptrs) uses y cost 100 { E_clc(); DoXADest(OC_ADC); }
+
+$endif
 
 // vim: sw=4 ts=4 et
 

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -969,25 +969,25 @@ gen stacki4 := LOAD4(p16)                        { var op := PeekOp(); op.mode :
 
 // --- Subroutines ----------------------------------------------------------
 
-gen STARTSUB():s
+gen STARTSUB()
 {
-    $s.subr.arch := Alloc(@bytesof ArchSubroutine) as [ArchSubroutine];
-    $s.subr.arch.end_label := AllocLabel();
-    $s.subr.arch.rts_label := AllocLabel();
+    current_subr.arch := Alloc(@bytesof ArchSubroutine) as [ArchSubroutine];
+    current_subr.arch.end_label := AllocLabel();
+    current_subr.arch.rts_label := AllocLabel();
 
     RegCacheReset();
 
     EmitterPushChunk();
-    E_h16($s.subr.id);
+    E_h16(current_subr.id);
 
     E("\n\n\t; ");
-    E($s.subr.name);
+    E(current_subr.name);
     E_nl();
 
     EmitByte(COO_ESCAPE_THISSUB);
     E(":\n");
 
-    var count := $s.subr.num_input_parameters;
+    var count := current_subr.num_input_parameters;
     var lastparam := count - 1;
     var popped: uint8 := 0;
 
@@ -1010,11 +1010,11 @@ gen STARTSUB():s
             $endif
 
             E_stx();
-            E_labelref($s.subr.arch.rts_label);
+            E_labelref(current_subr.arch.rts_label);
             E_nl();
 
             E_sty();
-            E_labelref($s.subr.arch.rts_label);
+            E_labelref(current_subr.arch.rts_label);
             E_plusone();
             E_nl();
 
@@ -1024,7 +1024,7 @@ gen STARTSUB():s
 
     while count != 0 loop
         count := count - 1;
-        var param := GetInputParameter($s.subr, count);
+        var param := GetInputParameter(current_subr, count);
 
         case param.vardata.type.typedata.width is
             when 1:
@@ -1075,21 +1075,21 @@ gen STARTSUB():s
         end case;
     end loop;
 
-    if IsSimpleSub($s.subr) == 0 then
+    if IsSimpleSub(current_subr) == 0 then
         PopReturnAddress();
     end if;
 }
 
-gen ENDSUB():s
+gen ENDSUB()
 {
     if current_subr.arch.seen_return != 0 then
         E_label(current_subr.arch.end_label);
     end if;
 
     var i: uint8 := 0;
-    var count := $s.subr.num_output_parameters;
+    var count := current_subr.num_output_parameters;
     while i != count loop
-        var param := GetOutputParameter($s.subr, i);
+        var param := GetOutputParameter(current_subr, i);
 
         var cache: RegId;
         case param.vardata.type.typedata.width is
@@ -1169,11 +1169,11 @@ gen ENDSUB():s
 
     i := 0;
     while i != 4 loop
-        EmitterDeclareWorkspace($s.subr, i, $s.subr.workspace[i]);
+        EmitterDeclareWorkspace(current_subr, i, current_subr.workspace[i]);
         i := i + 1;
     end loop;
 
-    Free($s.subr.arch as [uint8]);
+    Free(current_subr.arch as [uint8]);
 }
 
 gen RETURN()

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -211,16 +211,19 @@
         E("),y");
     end sub;
 
+    sub GetWsId(sym: [Symbol]): (wsid: uint8)
+        wsid := VARMEM_WS;
+        if is_zp(sym) != 0 then
+            wsid := PTRMEM_WS;
+        end if;
+    end sub;
+
     sub E_symref(sym: [Symbol], off: Size)
         if sym.vardata.externname != (0 as string) then
             E(sym.vardata.externname);
             E_i16(off as int16);
         else
-            var wsid: uint8 := VARMEM_WS;
-            if is_zp(sym) != 0 then
-                wsid := PTRMEM_WS;
-            end if;
-            E_wsref(sym.vardata.subr.id, wsid, sym.vardata.offset + off);
+            E_wsref(sym.vardata.subr.id, GetWsId(sym), sym.vardata.offset + off);
         end if;
     end sub;
 
@@ -276,7 +279,7 @@
     sub E_not() R_flush(REG_A); E_oc(OC_EOR); E("#255\n"); end sub;
 
     # Note: big endian on stack!
-    sub E_phax()
+    sub E_phxa()
         $ifdef ARCH_65C02
             E_pha();
             E_phx();
@@ -288,7 +291,7 @@
     end sub;
 
     # Note: big endian on stack!
-    sub E_plax()
+    sub E_plxa()
         $ifdef ARCH_65C02
             E_plx();
             E_pla();
@@ -921,7 +924,7 @@ gen JUMP():j
                     when REG_A:  E_pla(); return;
 
                     when REG_XA:
-                        E_plax();
+                        E_plxa();
                         return;
                 end case;
 
@@ -938,7 +941,7 @@ gen JUMP():j
             when REG_XA:
                 case dest is
                     when 0:
-                        E_phax();
+                        E_phxa();
                         return;
                 end case;
         end case;
@@ -1029,58 +1032,109 @@ gen STARTSUB()
         end if;
     end sub;
 
+    var current_wsid: uint8 := 0xff;
+    var current_top: Size;
+    var current_bot: Size;
+
+    sub CloseLoop()
+        if current_wsid != 0xff then
+            E("\t; pull wsid ");
+            E_u8(current_wsid);
+            E(" from ");
+            E_wsref(current_subr.id, current_wsid, current_bot);
+            E(" to ");
+            E_wsref(current_subr.id, current_wsid, current_top);
+            E_nl();
+            var count := current_top - current_bot + 1;
+            E("\t; count=");
+            E_u16(count);
+            E_nl();
+            E("\t; start=");
+            E_u16(256 - count);
+            E_nl();
+
+            E("; ");
+            E_loadconst(REG_Y, 256-(count as uint8));
+            var lid := E_new_label();
+            E("; ");
+            E_pla();
+            
+            E("; ");
+            E_sta();
+            E_wsref(current_subr.id, current_wsid, current_bot);
+            E_y_nl();
+
+            E("; ");
+            E_iny();
+            E("; ");
+            E_bne(lid);
+        end if;
+        current_wsid := 0xff;
+    end sub;
+
+    var param: [Symbol];
+    sub Pull()
+        var wsid := GetWsId(param);
+        var w := param.vardata.type.typedata.width as uint8;
+        if (wsid != current_wsid)
+                or (param.vardata.offset != (current_bot-(w as Size))) then
+            CloseLoop();
+            current_wsid := wsid;
+            current_top := param.vardata.offset + (w as Size) - 1;
+        end if;
+        current_bot := param.vardata.offset;
+    end sub;
+
     while count != 0 loop
         count := count - 1;
-        var param := GetInputParameter(current_subr, count);
+        param := GetInputParameter(current_subr, count);
 
         case param.vardata.type.typedata.width is
             when 1:
                 if count != lastparam then
                     PopReturnAddress();
+                    Pull();
                     E_pla();
                 end if;
-                E_sta();
-                E_symref(param, 0);
-                E_nl();
-                RegCacheLeavesValue(REG_A, param, 0);
+                    E_sta();
+                    E_symref(param, 0);
+                    E_nl();
+                    RegCacheLeavesValue(REG_A, param, 0);
+                #end if;
 
             when 2:
                 if count != lastparam then
                     PopReturnAddress();
-                    $ifdef ARCH_65C02
-                        E_plx();
-                        E_pla();
-                    $else
-                        E_pla();
-                        E_tax();
-                        E_pla();
-                    $endif
+                    Pull();
+                    E_plxa();
                 end if;
-                E_sta();
-                E_symref(param, 0);
-                E_nl();
+                    E_sta();
+                    E_symref(param, 0);
+                    E_nl();
 
-                E_stx();
-                E_symref(param, 1);
-                E_nl();
+                    E_stx();
+                    E_symref(param, 1);
+                    E_nl();
 
-                RegCacheLeavesValue(REG_XA, param, 0);
+                    RegCacheLeavesValue(REG_XA, param, 0);
+                #end if;
 
             when 4:
                 # WARNING: little endian on stack!
                 PopReturnAddress();
+                Pull();
                 E_loadconst(REG_Y, -4);
                 var lid := E_new_label();
+
                 E_pla();
-                
                 E_sta();
                 E_symref(param, -252);
                 E_y_nl();
-
                 E_iny();
                 E_bne(lid);
         end case;
     end loop;
+    CloseLoop();
 
     if IsSimpleSub(current_subr) == 0 then
         PopReturnAddress();
@@ -1117,12 +1171,12 @@ gen ENDSUB()
                     E_lda();
                     E_symref(param, 0);
                     E_nl();
-                    E_pha();
 
-                    E_lda();
+                    E_ldx();
                     E_symref(param, 1);
                     E_nl();
-                    E_pha();
+
+                    E_phxa();
                 else
                     cache := RegCacheFindValue(param, 0) & REG_XA;
                     if cache == 0 then
@@ -1225,15 +1279,14 @@ gen param := ARG2(param, xa, remaining==0);
 
 gen param := ARG2(param, xa, remaining!=0)
 {
-    # big endian on stack
-    E_phax();
+    E_phxa();
 }
 
 gen param := ARG4(param, in4s) uses y|a
 {
     var op := PopOp();
 
-    # WARNING: little endian on stack!
+    # WARNING: big endian on stack!
     E_loadconst(REG_Y, 3);
     var lid := E_new_label();
 

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -1918,7 +1918,7 @@ gen STARTCASE2(xa);
 gen STARTCASE4(v32)
 {
     var e := GetHelper("_when4");
-    var op := PeekOp();
+    var op := PopOp();
     var sid := op.stk.sid;
 
     E_lda();
@@ -1970,7 +1970,7 @@ gen WHENCASE4():c uses a
 
 gen ENDCASE1();
 gen ENDCASE2();
-gen ENDCASE4() { var op := PopOp(); }
+gen ENDCASE4();
 
 // --- Strings --------------------------------------------------------------
 

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -584,17 +584,26 @@ register p16; // pointer on fake stack
 register v32; // value on fake stack;
 register const address;
 register mem1 mem2 mem2p mem4;
-register memi1 memi2 memi4;
-register stacki1 stacki2 stacki4;
+$ifndef TINY
+    register memi1 memi2 memi4;
+    register stacki1 stacki2 stacki4;
+$endif
 register param;
 
 regclass r8 := a|x|y;
 regclass a16 := v16|p16;
-regclass in1s := const|mem1|memi1|stacki1|v8;
-regclass in2s := const|address|mem2|memi2|stacki2|a16;
-regclass in4s := const|mem4|memi4|stacki4|v32;
-regclass ptrs := mem2p|address|p16;
-regclass derefs := memi1|memi2|memi4|stacki1|stacki2|stacki4;
+$ifndef TINY
+    regclass in1s := const|mem1|memi1|stacki1|v8;
+    regclass in2s := const|address|mem2|memi2|stacki2|a16;
+    regclass in4s := const|mem4|memi4|stacki4|v32;
+    regclass ptrs := mem2p|address|p16;
+    regclass derefs := memi1|memi2|memi4|stacki1|stacki2|stacki4;
+$else
+    regclass in1s := const|mem1|v8;
+    regclass in2s := const|address|mem2|a16;
+    regclass in4s := const|mem4|v32;
+    regclass ptrs := mem2p|address|p16;
+$endif
 
 regdata a           uses xa|a compatible a|x|y;
 regdata x           uses xa|x compatible a|x;
@@ -610,12 +619,14 @@ regdata mem1 stacked;
 regdata mem2 stacked;
 regdata mem2p stacked;
 regdata mem4 stacked;
-regdata memi1 stacked;
-regdata memi2 stacked;
-regdata memi4 stacked;
-regdata stacki1 stacked;
-regdata stacki2 stacked;
-regdata stacki4 stacked;
+$ifndef TINY
+    regdata memi1 stacked;
+    regdata memi2 stacked;
+    regdata memi4 stacked;
+    regdata stacki1 stacked;
+    regdata stacki2 stacked;
+    regdata stacki4 stacked;
+$endif
 
 // --- Core things ----------------------------------------------------------
 
@@ -801,13 +812,13 @@ gen JUMP():j
                 E_stackref(operand.stk.sid);
                 E_closep();
 
-            when MODE_SYMBOL:
-                E_symref(operand.sym, operand.off);
-
             when MODE_SYMBOLI:
                 E_openp();
                 E_symref(operand.sym, operand.off);
                 E_closep();
+
+            when MODE_SYMBOL:
+                E_symref(operand.sym, operand.off);
 
             when else:
                 StartError();
@@ -853,6 +864,9 @@ gen JUMP():j
             when MODE_STACK:
                 E_stackref(operand.stk.sid + (offset as uint16));
 
+            when MODE_SYMBOL:
+                E_symref(operand.sym, operand.off + (offset as uint16));
+
             when MODE_STACKI:
                 E_openp();
                 E_stackref(operand.stk.sid);
@@ -864,9 +878,6 @@ gen JUMP():j
                 $else
                     E(",y");
                 $endif
-
-            when MODE_SYMBOL:
-                E_symref(operand.sym, operand.off + (offset as uint16));
 
             when MODE_SYMBOLI:
                 E_openp();
@@ -933,9 +944,9 @@ gen JUMP():j
 
         StartError();
         print("bad move ");
-        print_hex_i32(src);
+        print_hex_i32(src as uint32);
         print(" -> ");
-        print_hex_i32(dest);
+        print_hex_i32(dest as uint32);
         EndError();
     end sub;
 
@@ -954,12 +965,14 @@ gen mem1 := LOAD1(ADDRESS():a)                   { var op := PushSymOp($a.sym, $
 gen mem2 := LOAD2(ADDRESS():a)                   { var op := PushSymOp($a.sym, $a.off); }
 gen mem2p := LOAD2(ADDRESS(sym is zp):a)         { var op := PushSymOp($a.sym, $a.off); }
 gen mem4 := LOAD4(ADDRESS():a)                   { var op := PushSymOp($a.sym, $a.off); }
-gen memi1 := LOAD1(LOAD2(ADDRESS(sym is zp):a))  { var op := PushSymIOp($a.sym, $a.off); }
-gen memi2 := LOAD2(LOAD2(ADDRESS(sym is zp):a))  { var op := PushSymIOp($a.sym, $a.off); }
-gen memi4 := LOAD4(LOAD2(ADDRESS(sym is zp):a))  { var op := PushSymIOp($a.sym, $a.off); }
-gen stacki1 := LOAD1(p16)                        { var op := PeekOp(); op.mode := MODE_STACKI; }
-gen stacki2 := LOAD2(p16)                        { var op := PeekOp(); op.mode := MODE_STACKI; }
-gen stacki4 := LOAD4(p16)                        { var op := PeekOp(); op.mode := MODE_STACKI; }
+$ifndef TINY
+    gen memi1 := LOAD1(LOAD2(ADDRESS(sym is zp):a))  { var op := PushSymIOp($a.sym, $a.off); }
+    gen memi2 := LOAD2(LOAD2(ADDRESS(sym is zp):a))  { var op := PushSymIOp($a.sym, $a.off); }
+    gen memi4 := LOAD4(LOAD2(ADDRESS(sym is zp):a))  { var op := PushSymIOp($a.sym, $a.off); }
+    gen stacki1 := LOAD1(p16)                        { var op := PeekOp(); op.mode := MODE_STACKI; }
+    gen stacki2 := LOAD2(p16)                        { var op := PeekOp(); op.mode := MODE_STACKI; }
+    gen stacki4 := LOAD4(p16)                        { var op := PeekOp(); op.mode := MODE_STACKI; }
+$endif
 
 // ==========================================================================
 //                        STRICTLY NECESSARY RULES
@@ -1737,10 +1750,12 @@ gen BEQ2(xa:lhs, in2s:rhs):b
     E_bne($b.falselabel);
 
     var oc: uint8 := OC_CPX;
-    if ($rhs & REGCLASS_DEREFS) != 0 then
-        E_txa();
-        oc := OC_CMP;
-    end if;
+    $ifndef TINY
+        if ($rhs & REGCLASS_DEREFS) != 0 then
+            E_txa();
+            oc := OC_CMP;
+        end if;
+    $endif
     DoParamDirect(rhs, oc, 1);
     E_jumps_beq_bne(self.n[0]);
 }
@@ -2419,6 +2434,26 @@ gen BLTS4(in4s, CONSTANT(value==0)):b uses a|x|y
         end loop;
     end sub;
 %}
+
+// --- Combined casts -------------------------------------------------------
+
+gen a := CAST41(RSHIFTU4(in4s, CONSTANT(value==8))) uses y
+{
+    var op := PopOp();
+    DoParamDirect_lda(op, 1);
+}
+
+gen a := CAST41(RSHIFTU4(in4s, CONSTANT(value==16))) uses y
+{
+    var op := PopOp();
+    DoParamDirect_lda(op, 2);
+}
+
+gen a := CAST41(RSHIFTU4(in4s, CONSTANT(value==24))) uses y
+{
+    var op := PopOp();
+    DoParamDirect_lda(op, 3);
+}
 
 // --- Inline shifts --------------------------------------------------------
 

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -821,9 +821,9 @@ gen JUMP():j
         E_y_nl();
     end sub;
 
-    sub DoParamIndirect_lda(operand: [Operand]) DoParamIndirect(operand, OC_LDA, 0); end sub; 
-    sub DoParamIndirect_sta(operand: [Operand]) DoParamIndirect(operand, OC_STA, 0); end sub; 
-    sub DoParamIndirect_sbc(operand: [Operand]) DoParamIndirect(operand, OC_SBC, 0); end sub;
+    sub DoParamIndirect_lda(operand: [Operand]) R_flush(REG_A); DoParamIndirect(operand, OC_LDA, 0); end sub; 
+    sub DoParamIndirect_sta(operand: [Operand])                 DoParamIndirect(operand, OC_STA, 0); end sub; 
+    sub DoParamIndirect_sbc(operand: [Operand]) R_flush(REG_A); DoParamIndirect(operand, OC_SBC, 0); end sub;
 
     sub DoParamDirect(operand: [Operand], oc: uint8, offset: uint8)
         var m := operand.mode;
@@ -889,8 +889,8 @@ gen JUMP():j
         E_nl();
     end sub;
 
-    sub DoParamDirect_lda(operand: [Operand], offset: uint8) DoParamDirect(operand, OC_LDA, offset); end sub;
-    sub DoParamDirect_sta(operand: [Operand], offset: uint8) DoParamDirect(operand, OC_STA, offset); end sub;
+    sub DoParamDirect_lda(operand: [Operand], offset: uint8) R_flush(REG_A); DoParamDirect(operand, OC_LDA, offset); end sub;
+    sub DoParamDirect_sta(operand: [Operand], offset: uint8)                 DoParamDirect(operand, OC_STA, offset); end sub;
 
     # Note that this *destroys* the source register.
     sub ArchEmitMove(src: RegId, dest: RegId)
@@ -1301,23 +1301,6 @@ gen a|x|y := LOAD1(ADDRESS():a)
         E_nl();
         RegCacheLeavesValue($$, $a.sym, $a.off);
     end if;
-}
-
-gen a := LOAD1(LOAD2(ADDRESS(sym is zp):a)) uses y
-{
-    $ifndef ARCH_65C02
-        E_loadconst(REG_Y, 0);
-    $endif
-
-    E_ld($$);
-    E_openp();
-    E_symref($a.sym, $a.off);
-    E(")");
-    $ifdef ARCH_65C02
-        E_nl();
-    $else
-        E_y_nl();
-    $endif
 }
 
 gen a := LOAD1(ptrs) uses y
@@ -2212,6 +2195,23 @@ gen xa := LOAD2(ADD2(ADDRESS():a, CAST12(y, sext==0)))
     E_ldx();
     E_symref($a.sym, $a.off+1);
     E_y_nl();
+}
+
+gen a := LOAD1(LOAD2(ADDRESS(sym is zp):a)) uses y
+{
+    $ifndef ARCH_65C02
+        E_loadconst(REG_Y, 0);
+    $endif
+
+    E_ld($$);
+    E_openp();
+    E_symref($a.sym, $a.off);
+    E(")");
+    $ifdef ARCH_65C02
+        E_nl();
+    $else
+        E_y_nl();
+    $endif
 }
 
 // --- In place increments or decrements ------------------------------------

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -328,23 +328,6 @@
     sub E_sty() E_st(REG_Y); end sub;
     sub E_stz() E_oc(OC_STZ); end sub;
 
-    sub E_ldst_ws(oc: uint8, id: uint16, off: Size)
-        E_oc(oc);
-        E_wsref(id, PTRMEM_WS, off);
-        E_nl();
-    end sub;
-
-    sub E_sta_ws(id: uint16, off: Size) R_flush(REG_A); E_ldst_ws(OC_STA, id, off); end sub;
-    sub E_stx_ws(id: uint16, off: Size) R_flush(REG_X); E_ldst_ws(OC_STX, id, off); end sub;
-    sub E_lda_ws(id: uint16, off: Size)                 E_ldst_ws(OC_LDA, id, off); end sub;
-    sub E_ldx_ws(id: uint16, off: Size)                 E_ldst_ws(OC_LDX, id, off); end sub;
-
-    sub E_ldst_sym(oc: uint8, sym: [Symbol], off: Size)
-        E_oc(oc);
-        E_symref(sym, off);
-        E_nl();
-    end sub;
-
     sub E_cp(reg: RegId)
         case reg is
             when REG_A: E_oc(OC_CMP);
@@ -1315,13 +1298,10 @@ gen STORE4(CALLE4(param):s, ptrs) uses x|y|a { E_call($s.subr); PopArg4(PopAndDe
 gen param := END();
 
 gen param := ARG1(param, a, remaining==0); 
-gen param := ARG1(param, a, remaining!=0) { E_pha(); } 
 gen param := ARG2(param, xa, remaining==0);
 
-gen param := ARG2(param, xa, remaining!=0)
-{
-    E_phxa();
-}
+gen param := ARG1(param, a,  remaining!=0) { E_pha(); } 
+gen param := ARG2(param, xa, remaining!=0) { E_phxa(); }
 
 gen param := ARG4(param, in4s:lhs) uses y|a
 {
@@ -1360,18 +1340,7 @@ gen a := POPARG1(remaining==0);
 gen a := POPARG1(remaining!=0) { E_pla(); } 
 gen xa := POPARG2(remaining==0);
 
-gen xa := POPARG2(remaining!=0)
-{
-    # big endian on stack
-    $ifdef ARCH_65C02
-        E_plx();
-        E_pla();
-    $else
-        E_pla();
-        E_tax();
-        E_pla();
-    $endif
-}
+gen xa := POPARG2(remaining!=0) { E_plxa(); }
 
 gen v32 := POPARG4()        uses x|y|a { PopArg4(PushV32()); }
 gen STORE4(POPARG4(), ptrs) uses x|y|a { PopArg4(PopAndDerefOp()); }
@@ -1608,8 +1577,14 @@ gen xa := RSHIFTS2(xa, y) { E_callhelper("_rshifts2"); }
         var e := GetHelper("_mathpad");
 
         var subid := e.id;
-        E_sta_ws(subid, 0);
-        E_stx_ws(subid, 1);
+
+        E_sta();
+        E_wsref(subid, PTRMEM_WS, 0);
+        E_nl();
+
+        E_stx();
+        E_wsref(subid, PTRMEM_WS, 1);
+        E_nl();
 
         var rhs := PopOp();
         DoParamDirect_lda(rhs, 0);
@@ -1623,8 +1598,14 @@ gen xa := RSHIFTS2(xa, y) { E_callhelper("_rshifts2"); }
         var e := GetHelper("_mathpad");
 
         var subid := e.id;
-        E_lda_ws(subid, 4);
-        E_ldx_ws(subid, 5);
+
+        E_lda();
+        E_wsref(subid, PTRMEM_WS, 4);
+        E_nl();
+
+        E_ldx();
+        E_wsref(subid, PTRMEM_WS, 5);
+        E_nl();
     end sub;
 %}
 
@@ -2054,14 +2035,20 @@ gen STARTCASE4(v32)
     E_nl();
 
     var subid := e.id;
-    E_sta_ws(subid, 0);
+
+    E_sta();
+    E_wsref(subid, PTRMEM_WS, 0);
+    E_nl();
     
     E_lda();
     E_consthi();
     E_stackref(sid);
     E_nl();
 
-    E_sta_ws(subid, 1);
+    E_sta();
+    E_wsref(subid, PTRMEM_WS, 1);
+    E_nl();
+    
 }
 
 gen WHENCASE1():c

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -854,10 +854,10 @@ gen JUMP():j
                 E_closep();
                 $ifdef ARCH_65C02
                     if offset != 0 then
-                        E_y_nl();
+                        E(",y");
                     end if;
                 $else
-                    E_y_nl();
+                    E(",y");
                 $endif
 
             when MODE_SYMBOL:
@@ -869,10 +869,10 @@ gen JUMP():j
                 E_closep();
                 $ifdef ARCH_65C02
                     if offset != 0 then
-                        E_y_nl();
+                        E(",y");
                     end if;
                 $else
-                    E_y_nl();
+                    E(",y");
                 $endif
 
             when else:

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -1807,18 +1807,35 @@ gen BLTS2(xa:lhs, in2s:rhs):c
     sub DoCmp4LT(node: [Node], sext: uint8)
         var rhs := PopOp();
         var lhs := PopOp();
+        var lid: uint16;
 
-        E_loadconst(REG_X, 4);
-        E_loadconst(REG_Y, 0);
-        E_sec();
-        var lid := E_new_label();
+        $ifndef TINY
+        if (lhs.mode > MODE_STACKI) and (rhs.mode > MODE_STACKI) then
+            E_loadconst(REG_Y, 252);
+            E_sec();
+            lid := E_new_label();
 
-        DoParamIndirect_lda(lhs);
-        DoParamIndirect_sbc(rhs);
+            DoParamIndirect(lhs, OC_LDA, -252);
+            DoParamIndirect(rhs, OC_SBC, -252);
 
-        E_iny();
-        E_dex();
-        E_bne(lid);
+            E_iny();
+            E_bne(lid);
+        else
+        $endif
+            E_loadconst(REG_X, 4);
+            E_loadconst(REG_Y, 0);
+            E_sec();
+            lid := E_new_label();
+
+            DoParamIndirect_lda(lhs);
+            DoParamIndirect_sbc(rhs);
+
+            E_iny();
+            E_dex();
+            E_bne(lid);
+        $ifndef TINY
+        end if;
+        $endif
 
         if sext != 0 then
             E_tay(); # set flags from A

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -238,7 +238,6 @@
     end sub;
 
     sub E_jump(oc: uint8, label: LabelRef)
-        R_flushall();
         E_oc(oc);
         E_labelref(label);
         E_nl();
@@ -1293,7 +1292,6 @@ gen xa := CALLE2(param):s uses y
 %}
 
 gen v32 := CALLE4(param):s        uses x|y|a { E_call($s.subr); PopArg4(PushV32()); }
-gen STORE4(CALLE4(param):s, ptrs) uses x|y|a { E_call($s.subr); PopArg4(PopAndDerefOp()); }
 
 gen param := END();
 
@@ -2593,15 +2591,6 @@ gen xa := RSHIFTU2(xa, CONSTANT(value==8))
 
 gen a := CAST21(RSHIFTU2(xa, CONSTANT(value==8))) { E_txa(); }
 gen a := CAST21(RSHIFTS2(xa, CONSTANT(value==8))) { E_txa(); }
-
-// --- Weird things ---------------------------------------------------------
-
-// Because of some quirk of the way the code is generated, this rule helps a
-// lot as it has xa on the RHS --- but the same rule for SUB2, AND2 etc
-// actually makes things worse, I think because it prevents one of the pointer
-// indexing rules from firing.
-
-gen STORE2(ADD2(in2s, xa), ptrs) uses y cost 100 { E_clc(); DoXADest(OC_ADC); }
 
 $endif
 

--- a/src/cowcom/arch6502.cow.ng
+++ b/src/cowcom/arch6502.cow.ng
@@ -72,7 +72,7 @@
     end sub;
 
     sub is_zp(sym: [Symbol]): (result: uint8)
-        if (sym.vardata.type == int8_type) or (sym.vardata.type == uint8_type)
+        if (sym.vardata.type.typedata.width == 1)
                 or (IsPtr(sym.vardata.type) != 0) then
             result := 1;
         else
@@ -334,10 +334,16 @@
         E_nl();
     end sub;
 
-    sub E_sta_ws(id: uint16, off: Size) E_ldst_ws(OC_STA, id, off); end sub;
-    sub E_stx_ws(id: uint16, off: Size) E_ldst_ws(OC_STX, id, off); end sub;
-    sub E_lda_ws(id: uint16, off: Size) E_ldst_ws(OC_LDA, id, off); end sub;
-    sub E_ldx_ws(id: uint16, off: Size) E_ldst_ws(OC_LDX, id, off); end sub;
+    sub E_sta_ws(id: uint16, off: Size) R_flush(REG_A); E_ldst_ws(OC_STA, id, off); end sub;
+    sub E_stx_ws(id: uint16, off: Size) R_flush(REG_X); E_ldst_ws(OC_STX, id, off); end sub;
+    sub E_lda_ws(id: uint16, off: Size)                 E_ldst_ws(OC_LDA, id, off); end sub;
+    sub E_ldx_ws(id: uint16, off: Size)                 E_ldst_ws(OC_LDX, id, off); end sub;
+
+    sub E_ldst_sym(oc: uint8, sym: [Symbol], off: Size)
+        E_oc(oc);
+        E_symref(sym, off);
+        E_nl();
+    end sub;
 
     sub E_cp(reg: RegId)
         case reg is
@@ -803,6 +809,12 @@ gen JUMP():j
     end sub;
 
     sub DoParamIndirect(operand: [Operand], oc: uint8, off: Size)
+        sub CheckSize()
+            if off != 0 then
+                SimpleError("bad indirect");
+            end if;
+        end sub;
+
         E_oc(oc);
         case operand.mode is
             when MODE_CONST:
@@ -812,11 +824,13 @@ gen JUMP():j
                 E_stackref(operand.stk.sid);
 
             when MODE_STACKI:
+                CheckSize();
                 E_openp();
                 E_stackref(operand.stk.sid);
                 E_closep();
 
             when MODE_SYMBOLI:
+                CheckSize();
                 E_openp();
                 E_symref(operand.sym, operand.off);
                 E_closep();
@@ -1038,36 +1052,36 @@ gen STARTSUB()
 
     sub CloseLoop()
         if current_wsid != 0xff then
-            E("\t; pull wsid ");
-            E_u8(current_wsid);
-            E(" from ");
-            E_wsref(current_subr.id, current_wsid, current_bot);
-            E(" to ");
-            E_wsref(current_subr.id, current_wsid, current_top);
-            E_nl();
             var count := current_top - current_bot + 1;
-            E("\t; count=");
-            E_u16(count);
-            E_nl();
-            E("\t; start=");
-            E_u16(256 - count);
-            E_nl();
 
-            E("; ");
-            E_loadconst(REG_Y, 256-(count as uint8));
-            var lid := E_new_label();
-            E("; ");
-            E_pla();
-            
-            E("; ");
-            E_sta();
-            E_wsref(current_subr.id, current_wsid, current_bot);
-            E_y_nl();
+            if count == 2 then
+                E_pla();
 
-            E("; ");
-            E_iny();
-            E("; ");
-            E_bne(lid);
+                E_sta();
+                E_wsref(current_subr.id, current_wsid, current_bot+1);
+                E_nl();
+
+                count := 1;
+            end if;
+            if count == 1 then
+                E_pla();
+
+                E_sta();
+                E_wsref(current_subr.id, current_wsid, current_bot);
+                E_nl();
+            end if;
+            if count > 2 then
+                E_loadconst(REG_Y, (count as uint8)-1);
+                var lid := E_new_label();
+                E_pla();
+                
+                E_sta();
+                E_wsref(current_subr.id, current_wsid, current_bot);
+                E_y_nl();
+
+                E_dey();
+                E_bpl(lid);
+            end if;
         end if;
         current_wsid := 0xff;
     end sub;
@@ -1075,12 +1089,12 @@ gen STARTSUB()
     var param: [Symbol];
     sub Pull()
         var wsid := GetWsId(param);
-        var w := param.vardata.type.typedata.width as uint8;
+        var w := param.vardata.type.typedata.width;
         if (wsid != current_wsid)
-                or (param.vardata.offset != (current_bot-(w as Size))) then
+                or (param.vardata.offset != (current_bot-w)) then
             CloseLoop();
             current_wsid := wsid;
-            current_top := param.vardata.offset + (w as Size) - 1;
+            current_top := param.vardata.offset + w - 1;
         end if;
         current_bot := param.vardata.offset;
     end sub;
@@ -1094,20 +1108,18 @@ gen STARTSUB()
                 if count != lastparam then
                     PopReturnAddress();
                     Pull();
-                    E_pla();
-                end if;
+                else
                     E_sta();
                     E_symref(param, 0);
                     E_nl();
                     RegCacheLeavesValue(REG_A, param, 0);
-                #end if;
+                end if;
 
             when 2:
                 if count != lastparam then
                     PopReturnAddress();
                     Pull();
-                    E_plxa();
-                end if;
+                else
                     E_sta();
                     E_symref(param, 0);
                     E_nl();
@@ -1117,21 +1129,12 @@ gen STARTSUB()
                     E_nl();
 
                     RegCacheLeavesValue(REG_XA, param, 0);
-                #end if;
+                end if;
 
             when 4:
                 # WARNING: little endian on stack!
                 PopReturnAddress();
                 Pull();
-                E_loadconst(REG_Y, -4);
-                var lid := E_new_label();
-
-                E_pla();
-                E_sta();
-                E_symref(param, -252);
-                E_y_nl();
-                E_iny();
-                E_bne(lid);
         end case;
     end loop;
     CloseLoop();
@@ -1147,37 +1150,82 @@ gen ENDSUB()
         E_label(current_subr.arch.end_label);
     end if;
 
+    var current_wsid: uint8 := 0xff;
+    var current_top: Size;
+    var current_bot: Size;
+
+    sub CloseLoop()
+        if current_wsid != 0xff then
+            var count := current_top - current_bot + 1;
+
+            if count <= 2 then
+                E_lda();
+                E_wsref(current_subr.id, current_wsid, current_bot);
+                E_nl();
+
+                E_pha();
+            end if;
+            if count == 2 then
+                E_lda();
+                E_wsref(current_subr.id, current_wsid, current_bot+1);
+                E_nl();
+
+                E_pha();
+            end if;
+            if count > 2 then
+                E_loadconst(REG_Y, 256-(count as uint8));
+                var lid := E_new_label();
+                E_lda();
+                E_wsref(current_subr.id, current_wsid, current_bot - (256 - count));
+                E_y_nl();
+                
+                E_pha();
+
+                E_iny();
+                E_bne(lid);
+            end if;
+        end if;
+        current_wsid := 0xff;
+    end sub;
+
+    var param: [Symbol];
+    sub Push()
+        var wsid := GetWsId(param);
+        var w := param.vardata.type.typedata.width as uint8;
+        if (wsid != current_wsid)
+                or (param.vardata.offset != (current_top+1)) then
+            CloseLoop();
+            current_wsid := wsid;
+            current_bot := param.vardata.offset;
+        end if;
+        current_top := param.vardata.offset + (w as Size) - 1;
+    end sub;
+
     var i: uint8 := 0;
     var count := current_subr.num_output_parameters;
     while i != count loop
-        var param := GetOutputParameter(current_subr, i);
+        param := GetOutputParameter(current_subr, i);
 
         var cache: RegId;
         case param.vardata.type.typedata.width is
             when 1:
-                cache := RegCacheFindValue(param, 0) & REG_A;
-                if cache == 0 then
-                    E_lda();
-                    E_symref(param, 0);
-                    E_nl();
-                end if;
-                if i != (count-1) then
-                    E_pha();
+                if i == (count - 1) then
+                    CloseLoop();
+
+                    cache := RegCacheFindValue(param, 0) & REG_A;
+                    if cache == 0 then
+                        E_lda();
+                        E_symref(param, 0);
+                        E_nl();
+                    end if;
+                else
+                    Push();
                 end if;
 
             when 2:
-                if i != (count-1) then
-                    # Warning: big endian!
-                    E_lda();
-                    E_symref(param, 0);
-                    E_nl();
+                if i == (count - 1) then
+                    CloseLoop();
 
-                    E_ldx();
-                    E_symref(param, 1);
-                    E_nl();
-
-                    E_phxa();
-                else
                     cache := RegCacheFindValue(param, 0) & REG_XA;
                     if cache == 0 then
                         E_lda();
@@ -1188,24 +1236,16 @@ gen ENDSUB()
                         E_symref(param, 1);
                         E_nl();
                     end if;
+                else
+                    Push();
                 end if;
 
             when 4:
-                # Push from low to high so the value ends up in big-endian
-                # order on the stack. This allows the caller to pop it off
-                # using smaller code.
-                E_loadconst(REG_Y, -4);
-                var lid := E_new_label();
-
-                E_lda();
-                E_symref(param, -252);
-                E_y_nl();
-                E_pha();
-                E_iny();
-                E_bne(lid);
+                Push();
         end case;
         i := i + 1;
     end loop;
+    CloseLoop();
 
     if IsSimpleSub(current_subr) != 0 then
         E_rts();
@@ -1258,6 +1298,7 @@ gen xa := CALLE2(param):s uses y
 
 %{
     sub PopArg4(dest: [Operand])
+        # WARNING: lowest byte on stack is MSB, so pop the MSB first!
         E_loadconst(REG_Y, 3);
         var lid := E_new_label();
 
@@ -1282,18 +1323,37 @@ gen param := ARG2(param, xa, remaining!=0)
     E_phxa();
 }
 
-gen param := ARG4(param, in4s) uses y|a
+gen param := ARG4(param, in4s:lhs) uses y|a
 {
     var op := PopOp();
+    var lid := AllocLabel();
 
-    # WARNING: big endian on stack!
-    E_loadconst(REG_Y, 3);
-    var lid := E_new_label();
+    # WARNING: lowest byte on stack is MSB, so push the LSB first!
+    $ifndef TINY
+    if ($lhs & REGCLASS_DEREFS) != 0 then
+        E_loadconst(REG_X, 4);
+        E_loadconst(REG_Y, 0);
+        E_label(lid);
 
-    DoParamIndirect_lda(op);
-    E_pha();
-    E_dey();
-    E_bpl(lid);
+        DoParamIndirect_lda(op);
+        E_pha();
+        E_iny();
+        E_dex();
+    else
+    $endif
+
+        E_loadconst(REG_Y, 252);
+        E_label(lid);
+
+        DoParamIndirect(op, OC_LDA, -252);
+        E_pha();
+        E_iny();
+
+    $ifndef TINY
+    end if;
+    $endif
+
+    E_bne(lid);
 }
 
 gen a := POPARG1(remaining==0);
@@ -1643,7 +1703,7 @@ gen STORE4(NOT4(in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var lhs :
         if (lhs.mode > MODE_STACKI) and (rhs.mode > MODE_STACKI) and (dest.mode > MODE_STACKI) then
             # None of the operands are indirected, so we can use a more efficient loop.
 
-            E_loadconst(REG_Y, -4);
+            E_loadconst(REG_Y, 252);
             lid := E_new_label();
 
             DoParamIndirect(lhs, OC_LDA, -252);

--- a/src/cowcom/arch65c02-tiny.cow.ng
+++ b/src/cowcom/arch65c02-tiny.cow.ng
@@ -1,0 +1,4 @@
+$define ARCH_65C02
+$define TINY
+$include "arch6502.cow.ng"
+

--- a/src/cowcom/arch80386.cow.ng
+++ b/src/cowcom/arch80386.cow.ng
@@ -674,22 +674,22 @@ gen JUMP():j
 
 // --- Subroutines ----------------------------------------------------------
 
-gen STARTSUB():s
+gen STARTSUB()
 {
 	RegCacheReset();
 
 	EmitterPushChunk();
-	E_h16($s.subr.id);
+	E_h16(current_subr.id);
 
 	E("\n\n\t# ");
-	E($s.subr.name);
+	E(current_subr.name);
 	E(" workspace at ");
 	EmitByte(COO_ESCAPE_WSREF);
-	E_h16($s.subr.id);
+	E_h16(current_subr.id);
 	E("000000");
 	E(" length ");
 	EmitByte(COO_ESCAPE_WSSIZE);
-	E_h16($s.subr.id);
+	E_h16(current_subr.id);
 	E("00");
 	E_nl();
 
@@ -697,7 +697,7 @@ gen STARTSUB():s
 	EmitByte(COO_ESCAPE_THISSUB);
 	E(":\n");
 
-	var count := $s.subr.num_input_parameters;
+	var count := current_subr.num_input_parameters;
 	var lastparam := count - 1;
 	var popped: uint8 := 0;
 
@@ -710,7 +710,7 @@ gen STARTSUB():s
 
 	while count != 0 loop
 		count := count - 1;
-		var param := GetInputParameter($s.subr, count);
+		var param := GetInputParameter(current_subr, count);
 
 		var reg: RegId;
 		case param.vardata.type.typedata.width is
@@ -731,16 +731,16 @@ gen STARTSUB():s
 	end if;
 }
 
-gen ENDSUB():s
+gen ENDSUB()
 {
 	R_flushall();
 
 	E("end_");
-	E_subref($s.subr);
+	E_subref(current_subr);
 	E(":\n");
 
 	var count: uint8 := 0;
-	var params := $s.subr.num_output_parameters;
+	var params := current_subr.num_output_parameters;
 	var pushed: uint8 := 0;
 
 	sub push_return_address()
@@ -751,7 +751,7 @@ gen ENDSUB():s
 	end sub;
 
 	while count != params loop
-		var param := GetOutputParameter($s.subr, count);
+		var param := GetOutputParameter(current_subr, count);
 
 		var reg: RegId;
 		case param.vardata.type.typedata.width is
@@ -774,7 +774,7 @@ gen ENDSUB():s
 		E_ret();
 	end if;
 
-	EmitterDeclareWorkspace($s.subr, 0, $s.subr.workspace[0]);
+	EmitterDeclareWorkspace(current_subr, 0, current_subr.workspace[0]);
 	EmitterPopChunk('S');
 }
 

--- a/src/cowcom/arch8080.cow.ng
+++ b/src/cowcom/arch8080.cow.ng
@@ -640,22 +640,22 @@ gen JUMP():j
 
 // --- Subroutines ----------------------------------------------------------
 
-gen STARTSUB():s
+gen STARTSUB()
 {
 	RegCacheReset();
 
 	EmitterPushChunk();
-	E_h16($s.subr.id);
+	E_h16(current_subr.id);
 
 	E("\n\n\t; ");
-	E($s.subr.name);
+	E(current_subr.name);
 	E(" workspace at ");
 	EmitByte(COO_ESCAPE_WSREF);
-	E_h16($s.subr.id);
+	E_h16(current_subr.id);
 	E("000000");
 	E(" length ");
 	EmitByte(COO_ESCAPE_WSSIZE);
-	E_h16($s.subr.id);
+	E_h16(current_subr.id);
 	E("00");
 	E_nl();
 
@@ -663,7 +663,7 @@ gen STARTSUB():s
 	EmitByte(COO_ESCAPE_THISSUB);
 	E(":\n");
 
-	var count := $s.subr.num_input_parameters;
+	var count := current_subr.num_input_parameters;
 	var lastparam := count - 1;
 	var popped: uint8 := 0;
 
@@ -676,7 +676,7 @@ gen STARTSUB():s
 
 	while count != 0 loop
 		count := count - 1;
-		var param := GetInputParameter($s.subr, count);
+		var param := GetInputParameter(current_subr, count);
 
 		case param.vardata.type.typedata.width is
 			when 1:
@@ -707,16 +707,16 @@ gen STARTSUB():s
 	end if;
 }
 
-gen ENDSUB():s
+gen ENDSUB()
 {
 	R_flushall();
 
 	E("end_");
-	E_subref($s.subr);
+	E_subref(current_subr);
 	E(":\n");
 
 	var count: uint8 := 0;
-	var params := $s.subr.num_output_parameters;
+	var params := current_subr.num_output_parameters;
 	var pushed: uint8 := 0;
 
 	sub push_return_address()
@@ -727,7 +727,7 @@ gen ENDSUB():s
 	end sub;
 
 	while count != params loop
-		var param := GetOutputParameter($s.subr, count);
+		var param := GetOutputParameter(current_subr, count);
 
 		case param.vardata.type.typedata.width is
 			when 1:
@@ -760,7 +760,7 @@ gen ENDSUB():s
 	end if;
 	E_ret();
 
-	EmitterDeclareWorkspace($s.subr, 0, $s.subr.workspace[0]);
+	EmitterDeclareWorkspace(current_subr, 0, current_subr.workspace[0]);
 	EmitterPopChunk('S');
 }
 

--- a/src/cowcom/archz80.cow.ng
+++ b/src/cowcom/archz80.cow.ng
@@ -788,22 +788,22 @@ gen JUMP():j
 
 // --- Subroutines ----------------------------------------------------------
 
-gen STARTSUB():s
+gen STARTSUB()
 {
 	RegCacheReset();
 
 	EmitterPushChunk();
-	E_h16($s.subr.id);
+	E_h16(current_subr.id);
 
 	E("\n\n\t; ");
-	E($s.subr.name);
+	E(current_subr.name);
 	E(" workspace at ");
 	EmitByte(COO_ESCAPE_WSREF);
-	E_h16($s.subr.id);
+	E_h16(current_subr.id);
 	E("000000");
 	E(" length ");
 	EmitByte(COO_ESCAPE_WSSIZE);
-	E_h16($s.subr.id);
+	E_h16(current_subr.id);
 	E("00");
 	E_nl();
 
@@ -811,7 +811,7 @@ gen STARTSUB():s
 	EmitByte(COO_ESCAPE_THISSUB);
 	E(":\n");
 
-	var count := $s.subr.num_input_parameters;
+	var count := current_subr.num_input_parameters;
 	var lastparam := count - 1;
 	var popped: uint8 := 0;
 
@@ -824,7 +824,7 @@ gen STARTSUB():s
 
 	while count != 0 loop
 		count := count - 1;
-		var param := GetInputParameter($s.subr, count);
+		var param := GetInputParameter(current_subr, count);
 
 		case param.vardata.type.typedata.width is
 			when 1:
@@ -863,16 +863,16 @@ gen STARTSUB():s
 	end if;
 }
 
-gen ENDSUB():s
+gen ENDSUB()
 {
 	R_flushall();
 
 	E("end_");
-	E_subref($s.subr);
+	E_subref(current_subr);
 	E(":\n");
 
 	var count: uint8 := 0;
-	var params := $s.subr.num_output_parameters;
+	var params := current_subr.num_output_parameters;
 	var pushed: uint8 := 0;
 
 	sub push_return_address()
@@ -883,7 +883,7 @@ gen ENDSUB():s
 	end sub;
 
 	while count != params loop
-		var param := GetOutputParameter($s.subr, count);
+		var param := GetOutputParameter(current_subr, count);
 
 		case param.vardata.type.typedata.width is
 			when 1:
@@ -923,7 +923,7 @@ gen ENDSUB():s
 	end if;
 	E_ret();
 
-	EmitterDeclareWorkspace($s.subr, 0, $s.subr.workspace[0]);
+	EmitterDeclareWorkspace(current_subr, 0, current_subr.workspace[0]);
 	EmitterPopChunk('S');
 }
 

--- a/src/cowcom/build.lua
+++ b/src/cowcom/build.lua
@@ -1,5 +1,5 @@
-local ARCHS = { "65c02", "6502", "z80", "8080", "80386", "cgen" }
-local BLACKLISTED_TOOLCHAINS = set { "bbct", "bbct6502" }
+local ARCHS = { "65c02-tiny", "65c02", "6502", "z80", "8080", "80386", "cgen" }
+local BLACKLISTED_TOOLCHAINS = set {} -- "bbct", "bbct6502" }
 
 lemoncowgol {
 	ins = { "src/cowcom/parser.y" },
@@ -10,7 +10,8 @@ lemoncowgol {
 }
 
 local extras = {
-	["65c02"] = "src/cowcom/arch6502.cow.ng"
+	["65c02"] = "src/cowcom/arch6502.cow.ng",
+	["65c02-tiny"] = "src/cowcom/arch6502.cow.ng"
 }
 
 for _, arch in ipairs(ARCHS) do
@@ -27,31 +28,33 @@ for _, arch in ipairs(ARCHS) do
 end
 
 for _, toolchain in ipairs(ALL_TOOLCHAINS) do
-	if not BLACKLISTED_TOOLCHAINS[toolchain.name] then
-		for _, arch in ipairs(ARCHS) do
-			cowgol {
-				toolchain = toolchain,
-				ins = {
-					"src/cowcom/main.cow",
-					"include/coodecls.coh",
-					"src/cowcom/codegen.coh",
-					"src/cowcom/emitter.coh",
-					"src/cowcom/expressions.coh",
-					"src/cowcom/lexer.coh",
-					"src/cowcom/midcodec.coh",
-					"src/cowcom/namespace.coh",
-					"src/cowcom/regcache.coh",
-					"src/cowcom/symbols.coh",
-					"src/cowcom/types.coh",
-					"$OBJ/src/cowcom/parser.coh",
-					"$OBJ/src/cowcom/parser.tokens.coh",
-					"$OBJ/cowcom-"..arch.."/inssel.coh",
-					"$OBJ/cowcom-"..arch.."/inssel.decl.coh",
-					"$OBJ/midcodes.coh",
-				},
-				outs = { "bin/cowcom-"..arch }
-			}
-		end
+	local archs = toolchain.archs
+	if not archs then
+		archs = ARCHS
+	end
+	for _, arch in ipairs(archs) do
+		cowgol {
+			toolchain = toolchain,
+			ins = {
+				"src/cowcom/main.cow",
+				"include/coodecls.coh",
+				"src/cowcom/codegen.coh",
+				"src/cowcom/emitter.coh",
+				"src/cowcom/expressions.coh",
+				"src/cowcom/lexer.coh",
+				"src/cowcom/midcodec.coh",
+				"src/cowcom/namespace.coh",
+				"src/cowcom/regcache.coh",
+				"src/cowcom/symbols.coh",
+				"src/cowcom/types.coh",
+				"$OBJ/src/cowcom/parser.coh",
+				"$OBJ/src/cowcom/parser.tokens.coh",
+				"$OBJ/cowcom-"..arch.."/inssel.coh",
+				"$OBJ/cowcom-"..arch.."/inssel.decl.coh",
+				"$OBJ/midcodes.coh",
+			},
+			outs = { "bin/cowcom-"..arch }
+		}
 	end
 end
 

--- a/src/cowcom/build.lua
+++ b/src/cowcom/build.lua
@@ -38,6 +38,7 @@ for _, toolchain in ipairs(ALL_TOOLCHAINS) do
 			ins = {
 				"src/cowcom/main.cow",
 				"include/coodecls.coh",
+				"src/cowcom/allocator.coh",
 				"src/cowcom/codegen.coh",
 				"src/cowcom/emitter.coh",
 				"src/cowcom/expressions.coh",

--- a/src/cowcom/codegen.coh
+++ b/src/cowcom/codegen.coh
@@ -724,6 +724,10 @@ sub GenerateConditional(rootnode: [Node])
 		var op := node.op;
 
 		sub push_and_free()
+			rhs.beq0.truelabel := t;
+			rhs.beq0.falselabel := f;
+			rhs.beq0.fallthrough := r;
+
 			node.left := (0 as [Node]);
 			node.right := (0 as [Node]);
 			PushNode(rhs);
@@ -740,10 +744,6 @@ sub GenerateConditional(rootnode: [Node])
 				lhs.beq0.falselabel := rr;
 				lhs.beq0.fallthrough := rr;
 
-				rhs.beq0.truelabel := t;
-				rhs.beq0.falselabel := f;
-				rhs.beq0.fallthrough := r;
-
 				push_and_free();
 
 			when MIDCODE_BAND:
@@ -752,10 +752,6 @@ sub GenerateConditional(rootnode: [Node])
 				lhs.beq0.truelabel := rr;
 				lhs.beq0.falselabel := f;
 				lhs.beq0.fallthrough := rr;
-
-				rhs.beq0.truelabel := t;
-				rhs.beq0.falselabel := f;
-				rhs.beq0.fallthrough := r;
 
 				push_and_free();
 

--- a/src/cowcom/codegen.coh
+++ b/src/cowcom/codegen.coh
@@ -17,11 +17,13 @@ record RegMove
 end record;
 
 record Instruction
+	next: [Instruction];
+	prev: [Instruction];
+	n: [Node][INSTRUCTION_TEMPLATE_DEPTH];
 	producable_regs: RegId;
 	produced_reg: RegId;
 	input_regs: RegId;
 	output_regs: RegId;
-	n: [Node][INSTRUCTION_TEMPLATE_DEPTH];
 	spills: RegMove[MAX_MOVE_COUNT];
 	reloads: RegMove[MAX_MOVE_COUNT];
 	num_spills: uint8;
@@ -112,19 +114,29 @@ sub IsStackedRegister(regid: RegId): (result: uint8)
 	end loop;
 end sub;
 
+# Calculates blocked registers *between* the two bounds, not the end ones.
 sub CalculateBlockedRegisters(insn: [Instruction], last: [Instruction]): (blocked: RegId)
 	blocked := 0;
-	while insn <= last loop
+	insn := insn.next;
+	while insn != last loop
 		blocked := blocked | insn.input_regs | insn.output_regs;
-		insn := @next insn;
+		if insn == last then
+			break;
+		end if;
+		insn := insn.next;
 	end loop;
 end sub;
 
+# Blocks registers *between* the two bounds, not the end ones.
 sub BlockRegisters(insn: [Instruction], last: [Instruction], blocked: RegId)
-	while insn <= last loop
+	insn := insn.next;
+	while insn != last loop
 		insn.input_regs := insn.input_regs | blocked;
 		insn.output_regs := insn.output_regs | blocked;
-		insn := @next insn;
+		if insn == last then
+			break;
+		end if;
+		insn := insn.next;
 	end loop;
 end sub;
 
@@ -276,9 +288,11 @@ end sub;
 sub Generate(rootnode: [Node])
 	var i: uint8;
 
-	var instructions: Instruction[32];
-	MemZero(&instructions[0] as [uint8], @bytesof instructions);
-	var next_instruction := &instructions[0];
+	# Remember that this list is actually emitted in *reverse* order, so
+	# last_instruction is the first machine code instruction in the clause.
+
+	var first_instruction: [Instruction] := 0 as [Instruction];
+	var last_instruction: [Instruction] := 0 as [Instruction];
 
 	#print_nl();
 	#PrintNodes(rootnode);
@@ -286,13 +300,16 @@ sub Generate(rootnode: [Node])
 	var old_next_node := next_node;
 	PushNode(rootnode);
 	while next_node != old_next_node loop
-		if next_instruction == &instructions[@sizeof instructions] then
-			PrintNodes(rootnode);
-			SimpleError("instruction queue overflow");
+		var producer := Alloc(@bytesof Instruction) as [Instruction];
+		if first_instruction == (0 as [Instruction]) then
+			first_instruction := producer;
+			last_instruction := producer;
+		else
+			last_instruction.next := producer;
+			producer.prev := last_instruction;
+			last_instruction := producer;
 		end if;
-		var producer := next_instruction;
-		next_instruction := @next next_instruction;
-
+			
 		# Find the first matching rule for this instruction.
 
 		var node := PopNode();
@@ -526,7 +543,7 @@ sub Generate(rootnode: [Node])
 					# the best available register between the producer and consumer.
 
 					var consumer := node.consumer;
-					var blocked := CalculateBlockedRegisters(@next consumer, @prev producer);
+					var blocked := CalculateBlockedRegisters(consumer, producer);
 					candidate := node.desired_reg & producer.producable_regs;
 
 					var mask1 := candidate & ~(blocked | producer.output_regs | consumer.input_regs);
@@ -540,7 +557,7 @@ sub Generate(rootnode: [Node])
 
 						blocked := FindConflictingRegisters(candidate);
 						consumer.input_regs := consumer.input_regs | blocked;
-						BlockRegisters(@next consumer, @prev producer, blocked);
+						BlockRegisters(consumer, producer, blocked);
 						producer.output_regs := producer.output_regs | blocked;
 					else
 						var compatible := FindCompatibleRegisters(node.desired_reg);
@@ -555,7 +572,7 @@ sub Generate(rootnode: [Node])
 							consumer.input_regs := consumer.input_regs
 								| FindConflictingRegisters(node.produced_reg);
 							blocked := FindConflictingRegisters(producer.produced_reg);
-							BlockRegisters(@next consumer, @prev producer, blocked);
+							BlockRegisters(consumer, producer, blocked);
 							producer.output_regs := producer.output_regs | blocked;
 							CreateReload(consumer, producer.produced_reg, node.produced_reg);
 						else
@@ -569,7 +586,7 @@ sub Generate(rootnode: [Node])
 								node.produced_reg := FindFirst(mask1);
 								blocked := FindConflictingRegisters(node.produced_reg);
 								consumer.input_regs := consumer.input_regs | blocked;
-								BlockRegisters(@next consumer, @prev producer, blocked);
+								BlockRegisters(consumer, producer, blocked);
 								producer.output_regs := producer.output_regs |
 										FindConflictingRegisters(producer.produced_reg);
 								CreateSpill(producer, producer.produced_reg, node.produced_reg);
@@ -660,28 +677,34 @@ sub Generate(rootnode: [Node])
 		end if;
 	end loop;
 
-	# We have a set of instructions for this expression; emit them.
+	# We have a set of instructions for this expression; emit them. In reverse
+	# order.
 
-	while next_instruction != &instructions[0] loop
-		next_instruction := @prev next_instruction;
+	sub EmitAndFreeInstructions()
+		loop
+			var insn := last_instruction;
+			if insn == (0 as [Instruction]) then
+				break;
+			end if;
+			last_instruction := last_instruction.prev;
 
-		#print("exec rule ");
-		#print_i8(next_instruction.ruleid);
-		#print_nl();
+			ShuffleRegisters(&insn.reloads[0]);
+			EmitOneInstruction(insn.ruleid, insn);
+			ShuffleRegisters(&insn.spills[0]);
+			ArchEndInstruction();
 
-		ShuffleRegisters(&next_instruction.reloads[0]);
-		EmitOneInstruction(next_instruction.ruleid, next_instruction);
-		ShuffleRegisters(&next_instruction.spills[0]);
-		ArchEndInstruction();
+			# If the root node of this instruction is a fallback node, it's
+			# not part of the tree and won't be discarded with the tree.
+			# Clean them up manually here.
 
-		# If the root node of this instruction is a fallback node, it's
-		# not part of the tree and won't be discarded with the tree.
-		# Clean them up manually here.
+			if insn.n[0].op == MIDCODE_FALLBACK then
+				Free(insn.n[0] as [uint8]);
+			end if;
+			Free(insn as [uint8]);
+		end loop;
+	end sub;
+	EmitAndFreeInstructions();
 
-		if next_instruction.n[0].op == MIDCODE_FALLBACK then
-			Free(next_instruction.n[0] as [uint8]);
-		end if;
-	end loop;
 	ArchEndGroup();
 
 	Discard(rootnode);

--- a/src/cowcom/codegen.coh
+++ b/src/cowcom/codegen.coh
@@ -688,6 +688,10 @@ sub Generate(rootnode: [Node])
 			end if;
 			last_instruction := last_instruction.prev;
 
+			#print("rule ");
+			#print_i8(insn.ruleid);
+			#print_nl();
+
 			ShuffleRegisters(&insn.reloads[0]);
 			EmitOneInstruction(insn.ruleid, insn);
 			ShuffleRegisters(&insn.spills[0]);

--- a/src/cowcom/codegen.coh
+++ b/src/cowcom/codegen.coh
@@ -285,7 +285,7 @@ sub PrintNodes(rootnode: [Node])
 	end loop;
 end sub;
 
-sub Generate(rootnode: [Node])
+sub ReallyGenerate(rootnode: [Node])
 	var i: uint8;
 
 	# Remember that this list is actually emitted in *reverse* order, so
@@ -712,6 +712,20 @@ sub Generate(rootnode: [Node])
 	ArchEndGroup();
 
 	Discard(rootnode);
+end sub;
+
+var old_op: uint8 := 0;
+sub Generate(statement: [Node])
+	var op := statement.op;
+	if (old_op == MIDCODE_JUMP) or (old_op == MIDCODE_RETURN) then
+		if (op != MIDCODE_LABEL) and (op != MIDCODE_ENDSUB) then
+			Discard(statement);
+			return;
+		end if;
+	end if;
+
+	old_op := statement.op;
+	ReallyGenerate(statement);
 end sub;
 
 sub GenerateConditional(rootnode: [Node])

--- a/src/cowcom/expressions.coh
+++ b/src/cowcom/expressions.coh
@@ -50,11 +50,13 @@ sub ResolveUntypedConstantsForAddOrSub(lhs: [Node], rhs: [Node])
 end sub;
 
 sub ResolveUntypedConstantsSimply(lhs: [Node], rhs: [Node])
-	if (lhs.type != (0 as [Symbol])) and (rhs.type == (0 as [Symbol])) then
-		rhs.type := lhs.type;
-	elseif (lhs.type == (0 as [Symbol])) and (rhs.type != (0 as [Symbol])) then
-		lhs.type := rhs.type;
-	elseif lhs.type != rhs.type then
+	var ltype := lhs.type;
+	var rtype := rhs.type;
+	if (ltype != (0 as [Symbol])) and (rtype == (0 as [Symbol])) then
+		rhs.type := ltype;
+	elseif (ltype == (0 as [Symbol])) and (rtype != (0 as [Symbol])) then
+		lhs.type := rtype;
+	elseif ltype != rtype then
 		expr_i_cant_do_that(lhs, rhs);
 	end if;
 end sub;
@@ -90,18 +92,20 @@ sub ExprAdd(lhs: [Node], rhs: [Node]): (result: [Node])
 		expr_i_cant_do_that(lhs, rhs);
 	end sub;
 
-	if (IsPtr(lhs.type) != 0) then
-		if (IsPtr(rhs.type) != 0) or (rhs.type != intptr_type) then
+	var ltype := lhs.type;
+	var rtype := rhs.type;
+	if (IsPtr(ltype) != 0) then
+		if (IsPtr(rtype) != 0) or (rtype != intptr_type) then
 			cant_add_that();
 		end if;
-	elseif IsPtr(rhs.type) != 0 then
+	elseif IsPtr(rtype) != 0 then
 		cant_add_that();
-	elseif (IsPtr(lhs.type) == 0) and (lhs.type != rhs.type) then
+	elseif (IsPtr(ltype) == 0) and (ltype != rtype) then
 		cant_add_that();
 	end if;
 	
 	result := MidC2Op(MIDCODE_ADD0, NodeWidth(lhs), lhs, rhs);
-	result.type := lhs.type;
+	result.type := ltype;
 end sub;
 
 sub ExprSub(lhs: [Node], rhs: [Node]): (result: [Node])
@@ -111,19 +115,21 @@ sub ExprSub(lhs: [Node], rhs: [Node]): (result: [Node])
 		expr_i_cant_do_that(lhs, rhs);
 	end sub;
 
-	if (IsPtr(lhs.type) != 0) and (IsPtr(rhs.type) == 0) and (rhs.type != intptr_type) then
+	var ltype := lhs.type;
+	var rtype := rhs.type;
+	if (IsPtr(ltype) != 0) and (IsPtr(rtype) == 0) and (rtype != intptr_type) then
 		cant_sub_that();
-	elseif (IsNum(lhs.type) != 0) and (IsPtr(rhs.type) != 0) then
+	elseif (IsNum(ltype) != 0) and (IsPtr(rtype) != 0) then
 		cant_sub_that();
-	elseif (IsNum(lhs.type) != 0) and (IsNum(rhs.type) != 0) and (lhs.type != rhs.type) then
+	elseif (IsNum(ltype) != 0) and (IsNum(rtype) != 0) and (ltype != rtype) then
 		cant_sub_that();
 	end if;
 
 	result := MidC2Op(MIDCODE_SUB0, NodeWidth(lhs), lhs, rhs);
-	if (IsPtr(lhs.type) != 0) and (lhs.type == rhs.type) then
+	if (IsPtr(ltype) != 0) and (ltype == rtype) then
 		result.type := intptr_type;
 	else
-		result.type := lhs.type;
+		result.type := ltype;
 	end if;
 end sub;
 

--- a/src/cowcom/expressions.coh
+++ b/src/cowcom/expressions.coh
@@ -139,8 +139,10 @@ sub Expr2Simple(sop: uint8, uop: uint8, lhs: [Node], rhs: [Node]): (result: [Nod
 	if IsSNum(lhs.type) != 0 then
 		op := sop;
 	end if;
+
+	var ltype := lhs.type;
 	result := MidC2Op(op, NodeWidth(lhs), lhs, rhs);
-	result.type := lhs.type;
+	result.type := ltype;
 end sub;
 
 sub expr_i_checkrhsconst(rhs: [Node])
@@ -171,8 +173,9 @@ sub ExprShift(sop: uint8, uop: uint8, lhs: [Node], rhs: [Node]): (result: [Node]
 	end if;
 	expr_i_checkshift(lhs, rhs);
 
+	var ltype := lhs.type;
 	result := MidC2Op(op, NodeWidth(lhs), lhs, rhs);
-	result.type := lhs.type;
+	result.type := ltype;
 end sub;
 
 

--- a/src/cowcom/lempar.coh
+++ b/src/cowcom/lempar.coh
@@ -77,8 +77,7 @@ sub yy_trace_shift(stateno: YYACTIONTYPE, msg: string)
 	print_nl();
 end sub;
 
-sub yy_reduce(yyruleno: YYACTIONTYPE, yylookahead: YYCODETYPE, yylookaheadtoken: ParseTOKENTYPE):
-		(yyact: YYACTIONTYPE)
+sub yy_reduce(yyruleno: YYACTIONTYPE, yylookahead: YYCODETYPE): (yyact: YYACTIONTYPE)
 	var yysize := yyRuleInfoNRhs[yyruleno as @indexof yyRuleInfoNRhs];
 	#print("Reduce ");
 	#print_i16(yyruleno);
@@ -130,7 +129,7 @@ sub yy_parse_failed()
 end sub;
 
 # syntax error code
-sub yy_syntax_error(yymajor: YYCODETYPE, yyminor: ParseTOKENTYPE)
+sub yy_syntax_error(yymajor: YYCODETYPE, yyminor: [ParseTOKENTYPE])
 %%
 end sub;
 
@@ -152,17 +151,7 @@ sub ParserDeinit()
 	end loop;
 end sub;
 
-sub MakeNumberTokenData(): (yyminor: [Token])
-	yyminor := Alloc(@bytesof Token) as [Token];
-	yyminor.number := token_value;
-end sub;
-
-sub MakeStringTokenData(): (yyminor: [Token])
-	yyminor := Alloc(@bytesof Token) as [Token];
-	yyminor.string := StrDup(&token_buffer[0]);
-end sub;
-
-sub ParserFeedToken(yymajor: YYCODETYPE, yyminor: [Token])
+sub ParserFeedToken(yymajor: YYCODETYPE, yyminor: [YYMINORTYPE])
 	var yyact := yytos.stateno;
 
 	#print("Input '")
@@ -187,7 +176,7 @@ sub ParserFeedToken(yymajor: YYCODETYPE, yyminor: [Token])
 		end if;
 
 		if yyact >= YY_MIN_REDUCE then
-			yyact := yy_reduce(yyact - YY_MIN_REDUCE, yymajor, yyminor);
+			yyact := yy_reduce(yyact - YY_MIN_REDUCE, yymajor);
 		elseif yyact <= YY_MAX_SHIFTREDUCE then
 			if yytos == &yystack[YYSTACKDEPTH] then
 				yy_stack_overflow();
@@ -201,7 +190,7 @@ sub ParserFeedToken(yymajor: YYCODETYPE, yyminor: [Token])
 
 			yytos.stateno := yyact;
 			yytos.major := yymajor;
-			yytos.minor.yy0 := yyminor;
+			yytos.minor.yyall := yyminor.yyall;
 			#yy_trace_shift(yyact, "Shift");
 
 			if yyerrcnt >= 0 then
@@ -213,13 +202,11 @@ sub ParserFeedToken(yymajor: YYCODETYPE, yyminor: [Token])
 			yy_accept();
 			break;
 		else
-			var yyminorunion: YYMINORTYPE;
-			yyminorunion.yy0 := yyminor;
 			if yyerrcnt <= 0 then
-				yy_syntax_error(yymajor, yyminor);
+				yy_syntax_error(yymajor, &yyminor.yy0);
 			end if;
 			yyerrcnt := 3;
-			yy_destructor(yymajor, &yyminorunion);
+			yy_destructor(yymajor, yyminor);
 			if yymajor == 0 then
 				yy_parse_failed();
 				yyerrcnt := -1;

--- a/src/cowcom/lexer.coh
+++ b/src/cowcom/lexer.coh
@@ -7,7 +7,8 @@ record File
 	next: [File];
 	path: string;
 	lineno: uint16;
-	fcb: FCB;
+	pos: uint32;
+	fcb: [FCB];
 end record;
 
 var include_paths: [IncludePath] := 0 as [IncludePath];
@@ -235,6 +236,24 @@ sub LexerPrintSpaces()
 	end loop;
 end sub;
 
+sub lexer_i_open(file: [File]): (result: uint8)
+	var fcb := Alloc(@bytesof FCB) as [FCB];
+	if FCBOpenIn(fcb, file.path) == 0 then
+		file.fcb := fcb;
+		FCBSeek(fcb, file.pos);
+		result := 0;
+	else
+		Free(fcb as [uint8]);
+		result := 1;
+	end if;
+end sub;
+
+sub lexer_i_close(file: [File])
+	file.pos := FCBPos(file.fcb);
+	var e := FCBClose(file.fcb);
+	Free(file.fcb as [uint8]);
+end sub;
+
 sub LexerIncludeFile(path: string)
 	var f := Alloc(@bytesof File) as [File];
 	f.next := current_file;
@@ -247,12 +266,16 @@ sub LexerIncludeFile(path: string)
 		f.path := Alloc(fl + il + 1);
 		MemCopy(p.path, il, f.path);
 		MemCopy(path, fl+1, f.path + il);
-		if FCBOpenIn(&f.fcb, f.path) == 0 then
+		if lexer_i_open(f) == 0 then
 			file_nesting := file_nesting + 1;
 			LexerPrintSpaces();
 			print("> ");
 			print(f.path);
 			print_nl();
+
+			if current_file != (0 as [File]) then
+				lexer_i_close(current_file);
+			end if;
 			current_file := f;
 			return;
 		end if;
@@ -296,7 +319,7 @@ sub LexerReadToken(): (token: uint8)
 			end if;
 
 			var f := current_file;
-			c := FCBGetChar(&f.fcb);
+			c := FCBGetChar(f.fcb);
 			if c == 26 then
 				c := 0;
 			end if;
@@ -305,7 +328,7 @@ sub LexerReadToken(): (token: uint8)
 			end if;
 
 			current_file := f.next;
-			var i := FCBClose(&f.fcb);
+			lexer_i_close(f);
 			Free(f as [uint8]);
 
 			if current_file != (0 as [File]) then
@@ -314,6 +337,9 @@ sub LexerReadToken(): (token: uint8)
 				print("< ");
 				print(current_file.path);
 				print_nl();
+				if lexer_i_open(current_file) != 0 then
+					SimpleError("I/O error");
+				end if;
 			end if;
 		end loop;
 	end sub;

--- a/src/cowcom/main.cow
+++ b/src/cowcom/main.cow
@@ -71,7 +71,7 @@ print("COWCOM: ");
 PrintFreeMemory();
 
 ParseArguments();
-LexerAddIncludePath("./");
+LexerAddIncludePath("");
 LexerIncludeFile(inputfile);
 
 current_subr := Alloc(@bytesof Subroutine) as [Subroutine];

--- a/src/cowcom/main.cow
+++ b/src/cowcom/main.cow
@@ -86,7 +86,6 @@ Generate(MidStartsub(current_subr));
 
 ParserInit();
 loop
-	var justbefore: uint32 := 1;
 	var yymajor := LexerReadToken();
 	case yymajor is
 		when NUMBER:

--- a/src/cowcom/main.cow
+++ b/src/cowcom/main.cow
@@ -76,7 +76,6 @@ LexerIncludeFile(inputfile);
 
 current_subr := Alloc(@bytesof Subroutine) as [Subroutine];
 current_subr.name := "__main";
-current_subr.externname := "cmain";
 
 ArchInitTypes();
 EmitterOpenfile(outputfile);
@@ -87,19 +86,21 @@ Generate(MidStartsub(current_subr));
 ParserInit();
 loop
 	var yymajor := LexerReadToken();
+	var yyminor: YYMINORTYPE;
 	case yymajor is
 		when NUMBER:
-			ParserFeedToken(yymajor, MakeNumberTokenData());
+			yyminor.yy0.number := token_value;
 
 		when ID:
-			ParserFeedToken(yymajor, MakeStringTokenData());
+			yyminor.yy0.string := StrDup(&token_buffer[0]);
 
 		when STRING:
-			ParserFeedToken(yymajor, MakeStringTokenData());
+			yyminor.yy0.string := StrDup(&token_buffer[0]);
 
 		when else:
-			ParserFeedToken(yymajor, 0 as [Token]);
+			yyminor.yy0.number := 0;
 	end case;
+	ParserFeedToken(yymajor, &yyminor);
 	if yymajor == 0 then
 		break;
 	end if;

--- a/src/cowcom/namespace.coh
+++ b/src/cowcom/namespace.coh
@@ -38,40 +38,36 @@ sub AddToNamespace(namespace: [Namespace], symbol: [Symbol])
 	end if;
 end sub;
 
-# Consumes the string in Token
-sub AddSymbol(namespace: [Namespace], token: [Token]): (symbol: [Symbol])
+# Takes ownership of the string
+sub AddSymbol(namespace: [Namespace], name: string): (symbol: [Symbol])
 	if namespace == (0 as [Namespace]) then
 		namespace := &current_subr.namespace;
 	end if;
 
 	symbol := Alloc(@bytesof Symbol) as [Symbol];
-	if token != (0 as [Token]) then
-		if LookupSymbolInNamespace(namespace, token.string) != (0 as [Symbol]) then
+	if name != (0 as string) then
+		if LookupSymbolInNamespace(namespace, name) != (0 as [Symbol]) then
 			StartError();
 			print("symbol '");
-			print(token.string);
+			print(name);
 			print("' is already defined");
 			EndError();
 		end if;
-
-		symbol.name := token.string;
-		token.string := (0 as string);
 	end if;
 
+	symbol.name := name;
 	AddToNamespace(namespace, symbol);
 end sub;
 
-# Consumes the string in Token
-sub AddAlias(namespace: [Namespace], token: [Token], real: [Symbol]): (symbol: [Symbol])
-	symbol := AddSymbol(namespace, token);
+# Takes ownership of the name
+sub AddAlias(namespace: [Namespace], name: string, real: [Symbol]): (symbol: [Symbol])
+	symbol := AddSymbol(namespace, name);
 	symbol.kind := TYPEDEF;
 	symbol.alias := real;
 end sub;
 
 sub AddAliasString(name: string, real: [Symbol])
-	var token: Token;
-	token.string := name;
-	var symbol := AddAlias(0 as [Namespace], &token, real);
+	var symbol := AddAlias(0 as [Namespace], name, real);
 end sub;
 
 sub CheckNotPartialType(type: [Symbol])

--- a/src/cowcom/namespace.coh
+++ b/src/cowcom/namespace.coh
@@ -53,10 +53,11 @@ sub AddSymbol(namespace: [Namespace], name: string): (symbol: [Symbol])
 			print("' is already defined");
 			EndError();
 		end if;
-	end if;
 
-	symbol.name := name;
-	AddToNamespace(namespace, symbol);
+		# Only add the symbol to the namespace if it has a name.
+		symbol.name := name;
+		AddToNamespace(namespace, symbol);
+	end if;
 end sub;
 
 # Takes ownership of the name

--- a/src/cowcom/parser.y
+++ b/src/cowcom/parser.y
@@ -918,9 +918,12 @@ statement ::= SUB substart subparams subgen statements END SUB.
 {
 	Generate(MidEndsub(current_subr));
 
-	break_label := current_subr.old_break_label;
-	continue_label := current_subr.old_continue_label;
-	current_subr := current_subr.parent;
+	var subr := current_subr;
+	break_label := subr.old_break_label;
+	continue_label := subr.old_continue_label;
+	current_subr := subr.parent;
+
+	DestructSubroutineContents(subr);
 }
 
 substart ::= newid(S).

--- a/src/cowcom/parser.y
+++ b/src/cowcom/parser.y
@@ -588,6 +588,7 @@ cvalue(C) ::= expression(E).
 		parser_i_constant_error();
 	end if;
 	C := E.constant.value;
+	Discard(E);
 }
 
 statement ::= CONST newid(S) ASSIGN cvalue(C) SEMICOLON.
@@ -1231,6 +1232,7 @@ initialiser ::= expression(E).
 		when else:
 			parser_i_constant_error();
 	end case;
+	Discard(E);
 
 	current_offset := current_offset + w;
 	current_global_offset := current_global_offset + w;

--- a/src/cowcom/parser.y
+++ b/src/cowcom/parser.y
@@ -1098,16 +1098,10 @@ memberid(S) ::= ID(T).
 				current_type.typedata.arraytype.indextype := ArchGuessIntType(0, (size-1) as Arith);
 			end if;
 			if current_offset != current_type.typedata.width then
-				print("current_offset=");
-				print_i16(current_offset);
-				print(" typedata.width=");
-				print_i16(current_type.typedata.width);
-				print_nl();
 				WrongNumberOfElementsError();
 			end if;
 		else
 			if current_member != (0 as [Symbol]) then
-				print("2\n");
 				WrongNumberOfElementsError();
 			end if;
 		end if;
@@ -1146,12 +1140,6 @@ memberid(S) ::= ID(T).
 		end if;
 
 		if member.vardata.offset < current_offset then
-			print_i16(member.vardata.offset);
-			print_nl();
-			print_i16(current_offset);
-			print_nl();
-			print(member.name);
-			print_nl();
 			SimpleError("out of order static initialisation");
 		end if;
 	end sub;

--- a/src/cowcom/symbols.coh
+++ b/src/cowcom/symbols.coh
@@ -118,7 +118,5 @@ sub DestructSubroutineContents(subr: [Subroutine])
 		subr.namespace.first := 0 as [Symbol];
 	end if;
 	subr.namespace.last := last_parameter;
-
-	CheckMemoryChain();
 end sub;
 

--- a/src/cowcom/symbols.coh
+++ b/src/cowcom/symbols.coh
@@ -48,4 +48,77 @@ sub MakeArrayType(type: [Symbol], size: Size): (arraytype: [Symbol])
 	arraytype.typedata.arraytype.indextype := ArchGuessIntType(0, (size-1) as Arith);
 end sub;
 
+# Called after a subroutine has been generated. This allows us to free up some
+# of the resources used. Note that we can't free *everything* until our parent
+# gets destructed, because parameters and types which they depend on might be
+# referred to.
+sub DestructSubroutineContents(subr: [Subroutine])
+	# Destroys a sumbol (which isn't a subroutine).
+	sub DestructSymbol(symbol: [Symbol])
+		if symbol.kind == TYPE then
+			var pointer := symbol.typedata.pointerto;
+			while pointer != (0 as [Symbol]) loop
+				var p := pointer;
+				pointer := pointer.typedata.pointerto;
+
+				Free(p.name);
+				Free(p as [uint8]);
+			end loop;
+		end if;
+		Free(symbol.name);
+		Free(symbol as [uint8]);
+	end sub;
+
+	# Destroys a subroutine, freeing all parameters, variables, types etc.
+	sub DestructSubroutine(subr: [Subroutine])
+		var symbol := subr.namespace.first;
+		while symbol != (0 as [Symbol]) loop
+			var s := symbol;
+			symbol := symbol.next;
+			DestructSymbol(s);
+		end loop;
+		Free(subr as [uint8]);
+	end sub;
+
+	# Find the last parameter.
+
+	var last_parameter := subr.first_output_parameter;
+	if last_parameter == (0 as [Symbol]) then
+		last_parameter := subr.first_input_parameter;
+	end if;
+	if last_parameter != (0 as [Symbol]) then
+		loop
+			var next := last_parameter.vardata.next_parameter;
+			if next == (0 as [Symbol]) then
+				break;
+			end if;
+			last_parameter := next;
+		end loop;
+	end if;
+
+	# last_parameter is now pointing at the last parameter, or null if there
+	# are none.
+
+	var symbol := subr.namespace.first;
+	if last_parameter != (0 as [Symbol]) then
+		symbol := last_parameter.next;
+	end if;
+	while symbol != (0 as [Symbol]) loop
+		next := symbol.next;
+		if symbol.kind == SUB then
+			DestructSubroutine(symbol.subr);
+		end if;
+		DestructSymbol(symbol);
+		symbol := next;
+	end loop;
+
+	if last_parameter != (0 as [Symbol]) then
+		last_parameter.next := 0 as [Symbol];
+	else
+		subr.namespace.first := 0 as [Symbol];
+	end if;
+	subr.namespace.last := last_parameter;
+
+	CheckMemoryChain();
+end sub;
 

--- a/src/cowcom/symbols.coh
+++ b/src/cowcom/symbols.coh
@@ -17,7 +17,7 @@ end sub;
 sub MakePointerType(type: [Symbol]): (ptrtype: [Symbol])
 	ptrtype := type.typedata.pointerto;
 	if ptrtype == (0 as [Symbol]) then
-		ptrtype := AddSymbol(0 as [Namespace], 0 as [Token]);
+		ptrtype := AddSymbol(0 as [Namespace], 0 as string);
 		ptrtype.name := StrDupBraced(type.name);
 		ptrtype.kind := TYPE;
 		ptrtype.typedata.kind := TYPE_POINTER;
@@ -32,7 +32,7 @@ end sub;
 sub MakeArrayType(type: [Symbol], size: Size): (arraytype: [Symbol])
 	CheckNotPartialType(type);
 
-	arraytype := AddSymbol(0 as [Namespace], 0 as [Token]);
+	arraytype := AddSymbol(0 as [Namespace], 0 as string);
 	arraytype.name := StrDupArrayed(type.name, size);
 	arraytype.kind := TYPE;
 	arraytype.typedata.kind := TYPE_ARRAY;

--- a/src/cowcom/types.coh
+++ b/src/cowcom/types.coh
@@ -75,7 +75,6 @@ end record;
 
 record Subroutine
 	name: string;
-	externname: string;
 	parent: [Subroutine];
 	namespace: Namespace;
 	first_input_parameter: [Symbol];

--- a/src/cowlink/arch8080.coh
+++ b/src/cowlink/arch8080.coh
@@ -10,9 +10,11 @@ sub ArchAlignUp(value: Size, alignment: uint8): (newvalue: Size)
 	newvalue := value;
 end sub;
 
-sub ArchEmitSubRef(subid: uint16)
-	E("f");
-	E_u16(subid);
+sub ArchEmitSubRef(subr: [Subroutine])
+	EmitByte('f');
+	E_u16(subr.id);
+	EmitByte('_');
+	E(subr.name);
 end sub;
 
 sub ArchEmitWSRef(wid: uint8, address: Size)
@@ -32,7 +34,7 @@ sub ArchEmitHeader(coo: [Coo])
 		var main := coo.index.subroutines[0];
 		if main != (0 as [Subroutine]) then
 			E("\tcall ");
-			ArchEmitSubRef(main.id);
+			ArchEmitSubRef(main);
 			E_nl();
 		end if;
 		coo := coo.next;

--- a/src/cowlink/archbbct.coh
+++ b/src/cowlink/archbbct.coh
@@ -22,6 +22,10 @@ sub ArchEmitWSRef(wid: uint8, address: Size)
 end sub;
 
 sub ArchEmitHeader(coo: [Coo])
+	if (workspaceSize[1] + workspaceSize[3]) > 0xee then
+		SimpleError("ran out of zero page space");
+	end if;
+
 	E(".cpu \"65c02\"\n");
 	E("* = $400\n");
 	E("ws1 = 0\n");

--- a/src/cowlink/archbbct.coh
+++ b/src/cowlink/archbbct.coh
@@ -10,9 +10,11 @@ sub ArchAlignUp(value: Size, alignment: uint8): (newvalue: Size)
 	newvalue := value;
 end sub;
 
-sub ArchEmitSubRef(subid: uint16)
-	E("f");
-	E_u16(subid);
+sub ArchEmitSubRef(subr: [Subroutine])
+	EmitByte('f');
+	E_u16(subr.id);
+	EmitByte('_');
+	E(subr.name);
 end sub;
 
 sub ArchEmitWSRef(wid: uint8, address: Size)
@@ -47,7 +49,7 @@ sub ArchEmitHeader(coo: [Coo])
 		var main := coo.index.subroutines[0];
 		if main != (0 as [Subroutine]) then
 			E("\tjsr ");
-			ArchEmitSubRef(main.id);
+			ArchEmitSubRef(main);
 			E_nl();
 		end if;
 		coo := coo.next;

--- a/src/cowlink/archbbct.coh
+++ b/src/cowlink/archbbct.coh
@@ -28,8 +28,15 @@ sub ArchEmitHeader(coo: [Coo])
 
 	E(".cpu \"65c02\"\n");
 	E("* = $400\n");
+	E("ajsr .macro\n");
+	E("\t.if (* & $ff) == $fd\n");
+	E("\tnop\n");
+	E("\t.endif\n");
+	E("\tjsr \\1\n");
+	E("\t.endm\n");
 	E("ws1 = 0\n");
 	E("ws3 = ws1 + ");
+
 	E_u16(workspaceSize[1]);
 	E_nl();
 

--- a/src/cowlink/archcgen.coh
+++ b/src/cowlink/archcgen.coh
@@ -12,9 +12,11 @@ sub E_nl()
 	EmitByte('\n');
 end sub;
 
-sub ArchEmitSubRef(subid: uint16)
-	E("f");
-	E_u16(subid);
+sub ArchEmitSubRef(subr: [Subroutine])
+	EmitByte('f');
+	E_u16(subr.id);
+	EmitByte('_');
+	E(subr.name);
 end sub;
 
 sub ArchEmitWSRef(wid: uint8, address: Size)
@@ -37,7 +39,7 @@ sub ArchEmitFooter(coo: [Coo])
 		var main := coo.index.subroutines[0];
 		if main != (0 as [Subroutine]) then
 			EmitByte('\t');
-			ArchEmitSubRef(main.id);
+			ArchEmitSubRef(main);
 			E("();\n");
 		end if;
 		coo := coo.next;

--- a/src/cowlink/archlx386.coh
+++ b/src/cowlink/archlx386.coh
@@ -10,9 +10,11 @@ sub ArchAlignUp(value: Size, alignment: uint8): (newvalue: Size)
 	newvalue := value;
 end sub;
 
-sub ArchEmitSubRef(subid: uint16)
-	E("f");
-	E_u16(subid);
+sub ArchEmitSubRef(subr: [Subroutine])
+	EmitByte('f');
+	E_u16(subr.id);
+	EmitByte('_');
+	E(subr.name);
 end sub;
 
 sub ArchEmitWSRef(wid: uint8, address: Size)
@@ -32,7 +34,7 @@ sub ArchEmitHeader(coo: [Coo])
 		var main := coo.index.subroutines[0];
 		if main != (0 as [Subroutine]) then
 			E("\tcall ");
-			ArchEmitSubRef(main.id);
+			ArchEmitSubRef(main);
 			E_nl();
 		end if;
 		coo := coo.next;

--- a/src/cowlink/asmwrite.coh
+++ b/src/cowlink/asmwrite.coh
@@ -59,13 +59,13 @@ sub WriteSubroutinesToOutputFile(coo: [Coo])
 					EmitByte('_');
 
 				when COO_ESCAPE_THISSUB:
-					ArchEmitSubRef(subroutine.id);
+					ArchEmitSubRef(subroutine);
 
 				when COO_ESCAPE_SUBREF:
 					subid := ReadH4();
 					subr := FindOrCreateSub(coo, subid);
 					subr := Deref(subr);
-					ArchEmitSubRef(subr.id);
+					ArchEmitSubRef(subr);
 
 				when COO_ESCAPE_WSREF:
 					subid := ReadH4();

--- a/tests/pointers.good
+++ b/tests/pointers.good
@@ -1,2 +1,3 @@
 @next: yes
 @prev: yes
+p.byte==4: yes

--- a/tests/pointers.test.cow
+++ b/tests/pointers.test.cow
@@ -12,3 +12,6 @@ var p := &unaligned[1];
 print("@next"); if @next p == &unaligned[2] then yes(); else no(); end if;
 print("@prev"); if @prev p == &unaligned[0] then yes(); else no(); end if;
 
+unaligned[1].byte := 4;
+print("p.byte==4"); if p.byte==4 then yes(); else no(); end if;
+

--- a/toolchains.lua
+++ b/toolchains.lua
@@ -61,7 +61,20 @@ toolchain_bbct = {
 	runtime = "rt/bbct",
 	asmext = ".asm",
 	binext = ".bbct",
-	tester = tubeemutest
+	tester = tubeemutest,
+	archs = { "65c02-tiny" }
+}
+
+toolchain_bbctiny = {
+	name = "bbctiny",
+	compiler = "bin/cowcom-65c02-tiny.nncgen.exe",
+	linker = "bin/cowlink-bbct.nncgen.exe",
+	assembler = buildtass64,
+	runtime = "rt/bbct",
+	asmext = ".asm",
+	binext = ".bbctiny",
+	tester = tubeemutest,
+	archs = {},
 }
 
 toolchain_bbct6502 = {
@@ -72,7 +85,8 @@ toolchain_bbct6502 = {
 	runtime = "rt/bbct",
 	asmext = ".asm",
 	binext = ".bbct6502",
-	tester = tubeemutest
+	tester = tubeemutest,
+	archs = {}
 }
 
 ALL_TOOLCHAINS = {
@@ -82,6 +96,7 @@ ALL_TOOLCHAINS = {
 	toolchain_ncpmz,
 	toolchain_lx386,
 	toolchain_bbct,
-	toolchain_bbct6502
+	toolchain_bbctiny,
+	toolchain_bbct6502,
 }
 

--- a/toolchains.lua
+++ b/toolchains.lua
@@ -92,8 +92,8 @@ toolchain_bbct6502 = {
 ALL_TOOLCHAINS = {
 	toolchain_nncgen,
 	toolchain_ncgen,
---	toolchain_ncpm,
---	toolchain_ncpmz,
+	toolchain_ncpm,
+	toolchain_ncpmz,
 	toolchain_lx386,
 	toolchain_bbct,
 	toolchain_bbctiny,

--- a/toolchains.lua
+++ b/toolchains.lua
@@ -92,8 +92,8 @@ toolchain_bbct6502 = {
 ALL_TOOLCHAINS = {
 	toolchain_nncgen,
 	toolchain_ncgen,
-	toolchain_ncpm,
-	toolchain_ncpmz,
+--	toolchain_ncpm,
+--	toolchain_ncpmz,
 	toolchain_lx386,
 	toolchain_bbct,
 	toolchain_bbctiny,


### PR DESCRIPTION
In an attempt to try and get a 6502 compiler small enough to fit on an actual 6502, I've added a variant which has all (or most) non-critical backend rules disabled and the memi and stacki registers omitted. This, plus a fair bit of byte shaving, gets the overall binary size down to about 56.5kB. This is still too big, but it's small enough to actually run. I compiled my first program!

There's also a huge slew of bugfixes, optimisations, better code throughout, and unfortunately some additional compiler complexity which kinda defeats the point, self-hosting-wise.

There are still some bugs to work out...