### PR TITLE
The --defines= flag is a GNU-ism, so we need to specify bison -y.

### DIFF
--- a/build/yacc.lua
+++ b/build/yacc.lua
@@ -2,7 +2,7 @@ function yacc(e)
 	rule {
 		ins = e.ins,
 		outs = e.outs,
-		cmd = "yacc -t -o &1 --defines=&2 @1"
+		cmd = "bison -y -t -o &1 --defines=&2 @1"
 	}
 end
 


### PR DESCRIPTION
Hello.

Berkeley Yacc does not have a --defines= flag. So we should specify bison.
This lets cowgol build and run on systems where yacc isn't bison; for example, OpenBSD (where cowgol has been tested and working).

Thanks!