### PR TITLE
Rework how loads and stores work to be more addressing-mode friendly

### DIFF
--- a/src/cowbe/arch6303.cow.ng
+++ b/src/cowbe/arch6303.cow.ng
@@ -676,34 +676,34 @@ gen RETURN()
 
 // --- Read operands --------------------------------------------------------
 
-gen mem := LOAD1(ADDRESS():a) cost 5
+gen mem := DEREF1(ADDRESS():a) cost 5
 {
 	var op := &self.n[0].operand;
 	op.mem.sym := &$a.sym;
 	op.mem.off := $a.off;
 }
 
-gen mem := LOAD2(ADDRESS():a) cost 5
+gen mem := DEREF2(ADDRESS():a) cost 5
 {
 	var op := &self.n[0].operand;
 	op.mem.sym := &$a.sym;
 	op.mem.off := $a.off;
 }
 
-gen mem := LOAD4(ADDRESS():a) cost 5
+gen mem := DEREF4(ADDRESS():a) cost 5
 {
 	var op := &self.n[0].operand;
 	op.mem.sym := &$a.sym;
 	op.mem.off := $a.off;
 }
 
-gen xind := LOAD1(ADD2(x, CONSTANT(value is byte):c)) cost 5
+gen xind := DEREF1(ADD2(x, CONSTANT(value is byte):c)) cost 5
 {
 	var op := &self.n[0].operand;
 	op.xind.off := $c.value as uint8;
 }
 
-gen xind := LOAD2(ADD2(x, CONSTANT(value is bytem1):c)) cost 5
+gen xind := DEREF2(ADD2(x, CONSTANT(value is bytem1):c)) cost 5
 {
 	var op := &self.n[0].operand;
 	op.xind.off := $c.value as uint8;
@@ -838,20 +838,20 @@ gen i4 := CONSTANT():c uses x
 
 // --- Stores (these don't use operands) ------------------------------------
 
-gen STORE1(a|b:lhs, x)
+gen STORE(a|b:lhs, DEREF1(x))
 {
 	E_st($lhs);
 	E(",x\n");
 }
 
-gen STORE1(a|b:lhs, ADD2(x, CONSTANT(value is byte):c))
+gen STORE(a|b:lhs, DEREF1(ADD2(x, CONSTANT(value is byte):c)))
 {
 	E_st($lhs);
 	E_u16($c.value as uint16);
 	E(",x\n");
 }
 
-gen STORE1(a|b:lhs, ADDRESS():a)
+gen STORE(a|b:lhs, DEREF1(ADDRESS():a))
 {
     var op: Operand;
     op.mem.sym := &$a.sym;
@@ -859,20 +859,20 @@ gen STORE1(a|b:lhs, ADDRESS():a)
     E_stop_c($lhs, REG_MEM, &op, 0, 0);
 }
 
-gen STORE2(x|d:lhs, x)
+gen STORE(x|d:lhs, DEREF2(x))
 {
 	E_st($lhs);
 	E(",x\n");
 }
 
-gen STORE2(x|d:lhs, ADD2(x, CONSTANT(value is bytem1):c))
+gen STORE(x|d:lhs, DEREF2(ADD2(x, CONSTANT(value is bytem1):c)))
 {
 	E_st($lhs);
 	E_u16($c.value as uint16);
 	E(",x\n");
 }
 
-gen STORE2(d:lhs, ADDRESS():a)
+gen STORE(d:lhs, DEREF2(ADDRESS():a))
 {
     var op: Operand;
     op.mem.sym := &$a.sym;
@@ -880,7 +880,7 @@ gen STORE2(d:lhs, ADDRESS():a)
     E_stop_c($lhs, REG_MEM, &op, 0, 0);
 }
 
-gen STORE4(i4|xd:lhs, ADDRESS():a) uses d
+gen STORE(i4|xd:lhs, DEREF4(ADDRESS():a)) uses d
 {
     var op: Operand;
     op.mem.sym := &$a.sym;
@@ -898,7 +898,7 @@ gen STORE4(i4|xd:lhs, ADDRESS():a) uses d
     end if;
 }
 
-gen STORE4(i4:lhs, x) uses d
+gen STORE(i4:lhs, DEREF4(x)) uses d
 {
     R_flush(REG_D);
     E_callhelper("_store4x");
@@ -906,13 +906,13 @@ gen STORE4(i4:lhs, x) uses d
 
 // --- Loads (these don't use operands) ----------------------------------
 
-gen a|b := LOAD1(x)
+gen a|b := DEREF1(x)
 {
 	E_ld($$);
 	E(",x\n");
 }
 
-gen a|b := LOAD1(ADDRESS():a)
+gen a|b := DEREF1(ADDRESS():a)
 {
     var op: Operand;
     op.mem.sym := &$a.sym;
@@ -920,20 +920,20 @@ gen a|b := LOAD1(ADDRESS():a)
     E_ldop_c($$, REG_MEM, &op, 0, 0);
 }
 
-gen a|b := LOAD1(ADD2(x, CONSTANT(value is byte):c))
+gen a|b := DEREF1(ADD2(x, CONSTANT(value is byte):c))
 {
 	E_ld($$);
 	E_u16($c.value as uint16);
 	E(",x\n");
 }
 
-gen x|d := LOAD2(x)
+gen x|d := DEREF2(x)
 {
 	E_ld($$);
 	E(",x\n");
 }
 
-gen x|d := LOAD2(ADDRESS():a)
+gen x|d := DEREF2(ADDRESS():a)
 {
     var op: Operand;
     op.mem.sym := &$a.sym;
@@ -941,14 +941,14 @@ gen x|d := LOAD2(ADDRESS():a)
     E_ldop_c($$, REG_MEM, &op, 0, 0);
 }
 
-gen x|d := LOAD2(ADD2(x, CONSTANT(value is bytem1):c))
+gen x|d := DEREF2(ADD2(x, CONSTANT(value is bytem1):c))
 {
 	E_ld($$);
 	E_u16($c.value as uint16);
 	E(",x\n");
 }
 
-gen xd := LOAD4(ADDRESS():a)
+gen xd := DEREF4(ADDRESS():a)
 {
     var op: Operand;
     op.mem.sym := &$a.sym;
@@ -959,7 +959,7 @@ gen xd := LOAD4(ADDRESS():a)
     E_ldop(REG_X, REG_MEM, &op, 0, 16);
 }
 
-gen i4 := LOAD4(ADDRESS():a) uses x
+gen i4 := DEREF4(ADDRESS():a) uses x
 {
     var op: Operand;
     op.mem.sym := &$a.sym;
@@ -972,14 +972,14 @@ gen i4 := LOAD4(ADDRESS():a) uses x
     E_push(REG_X);
 }
 
-gen xd := LOAD4(x)
+gen xd := DEREF4(x)
 {
     R_flush($$);
     E_insn_simple("ldd 2, x");
     E_insn_simple("ldx 0, x");
 }
 
-gen i4 := LOAD4(x) uses d
+gen i4 := DEREF4(x) uses d
 {
     R_flush(REG_D);
     E_callhelper("_load4x");
@@ -1064,7 +1064,7 @@ gen a|b := AND1($$:lhs, op|vs1:rhs) uses x { Alu1($$, $rhs, &$@rhs.operand, "and
 
 // This rule doesn't work, so disable it for now.
 //gen STORE1(
-//        ADD1(LOAD1(ADDRESS():a1), CONSTANT(value is inc_or_dec):c),
+//        ADD1(DEREF1(ADDRESS():a1), CONSTANT(value is inc_or_dec):c),
 //        ADDRESS():a2) uses a cost 100
 //{
 //    var op: Operand;

--- a/src/cowbe/arch6303.cow.ng
+++ b/src/cowbe/arch6303.cow.ng
@@ -838,20 +838,20 @@ gen i4 := CONSTANT():c uses x
 
 // --- Stores (these don't use operands) ------------------------------------
 
-gen STORE(a|b:lhs, DEREF1(x))
+gen STORE1(a|b:lhs, DEREF1(x))
 {
 	E_st($lhs);
 	E(",x\n");
 }
 
-gen STORE(a|b:lhs, DEREF1(ADD2(x, CONSTANT(value is byte):c)))
+gen STORE1(a|b:lhs, DEREF1(ADD2(x, CONSTANT(value is byte):c)))
 {
 	E_st($lhs);
 	E_u16($c.value as uint16);
 	E(",x\n");
 }
 
-gen STORE(a|b:lhs, DEREF1(ADDRESS():a))
+gen STORE1(a|b:lhs, DEREF1(ADDRESS():a))
 {
     var op: Operand;
     op.mem.sym := &$a.sym;
@@ -859,20 +859,20 @@ gen STORE(a|b:lhs, DEREF1(ADDRESS():a))
     E_stop_c($lhs, REG_MEM, &op, 0, 0);
 }
 
-gen STORE(x|d:lhs, DEREF2(x))
+gen STORE2(x|d:lhs, DEREF2(x))
 {
 	E_st($lhs);
 	E(",x\n");
 }
 
-gen STORE(x|d:lhs, DEREF2(ADD2(x, CONSTANT(value is bytem1):c)))
+gen STORE2(x|d:lhs, DEREF2(ADD2(x, CONSTANT(value is bytem1):c)))
 {
 	E_st($lhs);
 	E_u16($c.value as uint16);
 	E(",x\n");
 }
 
-gen STORE(d:lhs, DEREF2(ADDRESS():a))
+gen STORE2(d:lhs, DEREF2(ADDRESS():a))
 {
     var op: Operand;
     op.mem.sym := &$a.sym;
@@ -880,7 +880,7 @@ gen STORE(d:lhs, DEREF2(ADDRESS():a))
     E_stop_c($lhs, REG_MEM, &op, 0, 0);
 }
 
-gen STORE(i4|xd:lhs, DEREF4(ADDRESS():a)) uses d
+gen STORE4(i4|xd:lhs, DEREF4(ADDRESS():a)) uses d
 {
     var op: Operand;
     op.mem.sym := &$a.sym;
@@ -898,7 +898,7 @@ gen STORE(i4|xd:lhs, DEREF4(ADDRESS():a)) uses d
     end if;
 }
 
-gen STORE(i4:lhs, DEREF4(x)) uses d
+gen STORE4(i4:lhs, DEREF4(x)) uses d
 {
     R_flush(REG_D);
     E_callhelper("_store4x");

--- a/src/cowbe/arch6502.cow.ng
+++ b/src/cowbe/arch6502.cow.ng
@@ -1367,7 +1367,7 @@ gen xa := POPARG2(remaining==0);
 gen xa := POPARG2(remaining!=0) { E_plxa(); }
 
 gen v32 := POPARG4()               uses x|y|a { PopArg4(PushV32()); }
-gen STORE(POPARG4(), DEREF4(ptrs)) uses x|y|a { PopArg4(PopAndDerefOp()); }
+gen STORE4(POPARG4(), DEREF4(ptrs)) uses x|y|a { PopArg4(PopAndDerefOp()); }
 
 // --- 8-bit -----------------------------------------------------------------
 
@@ -1390,14 +1390,14 @@ gen a|x|y := CONSTANT():c
     E_loadconst($$, $c.value as uint8);
 }
 
-gen STORE(a:lhs, DEREF1(ptrs)) uses y
+gen STORE1(a:lhs, DEREF1(ptrs)) uses y
 {
     var op := PopAndDerefOp();
 
     DoParamDirect_sta(op, 0);
 }
 
-gen STORE(a|x|y:lhs, DEREF1(ADDRESS():a))
+gen STORE1(a|x|y:lhs, DEREF1(ADDRESS():a))
 {
     E_st($lhs);
     E_symref(&$a.sym, $a.off);
@@ -1511,7 +1511,7 @@ gen xa := SUBREF():a
     E_loadsubref($a.subr);
 }
 
-gen STORE(xa, DEREF2(ADDRESS():a))
+gen STORE2(xa, DEREF2(ADDRESS():a))
 {
     E_sta();
     E_symref(&$a.sym, $a.off);
@@ -1523,7 +1523,7 @@ gen STORE(xa, DEREF2(ADDRESS():a))
     RegCacheLeavesValue(REG_XA, &$a.sym, $a.off);
 }
 
-gen STORE(xa, DEREF2(ptrs)) uses y
+gen STORE2(xa, DEREF2(ptrs)) uses y
 {
     var op := PopAndDerefOp();
 
@@ -1659,7 +1659,7 @@ gen xa := REMS2(xa, in2s) uses y { Rem2("_divs2r"); }
     end sub;
 %}
 
-gen STORE(in4s, DEREF4(ptrs)) uses a|x|y
+gen STORE4(in4s, DEREF4(ptrs)) uses a|x|y
 {
     var dest := PopAndDerefOp();
     var lhs := PopOp();
@@ -1704,8 +1704,8 @@ gen v32 := DEREF4(ptrs) uses a|x|y
 
 gen v32 := NEG4(in4s) uses a|x|y { var lhs := PopOp(); var dest := PushV32(); Do2Op4_neg(lhs, dest); }
 gen v32 := NOT4(in4s) uses a|x|y { var lhs := PopOp(); var dest := PushV32(); Do2Op4_not(lhs, dest); }
-gen STORE(NEG4(in4s), DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var lhs := PopOp(); Do2Op4_neg(lhs, dest); }
-gen STORE(NOT4(in4s), DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var lhs := PopOp(); Do2Op4_not(lhs, dest); }
+gen STORE4(NEG4(in4s), DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var lhs := PopOp(); Do2Op4_neg(lhs, dest); }
+gen STORE4(NOT4(in4s), DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var lhs := PopOp(); Do2Op4_not(lhs, dest); }
 
 %{
     sub Do3Op4(oc: uint8, lhs: [MOperand], rhs: [MOperand], dest: [MOperand]) is
@@ -1743,11 +1743,11 @@ gen v32 := SUB4(in4s, in4s) uses a|x|y { var rhs := PopOp(); var lhs := PopOp();
 gen v32 := AND4(in4s, in4s) uses a|x|y { var rhs := PopOp(); var lhs := PopOp(); var dest := PushV32();          Do3Op4(OC_AND, lhs, rhs, dest); }
 gen v32 := OR4(in4s, in4s)  uses a|x|y { var rhs := PopOp(); var lhs := PopOp(); var dest := PushV32();          Do3Op4(OC_ORA, lhs, rhs, dest); }
 gen v32 := EOR4(in4s, in4s) uses a|x|y { var rhs := PopOp(); var lhs := PopOp(); var dest := PushV32();          Do3Op4(OC_EOR, lhs, rhs, dest); }
-gen STORE(ADD4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp(); E_clc(); Do3Op4(OC_ADC, lhs, rhs, dest); }
-gen STORE(SUB4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp(); E_sec(); Do3Op4(OC_SBC, lhs, rhs, dest); }
-gen STORE(AND4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp();          Do3Op4(OC_AND, lhs, rhs, dest); }
-gen STORE(OR4(in4s, in4s) , DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp();          Do3Op4(OC_ORA, lhs, rhs, dest); }
-gen STORE(EOR4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp();          Do3Op4(OC_EOR, lhs, rhs, dest); }
+gen STORE4(ADD4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp(); E_clc(); Do3Op4(OC_ADC, lhs, rhs, dest); }
+gen STORE4(SUB4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp(); E_sec(); Do3Op4(OC_SBC, lhs, rhs, dest); }
+gen STORE4(AND4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp();          Do3Op4(OC_AND, lhs, rhs, dest); }
+gen STORE4(OR4(in4s, in4s) , DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp();          Do3Op4(OC_ORA, lhs, rhs, dest); }
+gen STORE4(EOR4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp();          Do3Op4(OC_EOR, lhs, rhs, dest); }
 
 %{
     sub MulOrDivOrRem4(name: string, resultoffset: uint8, lhs: [MOperand], rhs: [MOperand], dest: [MOperand]) is
@@ -1804,11 +1804,11 @@ gen v32 := DIVU4(in4s, in4s) uses a|x|y { MulOrDivOrRem4ToV32("_divu4", 0); }
 gen v32 := REMU4(in4s, in4s) uses a|x|y { MulOrDivOrRem4ToV32("_divu4", 4); }
 gen v32 := DIVS4(in4s, in4s) uses a|x|y { MulOrDivOrRem4ToV32("_divs4", 0); }
 gen v32 := REMS4(in4s, in4s) uses a|x|y { MulOrDivOrRem4ToV32("_divs4", 4); }
-gen STORE(MUL4(in4s, in4s),  DEREF4(ptrs)) uses a|x|y { MulOrDivOrRem4ToDest("_mul4", 0); }
-gen STORE(DIVU4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { MulOrDivOrRem4ToDest("_divu4", 0); }
-gen STORE(REMU4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { MulOrDivOrRem4ToDest("_divu4", 4); }
-gen STORE(DIVS4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { MulOrDivOrRem4ToDest("_divs4", 0); }
-gen STORE(REMS4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { MulOrDivOrRem4ToDest("_divs4", 4); }
+gen STORE4(MUL4(in4s, in4s),  DEREF4(ptrs)) uses a|x|y { MulOrDivOrRem4ToDest("_mul4", 0); }
+gen STORE4(DIVU4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { MulOrDivOrRem4ToDest("_divu4", 0); }
+gen STORE4(REMU4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { MulOrDivOrRem4ToDest("_divu4", 4); }
+gen STORE4(DIVS4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { MulOrDivOrRem4ToDest("_divs4", 0); }
+gen STORE4(REMS4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { MulOrDivOrRem4ToDest("_divs4", 4); }
 
 %{
     sub Shift4(helper: string) is
@@ -1998,7 +1998,7 @@ gen xa := CAST12(a):c uses y
 %}
 
 gen v32 := CAST14(a):c               uses y { var dest := PushV32();       Cast14(dest, $c.sext); }
-gen STORE(CAST14(a):c, DEREF4(ptrs)) uses y { var dest := PopAndDerefOp(); Cast14(dest, $c.sext); }
+gen STORE4(CAST14(a):c, DEREF4(ptrs)) uses y { var dest := PopAndDerefOp(); Cast14(dest, $c.sext); }
 
 %{
     sub Cast24(dest: [MOperand], sext: uint8) is
@@ -2023,7 +2023,7 @@ gen STORE(CAST14(a):c, DEREF4(ptrs)) uses y { var dest := PopAndDerefOp(); Cast1
 %}
 
 gen v32 := CAST24(xa):c               uses y { var dest := PushV32();       Cast24(dest, $c.sext); }
-gen STORE(CAST24(xa):c, DEREF4(ptrs)) uses y { var dest := PopAndDerefOp(); Cast24(dest, $c.sext); }
+gen STORE4(CAST24(xa):c, DEREF4(ptrs)) uses y { var dest := PopAndDerefOp(); Cast24(dest, $c.sext); }
 
 gen a := CAST21(in2s|xa:rhs)
 {
@@ -2252,21 +2252,21 @@ $ifdef ARCH_65C02
     // The 65C02 can store zero to a memory location without needing to use
     // a register. It's kinda limited when it comes to addressing modes.
 
-    gen STORE(CONSTANT(value==0), DEREF1(ADDRESS():a))
+    gen STORE1(CONSTANT(value==0), DEREF1(ADDRESS():a))
     {
         E_stz();
         E_symref(&$a.sym, $a.off);
         E_nl();
     }
 
-    gen STORE(CONSTANT(value==0), DEREF1(ADD2(ADDRESS():a, CAST12(x, sext==0))))
+    gen STORE1(CONSTANT(value==0), DEREF1(ADD2(ADDRESS():a, CAST12(x, sext==0))))
     {
         E_stz();
         E_symref(&$a.sym, $a.off);
         E_x_nl();
     }
 
-    gen STORE(CONSTANT(value==0), DEREF2(ADDRESS():a))
+    gen STORE2(CONSTANT(value==0), DEREF2(ADDRESS():a))
     {
         E_stz();
         E_symref(&$a.sym, $a.off);
@@ -2302,21 +2302,21 @@ $endif
 // The (zp),y addressing mode gives us a free addition to the pointer when
 // dereferencing.
 
-gen STORE(a, DEREF1(ADD2(ptrs, CONSTANT(value>=0, value<=255):c))) uses y
+gen STORE1(a, DEREF1(ADD2(ptrs, CONSTANT(value>=0, value<=255):c))) uses y
 {
     var dest := PopAndDerefOp();
     E_loadconst(REG_Y, $c.value as uint8);
     DoParamIndirect_sta(dest);
 }
 
-gen STORE(a, DEREF1(ADD2(ADDRESS():a, CAST12(x, sext==0))))
+gen STORE1(a, DEREF1(ADD2(ADDRESS():a, CAST12(x, sext==0))))
 {
     E_sta();
     E_symref(&$a.sym, $a.off);
     E_x_nl();
 }
 
-gen STORE(a, DEREF1(ADD2(ptrs, CAST12(y, sext==0))))
+gen STORE1(a, DEREF1(ADD2(ptrs, CAST12(y, sext==0))))
 {
     var dest := PopAndDerefOp();
     DoParamIndirect_sta(dest);
@@ -2342,7 +2342,7 @@ gen a := DEREF1(ADD2(ptrs, CAST12(y, sext==0)))
     DoParamIndirect_lda(src);
 }
 
-gen STORE(xa, DEREF2(ADD2(ptrs, CONSTANT(value>=0, value<=254):c))) uses y
+gen STORE2(xa, DEREF2(ADD2(ptrs, CONSTANT(value>=0, value<=254):c))) uses y
 {
     var dest := PopAndDerefOp();
 
@@ -2404,7 +2404,7 @@ gen a := DEREF1(DEREF2(ADDRESS(&sym is zp):a)) uses y
     end sub;
 %}
 
-gen STORE(
+gen STORE1(
         ADD1(DEREF1(ADDRESS():a1), CONSTANT(value is inc_or_dec):c),
         DEREF1(ADDRESS():a2)) uses x cost 100
 {
@@ -2434,7 +2434,7 @@ gen STORE(
     end if;
 }
 
-gen STORE(
+gen STORE2(
         ADD2(DEREF2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c),
         DEREF2(ADDRESS():a2)) uses x|y|a cost 100
 {

--- a/src/cowbe/arch6502.cow.ng
+++ b/src/cowbe/arch6502.cow.ng
@@ -959,17 +959,17 @@ gen JUMP():j
 
 gen const := CONSTANT():c                        { var op := PushConstOp($c.value); }
 gen address := ADDRESS():a                       { var op := PushAddressOp(&$a.sym, $a.off); }
-gen mem1 := LOAD1(ADDRESS():a)                   { var op := PushSymOp(&$a.sym, $a.off); }
-gen mem2 := LOAD2(ADDRESS():a)                   { var op := PushSymOp(&$a.sym, $a.off); }
-gen mem2p := LOAD2(ADDRESS(&sym is zp):a)         { var op := PushSymOp(&$a.sym, $a.off); }
-gen mem4 := LOAD4(ADDRESS():a)                   { var op := PushSymOp(&$a.sym, $a.off); }
+gen mem1 := DEREF1(ADDRESS():a)                   { var op := PushSymOp(&$a.sym, $a.off); }
+gen mem2 := DEREF2(ADDRESS():a)                   { var op := PushSymOp(&$a.sym, $a.off); }
+gen mem2p := DEREF2(ADDRESS(&sym is zp):a)         { var op := PushSymOp(&$a.sym, $a.off); }
+gen mem4 := DEREF4(ADDRESS():a)                   { var op := PushSymOp(&$a.sym, $a.off); }
 $ifndef TINY
-    gen memi1 := LOAD1(LOAD2(ADDRESS(&sym is zp):a))  { var op := PushSymIOp(&$a.sym, $a.off); }
-    gen memi2 := LOAD2(LOAD2(ADDRESS(&sym is zp):a))  { var op := PushSymIOp(&$a.sym, $a.off); }
-    gen memi4 := LOAD4(LOAD2(ADDRESS(&sym is zp):a))  { var op := PushSymIOp(&$a.sym, $a.off); }
-    gen stacki1 := LOAD1(p16)                        { var op := PeekOp(); op.mode := MODE_STACKI; }
-    gen stacki2 := LOAD2(p16)                        { var op := PeekOp(); op.mode := MODE_STACKI; }
-    gen stacki4 := LOAD4(p16)                        { var op := PeekOp(); op.mode := MODE_STACKI; }
+    gen memi1 := DEREF1(DEREF2(ADDRESS(&sym is zp):a))  { var op := PushSymIOp(&$a.sym, $a.off); }
+    gen memi2 := DEREF2(DEREF2(ADDRESS(&sym is zp):a))  { var op := PushSymIOp(&$a.sym, $a.off); }
+    gen memi4 := DEREF4(DEREF2(ADDRESS(&sym is zp):a))  { var op := PushSymIOp(&$a.sym, $a.off); }
+    gen stacki1 := DEREF1(p16)                        { var op := PeekOp(); op.mode := MODE_STACKI; }
+    gen stacki2 := DEREF2(p16)                        { var op := PeekOp(); op.mode := MODE_STACKI; }
+    gen stacki4 := DEREF4(p16)                        { var op := PeekOp(); op.mode := MODE_STACKI; }
 $endif
 
 // ==========================================================================
@@ -1366,8 +1366,8 @@ gen xa := POPARG2(remaining==0);
 
 gen xa := POPARG2(remaining!=0) { E_plxa(); }
 
-gen v32 := POPARG4()        uses x|y|a { PopArg4(PushV32()); }
-gen STORE4(POPARG4(), ptrs) uses x|y|a { PopArg4(PopAndDerefOp()); }
+gen v32 := POPARG4()               uses x|y|a { PopArg4(PushV32()); }
+gen STORE(POPARG4(), DEREF4(ptrs)) uses x|y|a { PopArg4(PopAndDerefOp()); }
 
 // --- 8-bit -----------------------------------------------------------------
 
@@ -1390,14 +1390,14 @@ gen a|x|y := CONSTANT():c
     E_loadconst($$, $c.value as uint8);
 }
 
-gen STORE1(a:lhs, ptrs) uses y
+gen STORE(a:lhs, DEREF1(ptrs)) uses y
 {
     var op := PopAndDerefOp();
 
     DoParamDirect_sta(op, 0);
 }
 
-gen STORE1(a|x|y:lhs, ADDRESS():a)
+gen STORE(a|x|y:lhs, DEREF1(ADDRESS():a))
 {
     E_st($lhs);
     E_symref(&$a.sym, $a.off);
@@ -1405,7 +1405,7 @@ gen STORE1(a|x|y:lhs, ADDRESS():a)
     RegCacheLeavesValue($lhs, &$a.sym, $a.off);
 }
 
-gen a|x|y := LOAD1(ADDRESS():a)
+gen a|x|y := DEREF1(ADDRESS():a)
 {
     var cache := RegCacheFindValue(&$a.sym, $a.off) & $$;
     if cache == 0 then
@@ -1416,7 +1416,7 @@ gen a|x|y := LOAD1(ADDRESS():a)
     end if;
 }
 
-gen a := LOAD1(ptrs) uses y
+gen a := DEREF1(ptrs) uses y
 {
     var op := PopAndDerefOp();
 
@@ -1471,7 +1471,7 @@ gen xa := FALLBACK(a16) uses y cost -1000
     DoParamDirect(op, OC_LDX, 1);
 }
 
-gen xa := LOAD2(ADDRESS():a)
+gen xa := DEREF2(ADDRESS():a)
 {
     var cache := RegCacheFindValue(&$a.sym, $a.off);
     if cache != REG_XA then
@@ -1486,7 +1486,7 @@ gen xa := LOAD2(ADDRESS():a)
     RegCacheLeavesValue(REG_XA, &$a.sym, $a.off);
 }
 
-gen xa := LOAD2(ptrs)
+gen xa := DEREF2(ptrs)
 {
     var ptr := PopAndDerefOp();
 
@@ -1511,7 +1511,7 @@ gen xa := SUBREF():a
     E_loadsubref($a.subr);
 }
 
-gen STORE2(xa, ADDRESS():a)
+gen STORE(xa, DEREF2(ADDRESS():a))
 {
     E_sta();
     E_symref(&$a.sym, $a.off);
@@ -1523,7 +1523,7 @@ gen STORE2(xa, ADDRESS():a)
     RegCacheLeavesValue(REG_XA, &$a.sym, $a.off);
 }
 
-gen STORE2(xa, ptrs) uses y
+gen STORE(xa, DEREF2(ptrs)) uses y
 {
     var op := PopAndDerefOp();
 
@@ -1659,14 +1659,14 @@ gen xa := REMS2(xa, in2s) uses y { Rem2("_divs2r"); }
     end sub;
 %}
 
-gen STORE4(in4s, ptrs) uses a|x|y
+gen STORE(in4s, DEREF4(ptrs)) uses a|x|y
 {
     var dest := PopAndDerefOp();
     var lhs := PopOp();
     DoCopy4(dest, lhs);
 }
 
-gen v32 := LOAD4(ptrs) uses a|x|y
+gen v32 := DEREF4(ptrs) uses a|x|y
 {
     var lhs := PopAndDerefOp();
     var dest := PushV32();
@@ -1704,8 +1704,8 @@ gen v32 := LOAD4(ptrs) uses a|x|y
 
 gen v32 := NEG4(in4s) uses a|x|y { var lhs := PopOp(); var dest := PushV32(); Do2Op4_neg(lhs, dest); }
 gen v32 := NOT4(in4s) uses a|x|y { var lhs := PopOp(); var dest := PushV32(); Do2Op4_not(lhs, dest); }
-gen STORE4(NEG4(in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var lhs := PopOp(); Do2Op4_neg(lhs, dest); }
-gen STORE4(NOT4(in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var lhs := PopOp(); Do2Op4_not(lhs, dest); }
+gen STORE(NEG4(in4s), DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var lhs := PopOp(); Do2Op4_neg(lhs, dest); }
+gen STORE(NOT4(in4s), DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var lhs := PopOp(); Do2Op4_not(lhs, dest); }
 
 %{
     sub Do3Op4(oc: uint8, lhs: [MOperand], rhs: [MOperand], dest: [MOperand]) is
@@ -1743,11 +1743,11 @@ gen v32 := SUB4(in4s, in4s) uses a|x|y { var rhs := PopOp(); var lhs := PopOp();
 gen v32 := AND4(in4s, in4s) uses a|x|y { var rhs := PopOp(); var lhs := PopOp(); var dest := PushV32();          Do3Op4(OC_AND, lhs, rhs, dest); }
 gen v32 := OR4(in4s, in4s)  uses a|x|y { var rhs := PopOp(); var lhs := PopOp(); var dest := PushV32();          Do3Op4(OC_ORA, lhs, rhs, dest); }
 gen v32 := EOR4(in4s, in4s) uses a|x|y { var rhs := PopOp(); var lhs := PopOp(); var dest := PushV32();          Do3Op4(OC_EOR, lhs, rhs, dest); }
-gen STORE4(ADD4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp(); E_clc(); Do3Op4(OC_ADC, lhs, rhs, dest); }
-gen STORE4(SUB4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp(); E_sec(); Do3Op4(OC_SBC, lhs, rhs, dest); }
-gen STORE4(AND4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp();          Do3Op4(OC_AND, lhs, rhs, dest); }
-gen STORE4(OR4(in4s, in4s) , ptrs) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp();          Do3Op4(OC_ORA, lhs, rhs, dest); }
-gen STORE4(EOR4(in4s, in4s), ptrs) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp();          Do3Op4(OC_EOR, lhs, rhs, dest); }
+gen STORE(ADD4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp(); E_clc(); Do3Op4(OC_ADC, lhs, rhs, dest); }
+gen STORE(SUB4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp(); E_sec(); Do3Op4(OC_SBC, lhs, rhs, dest); }
+gen STORE(AND4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp();          Do3Op4(OC_AND, lhs, rhs, dest); }
+gen STORE(OR4(in4s, in4s) , DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp();          Do3Op4(OC_ORA, lhs, rhs, dest); }
+gen STORE(EOR4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { var dest := PopAndDerefOp(); var rhs := PopOp(); var lhs := PopOp();          Do3Op4(OC_EOR, lhs, rhs, dest); }
 
 %{
     sub MulOrDivOrRem4(name: string, resultoffset: uint8, lhs: [MOperand], rhs: [MOperand], dest: [MOperand]) is
@@ -1804,11 +1804,11 @@ gen v32 := DIVU4(in4s, in4s) uses a|x|y { MulOrDivOrRem4ToV32("_divu4", 0); }
 gen v32 := REMU4(in4s, in4s) uses a|x|y { MulOrDivOrRem4ToV32("_divu4", 4); }
 gen v32 := DIVS4(in4s, in4s) uses a|x|y { MulOrDivOrRem4ToV32("_divs4", 0); }
 gen v32 := REMS4(in4s, in4s) uses a|x|y { MulOrDivOrRem4ToV32("_divs4", 4); }
-gen STORE4(MUL4(in4s, in4s), ptrs) uses a|x|y { MulOrDivOrRem4ToDest("_mul4", 0); }
-gen STORE4(DIVU4(in4s, in4s), ptrs) uses a|x|y { MulOrDivOrRem4ToDest("_divu4", 0); }
-gen STORE4(REMU4(in4s, in4s), ptrs) uses a|x|y { MulOrDivOrRem4ToDest("_divu4", 4); }
-gen STORE4(DIVS4(in4s, in4s), ptrs) uses a|x|y { MulOrDivOrRem4ToDest("_divs4", 0); }
-gen STORE4(REMS4(in4s, in4s), ptrs) uses a|x|y { MulOrDivOrRem4ToDest("_divs4", 4); }
+gen STORE(MUL4(in4s, in4s),  DEREF4(ptrs)) uses a|x|y { MulOrDivOrRem4ToDest("_mul4", 0); }
+gen STORE(DIVU4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { MulOrDivOrRem4ToDest("_divu4", 0); }
+gen STORE(REMU4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { MulOrDivOrRem4ToDest("_divu4", 4); }
+gen STORE(DIVS4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { MulOrDivOrRem4ToDest("_divs4", 0); }
+gen STORE(REMS4(in4s, in4s), DEREF4(ptrs)) uses a|x|y { MulOrDivOrRem4ToDest("_divs4", 4); }
 
 %{
     sub Shift4(helper: string) is
@@ -1997,8 +1997,8 @@ gen xa := CAST12(a):c uses y
     end sub;
 %}
 
-gen v32 := CAST14(a):c        uses y { var dest := PushV32();       Cast14(dest, $c.sext); }
-gen STORE4(CAST14(a):c, ptrs) uses y { var dest := PopAndDerefOp(); Cast14(dest, $c.sext); }
+gen v32 := CAST14(a):c               uses y { var dest := PushV32();       Cast14(dest, $c.sext); }
+gen STORE(CAST14(a):c, DEREF4(ptrs)) uses y { var dest := PopAndDerefOp(); Cast14(dest, $c.sext); }
 
 %{
     sub Cast24(dest: [MOperand], sext: uint8) is
@@ -2022,8 +2022,8 @@ gen STORE4(CAST14(a):c, ptrs) uses y { var dest := PopAndDerefOp(); Cast14(dest,
     end sub;
 %}
 
-gen v32 := CAST24(xa):c        uses y { var dest := PushV32();       Cast24(dest, $c.sext); }
-gen STORE4(CAST24(xa):c, ptrs) uses y { var dest := PopAndDerefOp(); Cast24(dest, $c.sext); }
+gen v32 := CAST24(xa):c               uses y { var dest := PushV32();       Cast24(dest, $c.sext); }
+gen STORE(CAST24(xa):c, DEREF4(ptrs)) uses y { var dest := PopAndDerefOp(); Cast24(dest, $c.sext); }
 
 gen a := CAST21(in2s|xa:rhs)
 {
@@ -2252,21 +2252,21 @@ $ifdef ARCH_65C02
     // The 65C02 can store zero to a memory location without needing to use
     // a register. It's kinda limited when it comes to addressing modes.
 
-    gen STORE1(CONSTANT(value==0), ADDRESS():a)
+    gen STORE(CONSTANT(value==0), DEREF1(ADDRESS():a))
     {
         E_stz();
         E_symref(&$a.sym, $a.off);
         E_nl();
     }
 
-    gen STORE1(CONSTANT(value==0), ADD2(ADDRESS():a, CAST12(x, sext==0)))
+    gen STORE(CONSTANT(value==0), DEREF1(ADD2(ADDRESS():a, CAST12(x, sext==0))))
     {
         E_stz();
         E_symref(&$a.sym, $a.off);
         E_x_nl();
     }
 
-    gen STORE2(CONSTANT(value==0), ADDRESS():a)
+    gen STORE(CONSTANT(value==0), DEREF2(ADDRESS():a))
     {
         E_stz();
         E_symref(&$a.sym, $a.off);
@@ -2302,47 +2302,47 @@ $endif
 // The (zp),y addressing mode gives us a free addition to the pointer when
 // dereferencing.
 
-gen STORE1(a, ADD2(ptrs, CONSTANT(value>=0, value<=255):c)) uses y
+gen STORE(a, DEREF1(ADD2(ptrs, CONSTANT(value>=0, value<=255):c))) uses y
 {
     var dest := PopAndDerefOp();
     E_loadconst(REG_Y, $c.value as uint8);
     DoParamIndirect_sta(dest);
 }
 
-gen STORE1(a, ADD2(ADDRESS():a, CAST12(x, sext==0)))
+gen STORE(a, DEREF1(ADD2(ADDRESS():a, CAST12(x, sext==0))))
 {
     E_sta();
     E_symref(&$a.sym, $a.off);
     E_x_nl();
 }
 
-gen STORE1(a, ADD2(ptrs, CAST12(y, sext==0)))
+gen STORE(a, DEREF1(ADD2(ptrs, CAST12(y, sext==0))))
 {
     var dest := PopAndDerefOp();
     DoParamIndirect_sta(dest);
 }
 
-gen a := LOAD1(ADD2(ptrs, CONSTANT(value>=0, value<=255):c)) uses y
+gen a := DEREF1(ADD2(ptrs, CONSTANT(value>=0, value<=255):c)) uses y
 {
     var src := PopAndDerefOp();
     E_loadconst(REG_Y, $c.value as uint8);
     DoParamIndirect_lda(src);
 }
 
-gen a := LOAD1(ADD2(ADDRESS():a, CAST12(x, sext==0)))
+gen a := DEREF1(ADD2(ADDRESS():a, CAST12(x, sext==0)))
 {
     E_lda();
     E_symref(&$a.sym, $a.off);
     E_x_nl();
 }
 
-gen a := LOAD1(ADD2(ptrs, CAST12(y, sext==0)))
+gen a := DEREF1(ADD2(ptrs, CAST12(y, sext==0)))
 {
     var src := PopAndDerefOp();
     DoParamIndirect_lda(src);
 }
 
-gen STORE2(xa, ADD2(ptrs, CONSTANT(value>=0, value<=254):c)) uses y
+gen STORE(xa, DEREF2(ADD2(ptrs, CONSTANT(value>=0, value<=254):c))) uses y
 {
     var dest := PopAndDerefOp();
 
@@ -2352,7 +2352,7 @@ gen STORE2(xa, ADD2(ptrs, CONSTANT(value>=0, value<=254):c)) uses y
     DoParamDirect_sta(dest, off+1);
 }
 
-gen xa := LOAD2(ADD2(ptrs, CONSTANT(value>=0, value<=254):c)) uses y
+gen xa := DEREF2(ADD2(ptrs, CONSTANT(value>=0, value<=254):c)) uses y
 {
     var src := PopAndDerefOp();
 
@@ -2362,7 +2362,7 @@ gen xa := LOAD2(ADD2(ptrs, CONSTANT(value>=0, value<=254):c)) uses y
     DoParamDirect_lda(src, off);
 }
 
-gen xa := LOAD2(ADD2(ADDRESS():a, CAST12(y, sext==0)))
+gen xa := DEREF2(ADD2(ADDRESS():a, CAST12(y, sext==0)))
 {
     E_lda();
     E_symref(&$a.sym, $a.off+0);
@@ -2373,7 +2373,7 @@ gen xa := LOAD2(ADD2(ADDRESS():a, CAST12(y, sext==0)))
     E_y_nl();
 }
 
-gen a := LOAD1(LOAD2(ADDRESS(&sym is zp):a)) uses y
+gen a := DEREF1(DEREF2(ADDRESS(&sym is zp):a)) uses y
 {
     $ifndef ARCH_65C02
         E_loadconst(REG_Y, 0);
@@ -2404,9 +2404,9 @@ gen a := LOAD1(LOAD2(ADDRESS(&sym is zp):a)) uses y
     end sub;
 %}
 
-gen STORE1(
-        ADD1(LOAD1(ADDRESS():a1), CONSTANT(value is inc_or_dec):c),
-        ADDRESS():a2) uses x cost 100
+gen STORE(
+        ADD1(DEREF1(ADDRESS():a1), CONSTANT(value is inc_or_dec):c),
+        DEREF1(ADDRESS():a2)) uses x cost 100
 {
     if ($a1.sym.subr == $a2.sym.subr) and ($a1.sym.wsid == $a2.sym.wsid) and ($a1.sym.off == $a2.sym.off)
             and ($a1.off == $a2.off) then
@@ -2434,9 +2434,9 @@ gen STORE1(
     end if;
 }
 
-gen STORE2(
-        ADD2(LOAD2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c),
-        ADDRESS():a2) uses x|y|a cost 100
+gen STORE(
+        ADD2(DEREF2(ADDRESS():a1), CONSTANT(value is inc_or_dec):c),
+        DEREF2(ADDRESS():a2)) uses x|y|a cost 100
 {
     var lid := AllocPLabel();
     if ($a1.sym.subr == $a2.sym.subr) and ($a1.sym.wsid == $a2.sym.wsid) and ($a1.sym.off == $a2.sym.off)
@@ -2542,7 +2542,7 @@ gen BEQ2(xa, CONSTANT(value==0)):b uses a|y
     E_jumps_beq_bne(self.n[0]);
 }
 
-gen BEQ2(LOAD2(ADDRESS():a), CONSTANT(value==0)):b uses a
+gen BEQ2(DEREF2(ADDRESS():a), CONSTANT(value==0)):b uses a
 {
     E_lda();
     E_symref(&$a.sym, $a.off);

--- a/src/cowbe/arch6502i.cow.ng
+++ b/src/cowbe/arch6502i.cow.ng
@@ -340,29 +340,29 @@ gen s2 := SUBREF():a
 
 // --- Loads and stores -----------------------------------------------------
 
-gen STORE1(s1, ADDRESS():a)  { E_store1(&$a.sym, $a.off); }
-gen STORE2(s2, ADDRESS():a) { E_store2(&$a.sym, $a.off); }
-gen STORE4(s4, ADDRESS():a) { E_store4(&$a.sym, $a.off); }
+gen STORE(s1, DEREF1(ADDRESS():a))  { E_store1(&$a.sym, $a.off); }
+gen STORE(s2, DEREF2(ADDRESS():a)) { E_store2(&$a.sym, $a.off); }
+gen STORE(s4, DEREF4(ADDRESS():a)) { E_store4(&$a.sym, $a.off); }
 
-gen s1 := LOAD1(ADDRESS():a)  { E_load1(&$a.sym, $a.off); }
-gen s2 := LOAD2(ADDRESS():a) { E_load2(&$a.sym, $a.off); }
-gen s4 := LOAD4(ADDRESS():a) { E_load4(&$a.sym, $a.off); }
+gen s1 := DEREF1(ADDRESS():a)  { E_load1(&$a.sym, $a.off); }
+gen s2 := DEREF2(ADDRESS():a) { E_load2(&$a.sym, $a.off); }
+gen s4 := DEREF4(ADDRESS():a) { E_load4(&$a.sym, $a.off); }
 
-gen STORE1(s1, s2) { E_callhelper("store1"); }
-gen STORE2(s2, s2) { E_callhelper("store2"); }
-gen STORE4(s4, s2) { E_callhelper("store4"); }
+gen STORE(s1, DEREF1(s2)) { E_callhelper("store1"); }
+gen STORE(s2, DEREF2(s2)) { E_callhelper("store2"); }
+gen STORE(s4, DEREF4(s2)) { E_callhelper("store4"); }
 
-gen STORE1(s1, ADD2(s2, CONSTANT():c)) { E_callhelper("store1x"); E_dw(); E_u16($c.value as uint16); E_nl(); }
-gen STORE2(s2, ADD2(s2, CONSTANT():c)) { E_callhelper("store2x"); E_dw(); E_u16($c.value as uint16); E_nl(); }
-gen STORE4(s4, ADD2(s2, CONSTANT():c)) { E_callhelper("store4x"); E_dw(); E_u16($c.value as uint16); E_nl(); }
+gen STORE(s1, DEREF1(ADD2(s2, CONSTANT():c))) { E_callhelper("store1x"); E_dw(); E_u16($c.value as uint16); E_nl(); }
+gen STORE(s2, DEREF2(ADD2(s2, CONSTANT():c))) { E_callhelper("store2x"); E_dw(); E_u16($c.value as uint16); E_nl(); }
+gen STORE(s4, DEREF4(ADD2(s2, CONSTANT():c))) { E_callhelper("store4x"); E_dw(); E_u16($c.value as uint16); E_nl(); }
 
-gen s1 := LOAD1(s2) { E_callhelper("load1"); }
-gen s2 := LOAD2(s2) { E_callhelper("load2"); }
-gen s4 := LOAD4(s2) { E_callhelper("load4"); }
+gen s1 := DEREF1(s2) { E_callhelper("load1"); }
+gen s2 := DEREF2(s2) { E_callhelper("load2"); }
+gen s4 := DEREF4(s2) { E_callhelper("load4"); }
 
-gen s1 := LOAD1(ADD2(s2, CONSTANT():c)) { E_callhelper("load1x"); E_dw(); E_u16($c.value as uint16); E_nl(); }
-gen s2 := LOAD2(ADD2(s2, CONSTANT():c)) { E_callhelper("load2x"); E_dw(); E_u16($c.value as uint16); E_nl(); }
-gen s4 := LOAD4(ADD2(s2, CONSTANT():c)) { E_callhelper("load4x"); E_dw(); E_u16($c.value as uint16); E_nl(); }
+gen s1 := DEREF1(ADD2(s2, CONSTANT():c)) { E_callhelper("load1x"); E_dw(); E_u16($c.value as uint16); E_nl(); }
+gen s2 := DEREF2(ADD2(s2, CONSTANT():c)) { E_callhelper("load2x"); E_dw(); E_u16($c.value as uint16); E_nl(); }
+gen s4 := DEREF4(ADD2(s2, CONSTANT():c)) { E_callhelper("load4x"); E_dw(); E_u16($c.value as uint16); E_nl(); }
 
 // --- Maths ----------------------------------------------------------------
 

--- a/src/cowbe/arch6502i.cow.ng
+++ b/src/cowbe/arch6502i.cow.ng
@@ -340,21 +340,21 @@ gen s2 := SUBREF():a
 
 // --- Loads and stores -----------------------------------------------------
 
-gen STORE(s1, DEREF1(ADDRESS():a))  { E_store1(&$a.sym, $a.off); }
-gen STORE(s2, DEREF2(ADDRESS():a)) { E_store2(&$a.sym, $a.off); }
-gen STORE(s4, DEREF4(ADDRESS():a)) { E_store4(&$a.sym, $a.off); }
+gen STORE1(s1, DEREF1(ADDRESS():a))  { E_store1(&$a.sym, $a.off); }
+gen STORE2(s2, DEREF2(ADDRESS():a)) { E_store2(&$a.sym, $a.off); }
+gen STORE4(s4, DEREF4(ADDRESS():a)) { E_store4(&$a.sym, $a.off); }
 
 gen s1 := DEREF1(ADDRESS():a)  { E_load1(&$a.sym, $a.off); }
 gen s2 := DEREF2(ADDRESS():a) { E_load2(&$a.sym, $a.off); }
 gen s4 := DEREF4(ADDRESS():a) { E_load4(&$a.sym, $a.off); }
 
-gen STORE(s1, DEREF1(s2)) { E_callhelper("store1"); }
-gen STORE(s2, DEREF2(s2)) { E_callhelper("store2"); }
-gen STORE(s4, DEREF4(s2)) { E_callhelper("store4"); }
+gen STORE1(s1, DEREF1(s2)) { E_callhelper("store1"); }
+gen STORE2(s2, DEREF2(s2)) { E_callhelper("store2"); }
+gen STORE4(s4, DEREF4(s2)) { E_callhelper("store4"); }
 
-gen STORE(s1, DEREF1(ADD2(s2, CONSTANT():c))) { E_callhelper("store1x"); E_dw(); E_u16($c.value as uint16); E_nl(); }
-gen STORE(s2, DEREF2(ADD2(s2, CONSTANT():c))) { E_callhelper("store2x"); E_dw(); E_u16($c.value as uint16); E_nl(); }
-gen STORE(s4, DEREF4(ADD2(s2, CONSTANT():c))) { E_callhelper("store4x"); E_dw(); E_u16($c.value as uint16); E_nl(); }
+gen STORE1(s1, DEREF1(ADD2(s2, CONSTANT():c))) { E_callhelper("store1x"); E_dw(); E_u16($c.value as uint16); E_nl(); }
+gen STORE2(s2, DEREF2(ADD2(s2, CONSTANT():c))) { E_callhelper("store2x"); E_dw(); E_u16($c.value as uint16); E_nl(); }
+gen STORE4(s4, DEREF4(ADD2(s2, CONSTANT():c))) { E_callhelper("store4x"); E_dw(); E_u16($c.value as uint16); E_nl(); }
 
 gen s1 := DEREF1(s2) { E_callhelper("load1"); }
 gen s2 := DEREF2(s2) { E_callhelper("load2"); }

--- a/src/cowbe/arch80386.cow.ng
+++ b/src/cowbe/arch80386.cow.ng
@@ -820,39 +820,39 @@ gen r32 := SUBREF():a
 
 // --- Loads ---------------------------------------------------------------
 
-gen r8 := LOAD1(r32:rhs)     { E_loadix($$, $rhs, 0, 0); }
-gen r16 := LOAD2(r32:rhs)    { E_loadix($$, $rhs, 0, 0); }
-gen r32 := LOAD4(r32:rhs)    { E_loadix($$, $rhs, 0, 0); }
+gen r8 := DEREF1(r32:rhs)     { E_loadix($$, $rhs, 0, 0); }
+gen r16 := DEREF2(r32:rhs)    { E_loadix($$, $rhs, 0, 0); }
+gen r32 := DEREF4(r32:rhs)    { E_loadix($$, $rhs, 0, 0); }
 
-gen r8 := LOAD1(ADD4(r32:rhs, r32:idx))  { E_loadix($$, $rhs, $idx, 0); }
-gen r16 := LOAD2(ADD4(r32:rhs, r32:idx)) { E_loadix($$, $rhs, $idx, 0); }
-gen r32 := LOAD4(ADD4(r32:rhs, r32:idx)) { E_loadix($$, $rhs, $idx, 0); }
+gen r8 := DEREF1(ADD4(r32:rhs, r32:idx))  { E_loadix($$, $rhs, $idx, 0); }
+gen r16 := DEREF2(ADD4(r32:rhs, r32:idx)) { E_loadix($$, $rhs, $idx, 0); }
+gen r32 := DEREF4(ADD4(r32:rhs, r32:idx)) { E_loadix($$, $rhs, $idx, 0); }
 
-gen r8 := LOAD1(ADD4(r32:rhs, CONSTANT():c))  { E_loadix($$, $rhs, 0, $c.value); }
-gen r16 := LOAD2(ADD4(r32:rhs, CONSTANT():c)) { E_loadix($$, $rhs, 0, $c.value); }
-gen r32 := LOAD4(ADD4(r32:rhs, CONSTANT():c)) { E_loadix($$, $rhs, 0, $c.value); }
+gen r8 := DEREF1(ADD4(r32:rhs, CONSTANT():c))  { E_loadix($$, $rhs, 0, $c.value); }
+gen r16 := DEREF2(ADD4(r32:rhs, CONSTANT():c)) { E_loadix($$, $rhs, 0, $c.value); }
+gen r32 := DEREF4(ADD4(r32:rhs, CONSTANT():c)) { E_loadix($$, $rhs, 0, $c.value); }
 
-gen r8 := LOAD1(ADDRESS():a)  { E_load($$, &$a.sym, $a.off, 0); }
-gen r16 := LOAD2(ADDRESS():a) { E_load($$, &$a.sym, $a.off, 0); }
-gen r32 := LOAD4(ADDRESS():a) { E_load($$, &$a.sym, $a.off, 0); }
+gen r8 := DEREF1(ADDRESS():a)  { E_load($$, &$a.sym, $a.off, 0); }
+gen r16 := DEREF2(ADDRESS():a) { E_load($$, &$a.sym, $a.off, 0); }
+gen r32 := DEREF4(ADDRESS():a) { E_load($$, &$a.sym, $a.off, 0); }
 
 // --- Stores ---------------------------------------------------------------
 
-gen STORE1(r8:lhs, r32:rhs)  { E_storeix($lhs, $rhs, 0, 0); }
-gen STORE2(r16:lhs, r32:rhs) { E_storeix($lhs, $rhs, 0, 0); }
-gen STORE4(r32:lhs, r32:rhs) { E_storeix($lhs, $rhs, 0, 0); }
+gen STORE(r8:lhs, DEREF1(r32:rhs))  { E_storeix($lhs, $rhs, 0, 0); }
+gen STORE(r16:lhs, DEREF2(r32:rhs)) { E_storeix($lhs, $rhs, 0, 0); }
+gen STORE(r32:lhs, DEREF4(r32:rhs)) { E_storeix($lhs, $rhs, 0, 0); }
 
-gen STORE1(r8:lhs, ADD4(r32:rhs, r32:idx))  { E_storeix($lhs, $rhs, $idx, 0); }
-gen STORE2(r16:lhs, ADD4(r32:rhs, r32:idx)) { E_storeix($lhs, $rhs, $idx, 0); }
-gen STORE4(r32:lhs, ADD4(r32:rhs, r32:idx)) { E_storeix($lhs, $rhs, $idx, 0); }
+gen STORE(r8:lhs, DEREF1(ADD4(r32:rhs, r32:idx)))  { E_storeix($lhs, $rhs, $idx, 0); }
+gen STORE(r16:lhs, DEREF2(ADD4(r32:rhs, r32:idx))) { E_storeix($lhs, $rhs, $idx, 0); }
+gen STORE(r32:lhs, DEREF4(ADD4(r32:rhs, r32:idx))) { E_storeix($lhs, $rhs, $idx, 0); }
 
-gen STORE1(r8:lhs, ADD4(r32:rhs, CONSTANT():c))  { E_storeix($lhs, $rhs, 0, $c.value); }
-gen STORE2(r16:lhs, ADD4(r32:rhs, CONSTANT():c)) { E_storeix($lhs, $rhs, 0, $c.value); }
-gen STORE4(r32:lhs, ADD4(r32:rhs, CONSTANT():c)) { E_storeix($lhs, $rhs, 0, $c.value); }
+gen STORE(r8:lhs, DEREF1(ADD4(r32:rhs, CONSTANT():c)))  { E_storeix($lhs, $rhs, 0, $c.value); }
+gen STORE(r16:lhs, DEREF2(ADD4(r32:rhs, CONSTANT():c))) { E_storeix($lhs, $rhs, 0, $c.value); }
+gen STORE(r32:lhs, DEREF4(ADD4(r32:rhs, CONSTANT():c))) { E_storeix($lhs, $rhs, 0, $c.value); }
 
-gen STORE1(r8:lhs, ADDRESS():a)  { E_store($lhs, &$a.sym, $a.off, 0); }
-gen STORE2(r16:lhs, ADDRESS():a) { E_store($lhs, &$a.sym, $a.off, 0); }
-gen STORE4(r32:lhs, ADDRESS():a) { E_store($lhs, &$a.sym, $a.off, 0); }
+gen STORE(r8:lhs, DEREF1(ADDRESS():a))  { E_store($lhs, &$a.sym, $a.off, 0); }
+gen STORE(r16:lhs, DEREF2(ADDRESS():a)) { E_store($lhs, &$a.sym, $a.off, 0); }
+gen STORE(r32:lhs, DEREF4(ADDRESS():a)) { E_store($lhs, &$a.sym, $a.off, 0); }
 
 // --- Maths ----------------------------------------------------------------
 

--- a/src/cowbe/arch80386.cow.ng
+++ b/src/cowbe/arch80386.cow.ng
@@ -838,21 +838,21 @@ gen r32 := DEREF4(ADDRESS():a) { E_load($$, &$a.sym, $a.off, 0); }
 
 // --- Stores ---------------------------------------------------------------
 
-gen STORE(r8:lhs, DEREF1(r32:rhs))  { E_storeix($lhs, $rhs, 0, 0); }
-gen STORE(r16:lhs, DEREF2(r32:rhs)) { E_storeix($lhs, $rhs, 0, 0); }
-gen STORE(r32:lhs, DEREF4(r32:rhs)) { E_storeix($lhs, $rhs, 0, 0); }
+gen STORE1(r8:lhs, DEREF1(r32:rhs))  { E_storeix($lhs, $rhs, 0, 0); }
+gen STORE2(r16:lhs, DEREF2(r32:rhs)) { E_storeix($lhs, $rhs, 0, 0); }
+gen STORE4(r32:lhs, DEREF4(r32:rhs)) { E_storeix($lhs, $rhs, 0, 0); }
 
-gen STORE(r8:lhs, DEREF1(ADD4(r32:rhs, r32:idx)))  { E_storeix($lhs, $rhs, $idx, 0); }
-gen STORE(r16:lhs, DEREF2(ADD4(r32:rhs, r32:idx))) { E_storeix($lhs, $rhs, $idx, 0); }
-gen STORE(r32:lhs, DEREF4(ADD4(r32:rhs, r32:idx))) { E_storeix($lhs, $rhs, $idx, 0); }
+gen STORE1(r8:lhs, DEREF1(ADD4(r32:rhs, r32:idx)))  { E_storeix($lhs, $rhs, $idx, 0); }
+gen STORE2(r16:lhs, DEREF2(ADD4(r32:rhs, r32:idx))) { E_storeix($lhs, $rhs, $idx, 0); }
+gen STORE4(r32:lhs, DEREF4(ADD4(r32:rhs, r32:idx))) { E_storeix($lhs, $rhs, $idx, 0); }
 
-gen STORE(r8:lhs, DEREF1(ADD4(r32:rhs, CONSTANT():c)))  { E_storeix($lhs, $rhs, 0, $c.value); }
-gen STORE(r16:lhs, DEREF2(ADD4(r32:rhs, CONSTANT():c))) { E_storeix($lhs, $rhs, 0, $c.value); }
-gen STORE(r32:lhs, DEREF4(ADD4(r32:rhs, CONSTANT():c))) { E_storeix($lhs, $rhs, 0, $c.value); }
+gen STORE1(r8:lhs, DEREF1(ADD4(r32:rhs, CONSTANT():c)))  { E_storeix($lhs, $rhs, 0, $c.value); }
+gen STORE2(r16:lhs, DEREF2(ADD4(r32:rhs, CONSTANT():c))) { E_storeix($lhs, $rhs, 0, $c.value); }
+gen STORE4(r32:lhs, DEREF4(ADD4(r32:rhs, CONSTANT():c))) { E_storeix($lhs, $rhs, 0, $c.value); }
 
-gen STORE(r8:lhs, DEREF1(ADDRESS():a))  { E_store($lhs, &$a.sym, $a.off, 0); }
-gen STORE(r16:lhs, DEREF2(ADDRESS():a)) { E_store($lhs, &$a.sym, $a.off, 0); }
-gen STORE(r32:lhs, DEREF4(ADDRESS():a)) { E_store($lhs, &$a.sym, $a.off, 0); }
+gen STORE1(r8:lhs, DEREF1(ADDRESS():a))  { E_store($lhs, &$a.sym, $a.off, 0); }
+gen STORE2(r16:lhs, DEREF2(ADDRESS():a)) { E_store($lhs, &$a.sym, $a.off, 0); }
+gen STORE4(r32:lhs, DEREF4(ADDRESS():a)) { E_store($lhs, &$a.sym, $a.off, 0); }
 
 // --- Maths ----------------------------------------------------------------
 

--- a/src/cowbe/arch8080.cow.ng
+++ b/src/cowbe/arch8080.cow.ng
@@ -829,12 +829,12 @@ gen a := DEREF1(bc|de|hl:ptr)
 	end if;
 }
 
-gen STORE(a, DEREF1(ADDRESS():a))
+gen STORE1(a, DEREF1(ADDRESS():a))
 {
 	E_sta(&$a.sym, $a.off);
 }
 
-gen STORE(a, DEREF1(bc|de|hl:ptr))
+gen STORE1(a, DEREF1(bc|de|hl:ptr))
 {
 	if $ptr == REG_HL then
 		E_storem(REG_A);
@@ -876,12 +876,12 @@ gen hl|bc|de := DEREF2(hl) uses a
 	load2($$);
 }
 
-gen STORE(hl, DEREF2(ADDRESS():a))
+gen STORE2(hl, DEREF2(ADDRESS():a))
 {
 	E_shld(&$a.sym, $a.off);
 }
 
-gen STORE(bc|de:val, DEREF2(hl)) uses a
+gen STORE2(bc|de:val, DEREF2(hl)) uses a
 {
 	E_storem(loreg($val));
 	E_inx(REG_HL);
@@ -893,7 +893,7 @@ gen STORE(bc|de:val, DEREF2(hl)) uses a
 gen stk4 := DEREF4(hl)
 		{ E_callhelper("_load4"); }
 
-gen STORE(stk4, DEREF4(hl))
+gen STORE4(stk4, DEREF4(hl))
 		{ E_callhelper("_store4"); }
 
 // --- 8-bit arithmetic -----------------------------------------------------

--- a/src/cowbe/arch8080.cow.ng
+++ b/src/cowbe/arch8080.cow.ng
@@ -815,12 +815,12 @@ gen bc|de|hl := SUBREF():a
 
 // --- 8-bit loads and stores -----------------------------------------------
 
-gen a := LOAD1(ADDRESS():a)
+gen a := DEREF1(ADDRESS():a)
 {
 	E_lda(&$a.sym, $a.off);
 }
 
-gen a := LOAD1(bc|de|hl:ptr)
+gen a := DEREF1(bc|de|hl:ptr)
 {
 	if $ptr == REG_HL then
 		E_loadm(REG_A);
@@ -829,12 +829,12 @@ gen a := LOAD1(bc|de|hl:ptr)
 	end if;
 }
 
-gen STORE1(a, ADDRESS():a)
+gen STORE(a, DEREF1(ADDRESS():a))
 {
 	E_sta(&$a.sym, $a.off);
 }
 
-gen STORE1(a, bc|de|hl:ptr)
+gen STORE(a, DEREF1(bc|de|hl:ptr))
 {
 	if $ptr == REG_HL then
 		E_storem(REG_A);
@@ -851,7 +851,7 @@ gen STORE1(a, bc|de|hl:ptr)
 
 // --- 16-bit loads and stores ----------------------------------------------
 
-gen hl := LOAD2(ADDRESS():a)
+gen hl := DEREF2(ADDRESS():a)
 {
 	E_lhld(&$a.sym, $a.off);
 }
@@ -871,17 +871,17 @@ gen hl := LOAD2(ADDRESS():a)
 	end sub;
 %}
 
-gen hl|bc|de := LOAD2(hl) uses a
+gen hl|bc|de := DEREF2(hl) uses a
 {
 	load2($$);
 }
 
-gen STORE2(hl, ADDRESS():a)
+gen STORE(hl, DEREF2(ADDRESS():a))
 {
 	E_shld(&$a.sym, $a.off);
 }
 
-gen STORE2(bc|de:val, hl) uses a
+gen STORE(bc|de:val, DEREF2(hl)) uses a
 {
 	E_storem(loreg($val));
 	E_inx(REG_HL);
@@ -890,10 +890,10 @@ gen STORE2(bc|de:val, hl) uses a
 
 // --- 32-bit loads and stores ----------------------------------------------
 
-gen stk4 := LOAD4(hl)
+gen stk4 := DEREF4(hl)
 		{ E_callhelper("_load4"); }
 
-gen STORE4(stk4, hl)
+gen STORE(stk4, DEREF4(hl))
 		{ E_callhelper("_store4"); }
 
 // --- 8-bit arithmetic -----------------------------------------------------
@@ -1487,10 +1487,10 @@ gen stk4 := CAST14(a:rhs, sext!=0) uses hl|b
 gen a := CAST21(hl|bc|de:rhs)
 		{ E_mov(REG_A, loreg($rhs)); }
 
-gen a := CAST21(LOAD2(ADDRESS():a))
+gen a := CAST21(DEREF2(ADDRESS():a))
 		{ E_lda(&$a.sym, $a.off); }
 
-gen a|b|d|h := CAST21(LOAD2(hl))
+gen a|b|d|h := CAST21(DEREF2(hl))
 		{ E_loadm($$); }
 
 gen stk4 := CAST24(hl|de:rhs, sext==0) uses bc
@@ -1518,10 +1518,10 @@ gen a := CAST41(stk4) uses hl
 	E_pop(REG_HL);
 }
 
-gen a := CAST41(LOAD4(ADDRESS():a))
+gen a := CAST41(DEREF4(ADDRESS():a))
 		{ E_lda(&$a.sym, $a.off); }
 
-gen a|b|d|h := CAST41(LOAD4(hl))
+gen a|b|d|h := CAST41(DEREF4(hl))
 		{ E_loadm($$); }
 
 gen hl := CAST42(stk4) uses bc
@@ -1530,10 +1530,10 @@ gen hl := CAST42(stk4) uses bc
 	E_pop(REG_BC);
 }
 
-gen hl := CAST42(LOAD4(ADDRESS():a))
+gen hl := CAST42(DEREF4(ADDRESS():a))
 		{ E_lhld(&$a.sym, $a.off); }
 	
-gen hl|bc|de := CAST42(LOAD4(hl))
+gen hl|bc|de := CAST42(DEREF4(hl))
 		{ load2($$); }
 	
 // --- Strings --------------------------------------------------------------

--- a/src/cowbe/archbasic.cow.ng
+++ b/src/cowbe/archbasic.cow.ng
@@ -222,7 +222,7 @@ gen v := SUBREF():a
 
 // --- Loads and stores --------------------------------------------------
 
-gen STORE(CONSTANT():c, DEREF1(ADDRESS():a))
+gen STORE1(CONSTANT():c, DEREF1(ADDRESS():a))
 {
 	E("A(");
 	E_symref(&$a.sym, $a.off);
@@ -231,7 +231,7 @@ gen STORE(CONSTANT():c, DEREF1(ADDRESS():a))
 	E_nl();
 }
 
-gen STORE(v, DEREF1(ADDRESS():a))
+gen STORE1(v, DEREF1(ADDRESS():a))
 {
 	var vid := PopVar();
 	E("A(");
@@ -241,7 +241,7 @@ gen STORE(v, DEREF1(ADDRESS():a))
 	E_nl();
 }
 
-gen STORE(v, DEREF1(v))
+gen STORE1(v, DEREF1(v))
 {
 	var ptr := PopVar();
 	var vid := PopVar();

--- a/src/cowbe/archbasic.cow.ng
+++ b/src/cowbe/archbasic.cow.ng
@@ -222,7 +222,7 @@ gen v := SUBREF():a
 
 // --- Loads and stores --------------------------------------------------
 
-gen STORE1(CONSTANT():c, ADDRESS():a)
+gen STORE(CONSTANT():c, DEREF1(ADDRESS():a))
 {
 	E("A(");
 	E_symref(&$a.sym, $a.off);
@@ -231,7 +231,7 @@ gen STORE1(CONSTANT():c, ADDRESS():a)
 	E_nl();
 }
 
-gen STORE1(v, ADDRESS():a)
+gen STORE(v, DEREF1(ADDRESS():a))
 {
 	var vid := PopVar();
 	E("A(");
@@ -241,7 +241,7 @@ gen STORE1(v, ADDRESS():a)
 	E_nl();
 }
 
-gen STORE1(v, v)
+gen STORE(v, DEREF1(v))
 {
 	var ptr := PopVar();
 	var vid := PopVar();
@@ -252,7 +252,7 @@ gen STORE1(v, v)
 	E_nl();
 }
 
-gen v := LOAD1(ADDRESS():a)
+gen v := DEREF1(ADDRESS():a)
 {
 	var vid := PushVar();
 	E_varref(vid);
@@ -261,7 +261,7 @@ gen v := LOAD1(ADDRESS():a)
 	E(")\n");
 }
 
-gen v := LOAD1(v)
+gen v := DEREF1(v)
 {
 	var ptr := PopVar();
 	var vid := PushVar();

--- a/src/cowbe/archcgen.cow.ng
+++ b/src/cowbe/archcgen.cow.ng
@@ -456,15 +456,15 @@ gen v8 := SUBREF():a
 	end sub;
 %}
 
-gen STORE1(v1:val, v8:addr) { StoreVV(1); }
-gen STORE2(v2:val, v8:addr) { StoreVV(2); }
-gen STORE4(v4:val, v8:addr) { StoreVV(4); }
-gen STORE8(v8:val, v8:addr) { StoreVV(8); }
+gen STORE(v1:val, DEREF1(v8:addr)) { StoreVV(1); }
+gen STORE(v2:val, DEREF2(v8:addr)) { StoreVV(2); }
+gen STORE(v4:val, DEREF4(v8:addr)) { StoreVV(4); }
+gen STORE(v8:val, DEREF8(v8:addr)) { StoreVV(8); }
 
-gen v1 := LOAD1(v8:addr) { LoadVV(1); }
-gen v2 := LOAD2(v8:addr) { LoadVV(2); }
-gen v4 := LOAD4(v8:addr) { LoadVV(4); }
-gen v8 := LOAD8(v8:addr) { LoadVV(8); }
+gen v1 := DEREF1(v8:addr) { LoadVV(1); }
+gen v2 := DEREF2(v8:addr) { LoadVV(2); }
+gen v4 := DEREF4(v8:addr) { LoadVV(4); }
+gen v8 := DEREF8(v8:addr) { LoadVV(8); }
 
 // --- Maths ----------------------------------------------------------------
 

--- a/src/cowbe/archcgen.cow.ng
+++ b/src/cowbe/archcgen.cow.ng
@@ -456,10 +456,10 @@ gen v8 := SUBREF():a
 	end sub;
 %}
 
-gen STORE(v1:val, DEREF1(v8:addr)) { StoreVV(1); }
-gen STORE(v2:val, DEREF2(v8:addr)) { StoreVV(2); }
-gen STORE(v4:val, DEREF4(v8:addr)) { StoreVV(4); }
-gen STORE(v8:val, DEREF8(v8:addr)) { StoreVV(8); }
+gen STORE1(v1:val, DEREF1(v8:addr)) { StoreVV(1); }
+gen STORE2(v2:val, DEREF2(v8:addr)) { StoreVV(2); }
+gen STORE4(v4:val, DEREF4(v8:addr)) { StoreVV(4); }
+gen STORE8(v8:val, DEREF8(v8:addr)) { StoreVV(8); }
 
 gen v1 := DEREF1(v8:addr) { LoadVV(1); }
 gen v2 := DEREF2(v8:addr) { LoadVV(2); }

--- a/src/cowbe/archpdp11.cow.ng
+++ b/src/cowbe/archpdp11.cow.ng
@@ -1235,30 +1235,30 @@ gen r32 := CAST24(r16:val):c  { E_move($val, loreg($$)); if ($c.sext != 0) then 
 
 // --- Loads ---------------------------------------------------------------
 
-gen r8  := LOAD1(r16:rhs)     { E_loadix($$, $rhs, 0, 1); }
-gen r16 := LOAD2(r16:rhs)     { E_loadix($$, $rhs, 0, 0); }
-gen r32 := LOAD4(r16:rhs)     { E_loadix(loreg($$), $rhs, 0, 0); E_loadix(hireg($$), $rhs, 2, 0); }
+gen r8  := DEREF1(r16:rhs)     { E_loadix($$, $rhs, 0, 1); }
+gen r16 := DEREF2(r16:rhs)     { E_loadix($$, $rhs, 0, 0); }
+gen r32 := DEREF4(r16:rhs)     { E_loadix(loreg($$), $rhs, 0, 0); E_loadix(hireg($$), $rhs, 2, 0); }
 
-gen r8  := LOAD1(ADD1(r16:rhs, CONSTANT():c)) { E_loadix($$, $rhs, $c.value, 1); }
-gen r16 := LOAD2(ADD2(r16:rhs, CONSTANT():c)) { E_loadix($$, $rhs, $c.value, 0); }
-gen r8  := LOAD1(ADD1(ADDRESS():a), CONSTANT():c) { E_load($$, &$a.sym, $a.off + $c.value as uint16, 1); }
-gen r16 := LOAD2(ADD2(ADDRESS():a), CONSTANT():c) { E_load($$, &$a.sym, $a.off + $c.value as uint16, 0); }
+gen r8  := DEREF1(ADD1(r16:rhs, CONSTANT():c)) { E_loadix($$, $rhs, $c.value, 1); }
+gen r16 := DEREF2(ADD2(r16:rhs, CONSTANT():c)) { E_loadix($$, $rhs, $c.value, 0); }
+gen r8  := DEREF1(ADD1(ADDRESS():a), CONSTANT():c) { E_load($$, &$a.sym, $a.off + $c.value as uint16, 1); }
+gen r16 := DEREF2(ADD2(ADDRESS():a), CONSTANT():c) { E_load($$, &$a.sym, $a.off + $c.value as uint16, 0); }
 
-gen r8  := LOAD1(ADDRESS():a) { E_load($$, &$a.sym, $a.off, 1); }
-gen r16 := LOAD1(ADDRESS():a) { E_load($$, &$a.sym, $a.off, 1); }
-gen r16 := LOAD2(ADDRESS():a) { E_load($$, &$a.sym, $a.off, 0); }
+gen r8  := DEREF1(ADDRESS():a) { E_load($$, &$a.sym, $a.off, 1); }
+gen r16 := DEREF1(ADDRESS():a) { E_load($$, &$a.sym, $a.off, 1); }
+gen r16 := DEREF2(ADDRESS():a) { E_load($$, &$a.sym, $a.off, 0); }
 
-gen r32 := LOAD4(ADDRESS():a)
+gen r32 := DEREF4(ADDRESS():a)
 {
 	E_load(loreg($$), &$a.sym, $a.off, 0);
 	E_load(hireg($$), &$a.sym, $a.off + 2, 0);
 }
-gen r32 := LOAD4(ADD2(r16:rhs, CONSTANT():c))
+gen r32 := DEREF4(ADD2(r16:rhs, CONSTANT():c))
 {
 	E_loadix(loreg($$), $rhs, $c.value, 0);
 	E_loadix(hireg($$), $rhs, $c.value + 2, 0);
 }
-gen r32 := LOAD4(ADD2(ADDRESS():a), CONSTANT():c)
+gen r32 := DEREF4(ADD2(ADDRESS():a), CONSTANT():c)
 {
 	E_load(loreg($$), &$a.sym, $c.value as uint16 + $a.off, 0);
 	E_load(hireg($$), &$a.sym, $c.value as uint16 + $a.off + 2, 0);
@@ -1269,30 +1269,30 @@ gen r16 := ADDRESS():a        { E_loadaddr($$, &$a.sym, $a.off); }
 gen r16 := SUBREF():a         { E_loadsubref($$, $a.subr); }
 
 // XXX otherwise regs get destroyed?
-//n r8  := CAST21(LOAD2(ADDRESS():a)):c { E_load($$, &$a.sym, $a.off, 0); }
-//n r16 := CAST12(LOAD1(r16:rhs)):c     { E_loadix($$, $rhs, 0, 1); E_ext($$, $$, $c.sext); } // XXX bad code in FCBExt
-//n r16 := CAST12(LOAD1(ADDRESS():a)):c { E_load($$, &$a.sym, $a.off, 1); }
-//n r32 := CAST24(LOAD2(ADDRESS():a)):c { E_load(loreg($$), &$a.sym, $a.off, 0); if ($c.sext == 0) then E_clr(hireg($$)); else E_sxt(hireg($$)); end if; }
-//n r32 := CAST14(LOAD1(ADDRESS():a)):c { E_load(loreg($$), &$a.sym, $a.off, 1); E_ext(loreg($$), loreg($$), $c.sext); if ($c.sext != 0) then E_sxt(hireg($$)); else E_clr(hireg($$)); end if; }
+//n r8  := CAST21(DEREF2(ADDRESS():a)):c { E_load($$, &$a.sym, $a.off, 0); }
+//n r16 := CAST12(DEREF1(r16:rhs)):c     { E_loadix($$, $rhs, 0, 1); E_ext($$, $$, $c.sext); } // XXX bad code in FCBExt
+//n r16 := CAST12(DEREF1(ADDRESS():a)):c { E_load($$, &$a.sym, $a.off, 1); }
+//n r32 := CAST24(DEREF2(ADDRESS():a)):c { E_load(loreg($$), &$a.sym, $a.off, 0); if ($c.sext == 0) then E_clr(hireg($$)); else E_sxt(hireg($$)); end if; }
+//n r32 := CAST14(DEREF1(ADDRESS():a)):c { E_load(loreg($$), &$a.sym, $a.off, 1); E_ext(loreg($$), loreg($$), $c.sext); if ($c.sext != 0) then E_sxt(hireg($$)); else E_clr(hireg($$)); end if; }
 
 // --- Stores ---------------------------------------------------------------
 
-gen STORE1(CONSTANT():v, r16:rhs) { E_storeixc($v.value, $rhs, 0, 1); }
-gen STORE1(r8:lhs, r16:rhs)       { E_storeix($lhs, $rhs, 0, 1); }
-gen STORE1(r8:lhs, ADDRESS():a)   { E_store($lhs, &$a.sym, $a.off, 1); }
-gen STORE1(r8:lhs, ADD2(r16:rhs, CONSTANT():c)) { E_storeix($lhs, $rhs, $c.value, 1); }
+gen STORE(CONSTANT():v, DEREF1(r16:rhs)) { E_storeixc($v.value, $rhs, 0, 1); }
+gen STORE(r8:lhs, DEREF1(r16:rhs))       { E_storeix($lhs, $rhs, 0, 1); }
+gen STORE(r8:lhs, DEREF1(ADDRESS():a))   { E_store($lhs, &$a.sym, $a.off, 1); }
+gen STORE(r8:lhs, DEREF1(ADD2(r16:rhs, CONSTANT():c))) { E_storeix($lhs, $rhs, $c.value, 1); }
 
-gen STORE2(CONSTANT():v, r16:rhs) { E_storeixc($v.value, $rhs, 0, 0); }
-gen STORE2(r16:lhs, r16:rhs)      { E_storeix($lhs, $rhs, 0, 0); }
-gen STORE2(r16:lhs, ADDRESS():a)  { E_store($lhs, &$a.sym, $a.off, 0); }
-gen STORE2(r16:lhs, ADD2(r16:rhs, CONSTANT():c)) { E_storeix($lhs, $rhs, $c.value, 0); }
+gen STORE(CONSTANT():v, DEREF2(r16:rhs)) { E_storeixc($v.value, $rhs, 0, 0); }
+gen STORE(r16:lhs, DEREF2(r16:rhs))      { E_storeix($lhs, $rhs, 0, 0); }
+gen STORE(r16:lhs, DEREF2(ADDRESS():a))  { E_store($lhs, &$a.sym, $a.off, 0); }
+gen STORE(r16:lhs, DEREF2(ADD2(r16:rhs, CONSTANT():c))) { E_storeix($lhs, $rhs, $c.value, 0); }
 
-gen STORE4(r32:val, r16:rhs)
+gen STORE(r32:val, DEREF4(r16:rhs))
 {
 	E_storeix(loreg($val), $rhs, 0, 0);
 	E_storeix(hireg($val), $rhs, 2, 0);
 }
-gen STORE4(r32:val, ADDRESS():a)
+gen STORE(r32:val, DEREF4(ADDRESS():a))
 {
 	E_store(loreg($val), &$a.sym, $a.off, 0);
 	E_store(hireg($val), &$a.sym, $a.off + 2, 0);

--- a/src/cowbe/archpdp11.cow.ng
+++ b/src/cowbe/archpdp11.cow.ng
@@ -1277,22 +1277,22 @@ gen r16 := SUBREF():a         { E_loadsubref($$, $a.subr); }
 
 // --- Stores ---------------------------------------------------------------
 
-gen STORE(CONSTANT():v, DEREF1(r16:rhs)) { E_storeixc($v.value, $rhs, 0, 1); }
-gen STORE(r8:lhs, DEREF1(r16:rhs))       { E_storeix($lhs, $rhs, 0, 1); }
-gen STORE(r8:lhs, DEREF1(ADDRESS():a))   { E_store($lhs, &$a.sym, $a.off, 1); }
-gen STORE(r8:lhs, DEREF1(ADD2(r16:rhs, CONSTANT():c))) { E_storeix($lhs, $rhs, $c.value, 1); }
+gen STORE1(CONSTANT():v, DEREF1(r16:rhs)) { E_storeixc($v.value, $rhs, 0, 1); }
+gen STORE1(r8:lhs, DEREF1(r16:rhs))       { E_storeix($lhs, $rhs, 0, 1); }
+gen STORE1(r8:lhs, DEREF1(ADDRESS():a))   { E_store($lhs, &$a.sym, $a.off, 1); }
+gen STORE1(r8:lhs, DEREF1(ADD2(r16:rhs, CONSTANT():c))) { E_storeix($lhs, $rhs, $c.value, 1); }
 
-gen STORE(CONSTANT():v, DEREF2(r16:rhs)) { E_storeixc($v.value, $rhs, 0, 0); }
-gen STORE(r16:lhs, DEREF2(r16:rhs))      { E_storeix($lhs, $rhs, 0, 0); }
-gen STORE(r16:lhs, DEREF2(ADDRESS():a))  { E_store($lhs, &$a.sym, $a.off, 0); }
-gen STORE(r16:lhs, DEREF2(ADD2(r16:rhs, CONSTANT():c))) { E_storeix($lhs, $rhs, $c.value, 0); }
+gen STORE2(CONSTANT():v, DEREF2(r16:rhs)) { E_storeixc($v.value, $rhs, 0, 0); }
+gen STORE2(r16:lhs, DEREF2(r16:rhs))      { E_storeix($lhs, $rhs, 0, 0); }
+gen STORE2(r16:lhs, DEREF2(ADDRESS():a))  { E_store($lhs, &$a.sym, $a.off, 0); }
+gen STORE2(r16:lhs, DEREF2(ADD2(r16:rhs, CONSTANT():c))) { E_storeix($lhs, $rhs, $c.value, 0); }
 
-gen STORE(r32:val, DEREF4(r16:rhs))
+gen STORE4(r32:val, DEREF4(r16:rhs))
 {
 	E_storeix(loreg($val), $rhs, 0, 0);
 	E_storeix(hireg($val), $rhs, 2, 0);
 }
-gen STORE(r32:val, DEREF4(ADDRESS():a))
+gen STORE4(r32:val, DEREF4(ADDRESS():a))
 {
 	E_store(loreg($val), &$a.sym, $a.off, 0);
 	E_store(hireg($val), &$a.sym, $a.off + 2, 0);

--- a/src/cowbe/archthumb2.ng
+++ b/src/cowbe/archthumb2.ng
@@ -385,24 +385,24 @@ gen reg := ADDRESS():a
 
 // --- Loads and stores --------------------------------------------------
 
-//gen reg := LOAD1(ADDRESS(sym is current_sub):a)
+//gen reg := DEREF1(ADDRESS(sym is current_sub):a)
 //	{ E("\tldrb %s, [r8, %d]\n", regref($$), $a.sym->u.var.offset + $a.off); }
 
-gen reg := LOAD1(reg:lhs)
+gen reg := DEREF1(reg:lhs)
 	{ E("\tldrb %s, [%s]\n", regref($$), regref($lhs)); }
 
-//gen reg := LOAD2(ADDRESS(sym is current_sub):a)
+//gen reg := DEREF2(ADDRESS(sym is current_sub):a)
 //	{ E("\tldrh %s, [r8, #%d]\n", regref($$), $a.sym->u.var.offset + $a.off); }
 
-gen reg := LOAD2(reg:lhs)
+gen reg := DEREF2(reg:lhs)
 	{ E("\tldrh %s, [%s]\n", regref($$), regref($lhs)); }
 
-rewrite CAST24(LOAD1(a)) := LOAD2(a);
+rewrite CAST24(DEREF1(a)) := DEREF2(a);
 
-//gen reg := LOAD4(ADDRESS(sym is current_sub):a)
+//gen reg := DEREF4(ADDRESS(sym is current_sub):a)
 //	{ E("\tldr %s, [r8, #%d]\n", regref($$), $a.sym->u.var.offset + $a.off); }
 
-gen reg := LOAD4(reg:lhs)
+gen reg := DEREF4(reg:lhs)
 	{ E("\tldr %s, [%s]\n", regref($$), regref($lhs)); }
 
 //gen STORE1(reg:val, ADDRESS(sym is current_sub):a)

--- a/src/cowbe/archz80.cow.ng
+++ b/src/cowbe/archz80.cow.ng
@@ -1003,25 +1003,25 @@ gen r32 := CONSTANT():c
 	end sub;
 %}
 
-gen a := LOAD1(ADDRESS():a)
+gen a := DEREF1(ADDRESS():a)
 {
 	E_lda(&$a.sym, $a.off);
 }
 
-gen a := LOAD1(r16:ptr)
+gen a := DEREF1(r16:ptr)
 		{ E_loada($ptr); }
 
-gen r8 := LOAD1(ADD2(ix|iy:ptr, CONSTANT(value is indexable_8bit):c))
+gen r8 := DEREF1(ADD2(ix|iy:ptr, CONSTANT(value is indexable_8bit):c))
 {
 	E_load8i($$, $ptr, $c.value as int8);
 }
 
-gen STORE1(a, ADDRESS():a)
+gen STORE(a, DEREF1(ADDRESS():a))
 {
 	E_sta(&$a.sym, $a.off);
 }
 
-gen STORE1(a, hl|bc|de:ptr)
+gen STORE(a, DEREF1(hl|bc|de:ptr))
 {
 	if $ptr == REG_HL then
 		E_storem(REG_A);
@@ -1030,12 +1030,12 @@ gen STORE1(a, hl|bc|de:ptr)
 	end if;
 }
 
-gen STORE1(r8:r, ADD2(ix|iy:ptr, CONSTANT(value is indexable_8bit):c))
+gen STORE(r8:r, DEREF1(ADD2(ix|iy:ptr, CONSTANT(value is indexable_8bit):c)))
 {
 	E_store8i($r, $ptr, $c.value as int8);
 }
 
-gen STORE1(CONSTANT():v, ADD2(ix|iy:ptr, CONSTANT(value is indexable_8bit):c))
+gen STORE(CONSTANT():v, DEREF1(ADD2(ix|iy:ptr, CONSTANT(value is indexable_8bit):c)))
 {
 	E_store8ic($v.value as uint8, $ptr, $c.value as int8);
 }
@@ -1051,12 +1051,12 @@ gen STORE1(CONSTANT():v, ADD2(ix|iy:ptr, CONSTANT(value is indexable_8bit):c))
 	end sub;
 %}
 
-gen r16 := LOAD2(ADDRESS():a)
+gen r16 := DEREF2(ADDRESS():a)
 {
 	E_load16($$, &$a.sym, $a.off);
 }
 
-gen hl|bc|de := LOAD2(hl|ix|iy:rhs) uses a
+gen hl|bc|de := DEREF2(hl|ix|iy:rhs) uses a
 {
 	if ($rhs & (REG_IX|REG_IY)) != 0 then
 		E_load8i(loreg($$), $rhs, 0);
@@ -1073,18 +1073,18 @@ gen hl|bc|de := LOAD2(hl|ix|iy:rhs) uses a
 	end if;
 }
 
-gen hl|bc|de := LOAD2(ADD2(ix|iy:rhs, CONSTANT(value is indexable_16bit):c))
+gen hl|bc|de := DEREF2(ADD2(ix|iy:rhs, CONSTANT(value is indexable_16bit):c))
 {
 	E_load8i(loreg($$), $rhs, ($c.value as int8)+0);
 	E_load8i(hireg($$), $rhs, ($c.value as int8)+1);
 }
 
-gen STORE2(r16:ptr, ADDRESS():a)
+gen STORE(r16:ptr, DEREF2(ADDRESS():a))
 {
 	E_store16($ptr, &$a.sym, $a.off);
 }
 
-gen STORE2(hl|bc|de:val, hl|ix|iy:rhs) uses a
+gen STORE(hl|bc|de:val, DEREF2(hl|ix|iy:rhs)) uses a
 {
 	if ($rhs & (REG_IX|REG_IY)) != 0 then
 		E_store8i(loreg($val), $rhs, 0);
@@ -1096,13 +1096,13 @@ gen STORE2(hl|bc|de:val, hl|ix|iy:rhs) uses a
 	end if;
 }
 
-gen STORE2(hl|bc|de:val, ADD2(ix|iy:rhs, CONSTANT(value is indexable_16bit):c)) uses a
+gen STORE(hl|bc|de:val, DEREF2(ADD2(ix|iy:rhs, CONSTANT(value is indexable_16bit):c))) uses a
 {
 	E_store8i(loreg($val), $rhs, ($c.value as int8)+0);
 	E_store8i(hireg($val), $rhs, ($c.value as int8)+1);
 }
 
-gen STORE2(CONSTANT():v, ADD2(ix|iy:rhs, CONSTANT(value is indexable_16bit):c)) uses a
+gen STORE(CONSTANT():v, DEREF2(ADD2(ix|iy:rhs, CONSTANT(value is indexable_16bit):c))) uses a
 {
 	E_store8ic($v.value as uint8, $rhs, ($c.value as int8)+0);
 	E_store8ic(($v.value>>8) as uint8, $rhs, ($c.value as int8)+1);
@@ -1119,7 +1119,7 @@ gen STORE2(CONSTANT():v, ADD2(ix|iy:rhs, CONSTANT(value is indexable_16bit):c)) 
 	end sub;
 %}
 
-gen bcbc|dede := LOAD4(hl|ix|iy:ptr)
+gen bcbc|dede := DEREF4(hl|ix|iy:ptr)
 {
 	if $ptr == REG_HL then
 		E_loadm(loreg($$));           #  7
@@ -1144,7 +1144,7 @@ gen bcbc|dede := LOAD4(hl|ix|iy:ptr)
 	end if;
 }
 
-gen hlhl := LOAD4(ix|iy:ptr)
+gen hlhl := DEREF4(ix|iy:ptr)
 {
 	E_load8i(loreg($$), $ptr, 0);
 	E_load8i(hireg($$), $ptr, 1);
@@ -1154,7 +1154,7 @@ gen hlhl := LOAD4(ix|iy:ptr)
 	E_exx();
 }
 
-gen r32 := LOAD4(ADD2(ix|iy:ptr, CONSTANT(value is indexable_32bit):c))
+gen r32 := DEREF4(ADD2(ix|iy:ptr, CONSTANT(value is indexable_32bit):c))
 {
 	E_load8i(loreg($$), $ptr, ($c.value as int8)+0);
 	E_load8i(hireg($$), $ptr, ($c.value as int8)+1);
@@ -1164,7 +1164,7 @@ gen r32 := LOAD4(ADD2(ix|iy:ptr, CONSTANT(value is indexable_32bit):c))
 	E_exx();
 }
 
-gen r32 := LOAD4(ADDRESS():a)
+gen r32 := DEREF4(ADDRESS():a)
 {
 	var cache := RegCacheFindValue(&$a.sym, $a.off);
 	if (cache & $$) != 0 then
@@ -1179,7 +1179,7 @@ gen r32 := LOAD4(ADDRESS():a)
 	RegCacheLeavesValue($$, &$a.sym, $a.off);
 }
 
-gen STORE4(r32:val, hl|ix|iy:ptr)
+gen STORE(r32:val, DEREF4(hl|ix|iy:ptr))
 {
 	if $ptr == REG_HL then
 		E_storem(loreg($val));           #  7
@@ -1204,7 +1204,7 @@ gen STORE4(r32:val, hl|ix|iy:ptr)
 	end if;
 }
 
-gen STORE4(r32:val, ADD2(ix|iy:ptr, CONSTANT(value is indexable_32bit):c))
+gen STORE(r32:val, DEREF4(ADD2(ix|iy:ptr, CONSTANT(value is indexable_32bit):c)))
 {
 	E_store8i(loreg($val), $ptr, ($c.value as int8)+0);
 	E_store8i(hireg($val), $ptr, ($c.value as int8)+1);
@@ -1214,7 +1214,7 @@ gen STORE4(r32:val, ADD2(ix|iy:ptr, CONSTANT(value is indexable_32bit):c))
 	E_exx();
 }
 
-gen STORE4(r32:val, ADDRESS():a)
+gen STORE(r32:val, DEREF4(ADDRESS():a))
 {
 	E_store16(wordreg($val), &$a.sym, $a.off);
 	E_exx();
@@ -1223,7 +1223,7 @@ gen STORE4(r32:val, ADDRESS():a)
 	RegCacheLeavesValue($$, &$a.sym, $a.off);
 }
 
-gen STORE4(CONSTANT():c, ADDRESS():a) uses hl
+gen STORE(CONSTANT():c, DEREF4(ADDRESS():a)) uses hl
 {
 	E_lxi(REG_HL, $c.value as uint16);
 	E_store16(REG_HL, &$a.sym, $a.off);
@@ -1909,19 +1909,19 @@ gen hlhl := CAST24(hl, sext!=0) uses a
 gen a := CAST21(hl|bc|de:rhs)
 		{ E_mov(REG_A, loreg($rhs)); }
 
-gen a := CAST21(LOAD2(ADDRESS():a))
+gen a := CAST21(DEREF2(ADDRESS():a))
 		{ E_lda(&$a.sym, $a.off); }
 
-gen a := CAST21(LOAD2(r16:ptr))
+gen a := CAST21(DEREF2(r16:ptr))
 		{ E_loada($ptr); }
 
 gen a := CAST41(r32:rhs)
 		{ E_mov(REG_A, loreg($rhs)); }
 
-gen a := CAST41(LOAD4(ADDRESS():a))
+gen a := CAST41(DEREF4(ADDRESS():a))
 		{ E_lda(&$a.sym, $a.off); }
 
-gen a := CAST41(LOAD4(r16:ptr))
+gen a := CAST41(DEREF4(r16:ptr))
 		{ E_loada($ptr); }
 
 gen hl := CAST42(hlhl);

--- a/src/cowbe/archz80.cow.ng
+++ b/src/cowbe/archz80.cow.ng
@@ -1016,12 +1016,12 @@ gen r8 := DEREF1(ADD2(ix|iy:ptr, CONSTANT(value is indexable_8bit):c))
 	E_load8i($$, $ptr, $c.value as int8);
 }
 
-gen STORE(a, DEREF1(ADDRESS():a))
+gen STORE1(a, DEREF1(ADDRESS():a))
 {
 	E_sta(&$a.sym, $a.off);
 }
 
-gen STORE(a, DEREF1(hl|bc|de:ptr))
+gen STORE1(a, DEREF1(hl|bc|de:ptr))
 {
 	if $ptr == REG_HL then
 		E_storem(REG_A);
@@ -1030,12 +1030,12 @@ gen STORE(a, DEREF1(hl|bc|de:ptr))
 	end if;
 }
 
-gen STORE(r8:r, DEREF1(ADD2(ix|iy:ptr, CONSTANT(value is indexable_8bit):c)))
+gen STORE1(r8:r, DEREF1(ADD2(ix|iy:ptr, CONSTANT(value is indexable_8bit):c)))
 {
 	E_store8i($r, $ptr, $c.value as int8);
 }
 
-gen STORE(CONSTANT():v, DEREF1(ADD2(ix|iy:ptr, CONSTANT(value is indexable_8bit):c)))
+gen STORE1(CONSTANT():v, DEREF1(ADD2(ix|iy:ptr, CONSTANT(value is indexable_8bit):c)))
 {
 	E_store8ic($v.value as uint8, $ptr, $c.value as int8);
 }
@@ -1079,12 +1079,12 @@ gen hl|bc|de := DEREF2(ADD2(ix|iy:rhs, CONSTANT(value is indexable_16bit):c))
 	E_load8i(hireg($$), $rhs, ($c.value as int8)+1);
 }
 
-gen STORE(r16:ptr, DEREF2(ADDRESS():a))
+gen STORE2(r16:ptr, DEREF2(ADDRESS():a))
 {
 	E_store16($ptr, &$a.sym, $a.off);
 }
 
-gen STORE(hl|bc|de:val, DEREF2(hl|ix|iy:rhs)) uses a
+gen STORE2(hl|bc|de:val, DEREF2(hl|ix|iy:rhs)) uses a
 {
 	if ($rhs & (REG_IX|REG_IY)) != 0 then
 		E_store8i(loreg($val), $rhs, 0);
@@ -1096,13 +1096,13 @@ gen STORE(hl|bc|de:val, DEREF2(hl|ix|iy:rhs)) uses a
 	end if;
 }
 
-gen STORE(hl|bc|de:val, DEREF2(ADD2(ix|iy:rhs, CONSTANT(value is indexable_16bit):c))) uses a
+gen STORE2(hl|bc|de:val, DEREF2(ADD2(ix|iy:rhs, CONSTANT(value is indexable_16bit):c))) uses a
 {
 	E_store8i(loreg($val), $rhs, ($c.value as int8)+0);
 	E_store8i(hireg($val), $rhs, ($c.value as int8)+1);
 }
 
-gen STORE(CONSTANT():v, DEREF2(ADD2(ix|iy:rhs, CONSTANT(value is indexable_16bit):c))) uses a
+gen STORE2(CONSTANT():v, DEREF2(ADD2(ix|iy:rhs, CONSTANT(value is indexable_16bit):c))) uses a
 {
 	E_store8ic($v.value as uint8, $rhs, ($c.value as int8)+0);
 	E_store8ic(($v.value>>8) as uint8, $rhs, ($c.value as int8)+1);
@@ -1179,7 +1179,7 @@ gen r32 := DEREF4(ADDRESS():a)
 	RegCacheLeavesValue($$, &$a.sym, $a.off);
 }
 
-gen STORE(r32:val, DEREF4(hl|ix|iy:ptr))
+gen STORE4(r32:val, DEREF4(hl|ix|iy:ptr))
 {
 	if $ptr == REG_HL then
 		E_storem(loreg($val));           #  7
@@ -1204,7 +1204,7 @@ gen STORE(r32:val, DEREF4(hl|ix|iy:ptr))
 	end if;
 }
 
-gen STORE(r32:val, DEREF4(ADD2(ix|iy:ptr, CONSTANT(value is indexable_32bit):c)))
+gen STORE4(r32:val, DEREF4(ADD2(ix|iy:ptr, CONSTANT(value is indexable_32bit):c)))
 {
 	E_store8i(loreg($val), $ptr, ($c.value as int8)+0);
 	E_store8i(hireg($val), $ptr, ($c.value as int8)+1);
@@ -1214,7 +1214,7 @@ gen STORE(r32:val, DEREF4(ADD2(ix|iy:ptr, CONSTANT(value is indexable_32bit):c))
 	E_exx();
 }
 
-gen STORE(r32:val, DEREF4(ADDRESS():a))
+gen STORE4(r32:val, DEREF4(ADDRESS():a))
 {
 	E_store16(wordreg($val), &$a.sym, $a.off);
 	E_exx();
@@ -1223,7 +1223,7 @@ gen STORE(r32:val, DEREF4(ADDRESS():a))
 	RegCacheLeavesValue($$, &$a.sym, $a.off);
 }
 
-gen STORE(CONSTANT():c, DEREF4(ADDRESS():a)) uses hl
+gen STORE4(CONSTANT():c, DEREF4(ADDRESS():a)) uses hl
 {
 	E_lxi(REG_HL, $c.value as uint16);
 	E_store16(REG_HL, &$a.sym, $a.off);

--- a/src/cowfe/namespace.coh
+++ b/src/cowfe/namespace.coh
@@ -160,7 +160,7 @@ sub MakeLValue(address: [Node]): (lvalue: [Node]) is
 	if IsScalar(elementtype) != 0 then
 		w := elementtype.width as uint8;
 	end if;
-	lvalue := MidLoad(w, address);
+	lvalue := MidDeref(w, address);
 	lvalue.type := elementtype;
 
 	#print("make ");
@@ -170,7 +170,7 @@ end sub;
 
 sub UndoLValue(lvalue: [Node]): (address: [Node]) is
 	var k := lvalue.op;
-	if (k < MIDCODE_LOAD0) or (k > MIDCODE_LOAD8) then
+	if (k < MIDCODE_DEREF0) or (k > MIDCODE_DEREF8) then
 		SimpleError("lvalue required");
 	end if;
 

--- a/src/cowfe/parser.y
+++ b/src/cowfe/parser.y
@@ -78,7 +78,8 @@ statement ::= VAR newid(S) COLON typeref(T) ASSIGN expression(E) SEMICOLON.
 	InitVariable(current_subr, S, T);
     CheckExpressionType(E, S.vardata.type);
 
-    Generate(MidStore(E, MidDeref(E.type.width as uint8, MidAddress(S, 0))));
+	var w := E.type.width as uint8;
+    Generate(MidStore(w, E, MidDeref(w, MidAddress(S, 0))));
 }
 
 statement ::= VAR newid(S) ASSIGN expression(E) SEMICOLON.
@@ -94,7 +95,8 @@ statement ::= VAR newid(S) ASSIGN expression(E) SEMICOLON.
 	InitVariable(current_subr, S, type);
 	CheckExpressionType(E, S.vardata.type);
 
-    Generate(MidStore(E, MidDeref(E.type.width as uint8, MidAddress(S, 0))));
+	var w := E.type.width as uint8;
+    Generate(MidStore(w, E, MidDeref(w, MidAddress(S, 0))));
 }
 
 /* --- Assignments ------------------------------------------------------- */
@@ -105,7 +107,8 @@ statement ::= expression(E1) ASSIGN expression(E2) SEMICOLON.
 	var address := UndoLValue(E1);
 
 	CheckExpressionType(E2, type);
-    Generate(MidStore(E2, MidDeref(type.width as uint8, address)));
+	var w := type.width as uint8;
+    Generate(MidStore(w, E2, MidDeref(w, address)));
 }
 
 /* --- Simple loops ------------------------------------------------------ */
@@ -836,6 +839,7 @@ statement ::= outputargs(OUTA) ASSIGN startsubcall inputargs(INA) SEMICOLON.
 		var w := param.vardata.type.width as uint8;
 		Generate(
 			MidStore(
+				w,
 				MidPoparg(w, intfsubr, count),
 				MidDeref(w, arg)
 			)

--- a/src/cowfe/parser.y
+++ b/src/cowfe/parser.y
@@ -78,7 +78,7 @@ statement ::= VAR newid(S) COLON typeref(T) ASSIGN expression(E) SEMICOLON.
 	InitVariable(current_subr, S, T);
     CheckExpressionType(E, S.vardata.type);
 
-    Generate(MidStore(E.type.width as uint8, E, MidAddress(S, 0)));
+    Generate(MidStore(E, MidDeref(E.type.width as uint8, MidAddress(S, 0))));
 }
 
 statement ::= VAR newid(S) ASSIGN expression(E) SEMICOLON.
@@ -94,7 +94,7 @@ statement ::= VAR newid(S) ASSIGN expression(E) SEMICOLON.
 	InitVariable(current_subr, S, type);
 	CheckExpressionType(E, S.vardata.type);
 
-	Generate(MidStore(E.type.width as uint8, E, MidAddress(S, 0)));
+    Generate(MidStore(E, MidDeref(E.type.width as uint8, MidAddress(S, 0))));
 }
 
 /* --- Assignments ------------------------------------------------------- */
@@ -105,7 +105,7 @@ statement ::= expression(E1) ASSIGN expression(E2) SEMICOLON.
 	var address := UndoLValue(E1);
 
 	CheckExpressionType(E2, type);
-	Generate(MidStore(type.width as uint8, E2, address));
+    Generate(MidStore(E2, MidDeref(type.width as uint8, address)));
 }
 
 /* --- Simple loops ------------------------------------------------------ */
@@ -565,7 +565,7 @@ expression(E) ::= expression(E1) DOT ID(X).
 	while IsPtr(type) != 0 loop
 		type := type.pointertype.element;
 		CheckNotPartialType(type);
-		address := MidLoad(intptr_type.width as uint8, address);
+		address := MidDeref(intptr_type.width as uint8, address);
 	end loop;
 	CheckNotPartialType(type);
 
@@ -835,9 +835,9 @@ statement ::= outputargs(OUTA) ASSIGN startsubcall inputargs(INA) SEMICOLON.
 
 		var w := param.vardata.type.width as uint8;
 		Generate(
-			MidStore(w,
+			MidStore(
 				MidPoparg(w, intfsubr, count),
-				arg
+				MidDeref(w, arg)
 			)
 		);
 

--- a/src/midcodes.coh.tab
+++ b/src/midcodes.coh.tab
@@ -57,7 +57,7 @@ y 0 1 POPARG(subr: [Subroutine], remaining: uint8)
 - 0 1 SUBREF(subr: [Subroutine])
 
 y 1 1 DEREF()
-- 2 0 STORE() # left is value, right is deref
+y 2 0 STORE() # left is value, right is deref
 
 - 2 1 BAND(truelabel: LabelRef, falselabel: LabelRef, fallthrough: LabelRef, negated: uint8) = ("true=%d false=%d, fallthrough=%d negated=%d", $$.truelabel, $$.falselabel, $$.fallthrough, $$.negated)
 - 2 1 BOR(truelabel: LabelRef, falselabel: LabelRef, fallthrough: LabelRef, negated: uint8) = ("true=%d false=%d, fallthrough=%d negated=%d", $$.truelabel, $$.falselabel, $$.fallthrough, $$.negated)

--- a/src/midcodes.coh.tab
+++ b/src/midcodes.coh.tab
@@ -56,8 +56,8 @@ y 0 1 POPARG(subr: [Subroutine], remaining: uint8)
 - 0 1 ADDRESS(sym: [Symbol], off: Size) = ("%s%+d", $$.sym.name, $$.off)
 - 0 1 SUBREF(subr: [Subroutine])
 
-y 1 1 LOAD()
-y 2 0 STORE() # left is value, right is address
+y 1 1 DEREF()
+- 2 0 STORE() # left is value, right is deref
 
 - 2 1 BAND(truelabel: LabelRef, falselabel: LabelRef, fallthrough: LabelRef, negated: uint8) = ("true=%d false=%d, fallthrough=%d negated=%d", $$.truelabel, $$.falselabel, $$.fallthrough, $$.negated)
 - 2 1 BOR(truelabel: LabelRef, falselabel: LabelRef, fallthrough: LabelRef, negated: uint8) = ("true=%d false=%d, fallthrough=%d negated=%d", $$.truelabel, $$.falselabel, $$.fallthrough, $$.negated)


### PR DESCRIPTION
This replaces LOADx and STOREx with DEREFx and STOREx. STOREx takes a DEREFx as the second parameter, so:

    STORE2(r1, r2) # [r2] := r1

becomes

    STORE2(r1, DEREF2(r2)) # [r2] := r1

(A bare DEREFx not inside a STOREx does a load.)

This allows (much) smaller rule tables for addressing-mode-heavy platforms like the x86 and 6809, as the same rule can generate an lvalue for use by either loads or stores.