### PR TITLE
Implement single-character get_char() for 8080 CP/M.

### DIFF
--- a/rt/cpm/cowgol.coh
+++ b/rt/cpm/cowgol.coh
@@ -18,6 +18,12 @@ sub AlignUp(in: intptr): (out: intptr) is
 	out := in;
 end sub;
 
+sub get_char(): (c: uint8) is
+	@asm "mvi c, 1";
+	@asm "call 5";
+	@asm "sta", c;
+end sub;
+
 sub print_char(c: uint8) is
 	if c == 10 then
 		@asm "mvi e, 13";


### PR DESCRIPTION
This allows us to write interactive Cowgol programs.
Works with cpmemu.

I have an RPN calculator that demonstrates this works: https://github.com/ibara/cowgol-utilities/blob/main/rpn.cow
I can run it as `cpmemu rpn.com` and it does the right thing.
(Ignore the spaghetti code of the calculator itself.)

Only have get_char() code for 8080 CP/M at the moment, though I plan to implement at least Z80 CP/M and Unix soon.
And obviously I'm OK with a name change. I just chose get_char() because of the analogous print_char().