### PR TITLE
Implement Cgen get_char().

### DIFF
--- a/rt/cgen/cowgol.coh
+++ b/rt/cgen/cowgol.coh
@@ -20,6 +20,10 @@ sub MemSet(buf: [uint8], byte: uint8, len: intptr) is
 	@asm "memset((void*)(intptr_t)", buf, ", ", byte, ", ", len, ");";
 end sub;
 
+sub get_char(): (c: uint8) is
+	@asm c, " = getchar();";
+end sub;
+
 sub print_char(c: uint8) is
 	@asm "putchar(", c, ");";
 end sub;


### PR DESCRIPTION
Cgen get_char. Unsurprisingly uses getchar() from libc.
Works on my OpenBSD machine.