### PR TITLE
Instructions now track used registers seperately from inputs and outputs

### DIFF
--- a/src/cowbe/arch6303.cow.ng
+++ b/src/cowbe/arch6303.cow.ng
@@ -628,31 +628,31 @@ gen ENDSUB()
 	end sub;
 %}
 
-gen         CALL(       param,      SUBREF():a) uses a|b|x { Call(&$a); }
-gen         CALL(  ARG1(param, a),  SUBREF():a) uses   b|x { Call(&$a); }
-gen         CALL(  ARG2(param, d),  SUBREF():a) uses     x { Call(&$a); }
-gen a :=    CALLE1(     param,      SUBREF():a) uses   b|x { Call(&$a); }
-gen a :=    CALLE1(ARG1(param, a),  SUBREF():a) uses   b|x { Call(&$a); }
-gen a :=    CALLE1(ARG2(param, d),  SUBREF():a) uses     x { Call(&$a); }
-gen d :=    CALLE2(     param,      SUBREF():a) uses     x { Call(&$a); }
-gen d :=    CALLE2(ARG1(param, a),  SUBREF():a) uses     x { Call(&$a); }
-gen d :=    CALLE2(ARG2(param, d),  SUBREF():a) uses     x { Call(&$a); }
-gen i4 :=   CALLE4(     param,      SUBREF():a) uses a|b|x { Call(&$a); }
-gen i4 :=   CALLE4(ARG1(param, a),  SUBREF():a) uses a|b|x { Call(&$a); }
-gen i4 :=   CALLE4(ARG2(param, d),  SUBREF():a) uses a|b|x { Call(&$a); }
+gen         CALL(       param,      SUBREF():a) uses all { Call(&$a); }
+gen         CALL(  ARG1(param, a),  SUBREF():a) uses all { Call(&$a); }
+gen         CALL(  ARG2(param, d),  SUBREF():a) uses all { Call(&$a); }
+gen a :=    CALLE1(     param,      SUBREF():a) uses all { Call(&$a); }
+gen a :=    CALLE1(ARG1(param, a),  SUBREF():a) uses all { Call(&$a); }
+gen a :=    CALLE1(ARG2(param, d),  SUBREF():a) uses all { Call(&$a); }
+gen d :=    CALLE2(     param,      SUBREF():a) uses all { Call(&$a); }
+gen d :=    CALLE2(ARG1(param, a),  SUBREF():a) uses all { Call(&$a); }
+gen d :=    CALLE2(ARG2(param, d),  SUBREF():a) uses all { Call(&$a); }
+gen i4 :=   CALLE4(     param,      SUBREF():a) uses all { Call(&$a); }
+gen i4 :=   CALLE4(ARG1(param, a),  SUBREF():a) uses all { Call(&$a); }
+gen i4 :=   CALLE4(ARG2(param, d),  SUBREF():a) uses all { Call(&$a); }
 
-gen         CALL(       param,      x) uses a|b { CallI(); }
-gen         CALL(  ARG1(param, a),  x) uses   b { CallI(); }
-gen         CALL(  ARG2(param, d),  x)          { CallI(); }
-gen a :=    CALLE1(     param,      x) uses   b { CallI(); }
-gen a :=    CALLE1(ARG1(param, a),  x) uses   b { CallI(); }
-gen a :=    CALLE1(ARG2(param, d),  x)          { CallI(); }
-gen d :=    CALLE2(     param,      x)          { CallI(); }
-gen d :=    CALLE2(ARG1(param, a),  x)          { CallI(); }
-gen d :=    CALLE2(ARG2(param, d),  x)          { CallI(); }
-gen i4 :=   CALLE4(     param,      x) uses a|b { CallI(); }
-gen i4 :=   CALLE4(ARG1(param, a),  x) uses a|b { CallI(); }
-gen i4 :=   CALLE4(ARG2(param, d),  x) uses a|b { CallI(); }
+gen         CALL(       param,      x) uses all { CallI(); }
+gen         CALL(  ARG1(param, a),  x) uses all { CallI(); }
+gen         CALL(  ARG2(param, d),  x) uses all { CallI(); }
+gen a :=    CALLE1(     param,      x) uses all { CallI(); }
+gen a :=    CALLE1(ARG1(param, a),  x) uses all { CallI(); }
+gen a :=    CALLE1(ARG2(param, d),  x) uses all { CallI(); }
+gen d :=    CALLE2(     param,      x) uses all { CallI(); }
+gen d :=    CALLE2(ARG1(param, a),  x) uses all { CallI(); }
+gen d :=    CALLE2(ARG2(param, d),  x) uses all { CallI(); }
+gen i4 :=   CALLE4(     param,      x) uses all { CallI(); }
+gen i4 :=   CALLE4(ARG1(param, a),  x) uses all { CallI(); }
+gen i4 :=   CALLE4(ARG2(param, d),  x) uses all { CallI(); }
 
 gen param := END();
 

--- a/src/cowbe/arch6502.cow.ng
+++ b/src/cowbe/arch6502.cow.ng
@@ -1304,23 +1304,23 @@ gen RETURN()
     end sub;
 %}
 
-gen        CALL(       param,      SUBREF():a)             uses x|y|a { Call(&$a); }
-gen        CALL(  ARG1(param, a),  SUBREF(subr is fast):a) uses x|y|a { Call(&$a); }
-gen        CALL(  ARG2(param, xa), SUBREF(subr is fast):a) uses x|y|a { Call(&$a); }
-gen a :=   CALLE1(     param,      SUBREF():a)             uses x|y   { Call(&$a); }
-gen a :=   CALLE1(ARG1(param, a),  SUBREF(subr is fast):a) uses x|y   { Call(&$a); }
-gen a :=   CALLE1(ARG2(param, xa), SUBREF(subr is fast):a) uses x|y   { Call(&$a); }
-gen xa :=  CALLE2(     param,      SUBREF():a)             uses y     { Call(&$a); }
-gen xa :=  CALLE2(ARG1(param, a),  SUBREF(subr is fast):a) uses y     { Call(&$a); }
-gen xa :=  CALLE2(ARG2(param, xa), SUBREF(subr is fast):a) uses y     { Call(&$a); }
-gen v32 := CALLE4(     param,      SUBREF():a)             uses x|y|a { Call(&$a); PopArg4(PushV32()); }
-gen v32 := CALLE4(ARG1(param, a),  SUBREF(subr is fast):a) uses x|y|a { Call(&$a); PopArg4(PushV32()); }
-gen v32 := CALLE4(ARG2(param, xa), SUBREF(subr is fast):a) uses x|y|a { Call(&$a); PopArg4(PushV32()); }
+gen        CALL(       param,      SUBREF():a)             uses all { Call(&$a); }
+gen        CALL(  ARG1(param, a),  SUBREF(subr is fast):a) uses all { Call(&$a); }
+gen        CALL(  ARG2(param, xa), SUBREF(subr is fast):a) uses all { Call(&$a); }
+gen a :=   CALLE1(     param,      SUBREF():a)             uses all { Call(&$a); }
+gen a :=   CALLE1(ARG1(param, a),  SUBREF(subr is fast):a) uses all { Call(&$a); }
+gen a :=   CALLE1(ARG2(param, xa), SUBREF(subr is fast):a) uses all { Call(&$a); }
+gen xa :=  CALLE2(     param,      SUBREF():a)             uses all { Call(&$a); }
+gen xa :=  CALLE2(ARG1(param, a),  SUBREF(subr is fast):a) uses all { Call(&$a); }
+gen xa :=  CALLE2(ARG2(param, xa), SUBREF(subr is fast):a) uses all { Call(&$a); }
+gen v32 := CALLE4(     param,      SUBREF():a)             uses all { Call(&$a); PopArg4(PushV32()); }
+gen v32 := CALLE4(ARG1(param, a),  SUBREF(subr is fast):a) uses all { Call(&$a); PopArg4(PushV32()); }
+gen v32 := CALLE4(ARG2(param, xa), SUBREF(subr is fast):a) uses all { Call(&$a); PopArg4(PushV32()); }
 
-gen        CALL(  param, xa) uses y { CallI(); }
-gen a :=   CALLE1(param, xa) uses y { CallI(); }
-gen xa :=  CALLE2(param, xa) uses y { CallI(); }
-gen v32 := CALLE4(param, xa) uses y { CallI(); PopArg4(PushV32()); }
+gen        CALL(  param, xa) uses all { CallI(); }
+gen a :=   CALLE1(param, xa) uses all { CallI(); }
+gen xa :=  CALLE2(param, xa) uses all { CallI(); }
+gen v32 := CALLE4(param, xa) uses all { CallI(); PopArg4(PushV32()); }
 
 gen param := END();
 

--- a/src/cowbe/arch80386.cow.ng
+++ b/src/cowbe/arch80386.cow.ng
@@ -749,39 +749,39 @@ gen RETURN()
 	end sub;
 %}
 
-gen        CALL(       param,       SUBREF():a) uses r32                 { Call(&$a); }
-gen        CALL(  ARG1(param, al),  SUBREF():a) uses ebx|ecx|edx|esi|edi { Call(&$a); }
-gen        CALL(  ARG2(param, ax),  SUBREF():a) uses ebx|ecx|edx|esi|edi { Call(&$a); }
-gen        CALL(  ARG4(param, eax), SUBREF():a) uses ebx|ecx|edx|esi|edi { Call(&$a); }
-gen al :=  CALLE1(     param,       SUBREF():a) uses ebx|ecx|edx|esi|edi { Call(&$a); }
-gen al :=  CALLE1(ARG1(param, al),  SUBREF():a) uses ebx|ecx|edx|esi|edi { Call(&$a); }
-gen al :=  CALLE1(ARG2(param, ax),  SUBREF():a) uses ebx|ecx|edx|esi|edi { Call(&$a); }
-gen al :=  CALLE1(ARG4(param, eax), SUBREF():a) uses ebx|ecx|edx|esi|edi { Call(&$a); }
-gen ax :=  CALLE2(     param,       SUBREF():a) uses ebx|ecx|edx|esi|edi { Call(&$a); }
-gen ax :=  CALLE2(ARG1(param, al),  SUBREF():a) uses ebx|ecx|edx|esi|edi { Call(&$a); }
-gen ax :=  CALLE2(ARG2(param, ax),  SUBREF():a) uses ebx|ecx|edx|esi|edi { Call(&$a); }
-gen ax :=  CALLE2(ARG4(param, eax), SUBREF():a) uses ebx|ecx|edx|esi|edi { Call(&$a); }
-gen eax := CALLE4(     param,       SUBREF():a) uses ebx|ecx|edx|esi|edi { Call(&$a); }
-gen eax := CALLE4(ARG1(param, al),  SUBREF():a) uses ebx|ecx|edx|esi|edi { Call(&$a); }
-gen eax := CALLE4(ARG2(param, ax),  SUBREF():a) uses ebx|ecx|edx|esi|edi { Call(&$a); }
-gen eax := CALLE4(ARG4(param, eax), SUBREF():a) uses ebx|ecx|edx|esi|edi { Call(&$a); }
+gen        CALL(       param,       SUBREF():a) uses all { Call(&$a); }
+gen        CALL(  ARG1(param, al),  SUBREF():a) uses all { Call(&$a); }
+gen        CALL(  ARG2(param, ax),  SUBREF():a) uses all { Call(&$a); }
+gen        CALL(  ARG4(param, eax), SUBREF():a) uses all { Call(&$a); }
+gen al :=  CALLE1(     param,       SUBREF():a) uses all { Call(&$a); }
+gen al :=  CALLE1(ARG1(param, al),  SUBREF():a) uses all { Call(&$a); }
+gen al :=  CALLE1(ARG2(param, ax),  SUBREF():a) uses all { Call(&$a); }
+gen al :=  CALLE1(ARG4(param, eax), SUBREF():a) uses all { Call(&$a); }
+gen ax :=  CALLE2(     param,       SUBREF():a) uses all { Call(&$a); }
+gen ax :=  CALLE2(ARG1(param, al),  SUBREF():a) uses all { Call(&$a); }
+gen ax :=  CALLE2(ARG2(param, ax),  SUBREF():a) uses all { Call(&$a); }
+gen ax :=  CALLE2(ARG4(param, eax), SUBREF():a) uses all { Call(&$a); }
+gen eax := CALLE4(     param,       SUBREF():a) uses all { Call(&$a); }
+gen eax := CALLE4(ARG1(param, al),  SUBREF():a) uses all { Call(&$a); }
+gen eax := CALLE4(ARG2(param, ax),  SUBREF():a) uses all { Call(&$a); }
+gen eax := CALLE4(ARG4(param, eax), SUBREF():a) uses all { Call(&$a); }
 
-gen        CALL(       param,       ebx) uses r32                 { E_callebx(); }
-gen        CALL(  ARG1(param, al),  ebx) uses ebx|ecx|edx|esi|edi { E_callebx(); }
-gen        CALL(  ARG2(param, ax),  ebx) uses ebx|ecx|edx|esi|edi { E_callebx(); }
-gen        CALL(  ARG4(param, eax), ebx) uses ebx|ecx|edx|esi|edi { E_callebx(); }
-gen al :=  CALLE1(     param,       ebx) uses ebx|ecx|edx|esi|edi { E_callebx(); }
-gen al :=  CALLE1(ARG1(param, al),  ebx) uses ebx|ecx|edx|esi|edi { E_callebx(); }
-gen al :=  CALLE1(ARG2(param, ax),  ebx) uses ebx|ecx|edx|esi|edi { E_callebx(); }
-gen al :=  CALLE1(ARG4(param, eax), ebx) uses ebx|ecx|edx|esi|edi { E_callebx(); }
-gen ax :=  CALLE2(     param,       ebx) uses ebx|ecx|edx|esi|edi { E_callebx(); }
-gen ax :=  CALLE2(ARG1(param, al),  ebx) uses ebx|ecx|edx|esi|edi { E_callebx(); }
-gen ax :=  CALLE2(ARG2(param, ax),  ebx) uses ebx|ecx|edx|esi|edi { E_callebx(); }
-gen ax :=  CALLE2(ARG4(param, eax), ebx) uses ebx|ecx|edx|esi|edi { E_callebx(); }
-gen eax := CALLE4(     param,       ebx) uses ebx|ecx|edx|esi|edi { E_callebx(); }
-gen eax := CALLE4(ARG1(param, al),  ebx) uses ebx|ecx|edx|esi|edi { E_callebx(); }
-gen eax := CALLE4(ARG2(param, ax),  ebx) uses ebx|ecx|edx|esi|edi { E_callebx(); }
-gen eax := CALLE4(ARG4(param, eax), ebx) uses ebx|ecx|edx|esi|edi { E_callebx(); }
+gen        CALL(       param,       ebx) uses all { E_callebx(); }
+gen        CALL(  ARG1(param, al),  ebx) uses all { E_callebx(); }
+gen        CALL(  ARG2(param, ax),  ebx) uses all { E_callebx(); }
+gen        CALL(  ARG4(param, eax), ebx) uses all { E_callebx(); }
+gen al :=  CALLE1(     param,       ebx) uses all { E_callebx(); }
+gen al :=  CALLE1(ARG1(param, al),  ebx) uses all { E_callebx(); }
+gen al :=  CALLE1(ARG2(param, ax),  ebx) uses all { E_callebx(); }
+gen al :=  CALLE1(ARG4(param, eax), ebx) uses all { E_callebx(); }
+gen ax :=  CALLE2(     param,       ebx) uses all { E_callebx(); }
+gen ax :=  CALLE2(ARG1(param, al),  ebx) uses all { E_callebx(); }
+gen ax :=  CALLE2(ARG2(param, ax),  ebx) uses all { E_callebx(); }
+gen ax :=  CALLE2(ARG4(param, eax), ebx) uses all { E_callebx(); }
+gen eax := CALLE4(     param,       ebx) uses all { E_callebx(); }
+gen eax := CALLE4(ARG1(param, al),  ebx) uses all { E_callebx(); }
+gen eax := CALLE4(ARG2(param, ax),  ebx) uses all { E_callebx(); }
+gen eax := CALLE4(ARG4(param, eax), ebx) uses all { E_callebx(); }
 
 gen param := END();
 

--- a/src/cowbe/arch8080.cow.ng
+++ b/src/cowbe/arch8080.cow.ng
@@ -728,31 +728,31 @@ gen ENDSUB()
 	end sub;
 %}
 
-gen         CALL(       param,      SUBREF():a) uses a|bc|de|hl { Call(&$a); }
-gen         CALL(  ARG1(param, a),  SUBREF():a) uses a|bc|de|hl { Call(&$a); }
-gen         CALL(  ARG2(param, hl), SUBREF():a) uses a|bc|de|hl { Call(&$a); }
-gen a :=    CALLE1(     param,      SUBREF():a) uses   bc|de|hl { Call(&$a); }
-gen a :=    CALLE1(ARG1(param, a),  SUBREF():a) uses   bc|de|hl { Call(&$a); }
-gen a :=    CALLE1(ARG2(param, hl), SUBREF():a) uses   bc|de|hl { Call(&$a); }
-gen hl :=   CALLE2(     param,      SUBREF():a) uses a|bc|de    { Call(&$a); }
-gen hl :=   CALLE2(ARG1(param, a),  SUBREF():a) uses a|bc|de    { Call(&$a); }
-gen hl :=   CALLE2(ARG2(param, hl), SUBREF():a) uses a|bc|de    { Call(&$a); }
-gen stk4 := CALLE4(     param,      SUBREF():a) uses a|bc|de|hl { Call(&$a); }
-gen stk4 := CALLE4(ARG1(param, a),  SUBREF():a) uses a|bc|de|hl { Call(&$a); }
-gen stk4 := CALLE4(ARG2(param, hl), SUBREF():a) uses a|bc|de|hl { Call(&$a); }
+gen         CALL(       param,      SUBREF():a) uses all { Call(&$a); }
+gen         CALL(  ARG1(param, a),  SUBREF():a) uses all { Call(&$a); }
+gen         CALL(  ARG2(param, hl), SUBREF():a) uses all { Call(&$a); }
+gen a :=    CALLE1(     param,      SUBREF():a) uses all { Call(&$a); }
+gen a :=    CALLE1(ARG1(param, a),  SUBREF():a) uses all { Call(&$a); }
+gen a :=    CALLE1(ARG2(param, hl), SUBREF():a) uses all { Call(&$a); }
+gen hl :=   CALLE2(     param,      SUBREF():a) uses all { Call(&$a); }
+gen hl :=   CALLE2(ARG1(param, a),  SUBREF():a) uses all { Call(&$a); }
+gen hl :=   CALLE2(ARG2(param, hl), SUBREF():a) uses all { Call(&$a); }
+gen stk4 := CALLE4(     param,      SUBREF():a) uses all { Call(&$a); }
+gen stk4 := CALLE4(ARG1(param, a),  SUBREF():a) uses all { Call(&$a); }
+gen stk4 := CALLE4(ARG2(param, hl), SUBREF():a) uses all { Call(&$a); }
 
-gen         CALL(       param,      de) uses a|bc|hl { CallI(); }
-gen         CALL(  ARG1(param, a),  de) uses   bc|hl { CallI(); }
-gen         CALL(  ARG2(param, hl), de) uses a|bc    { CallI(); }
-gen a :=    CALLE1(     param,      de) uses   bc|hl { CallI(); }
-gen a :=    CALLE1(ARG1(param, a),  de) uses   bc|hl { CallI(); }
-gen a :=    CALLE1(ARG2(param, hl), de) uses   bc    { CallI(); }
-gen hl :=   CALLE2(     param,      de) uses a|bc    { CallI(); }
-gen hl :=   CALLE2(ARG1(param, a),  de) uses   bc    { CallI(); }
-gen hl :=   CALLE2(ARG2(param, hl), de) uses a|bc    { CallI(); }
-gen stk4 := CALLE4(     param,      de) uses a|bc|hl { CallI(); }
-gen stk4 := CALLE4(ARG1(param, a),  de) uses   bc|hl { CallI(); }
-gen stk4 := CALLE4(ARG2(param, hl), de) uses a|bc    { CallI(); }
+gen         CALL(       param,      de) uses all { CallI(); }
+gen         CALL(  ARG1(param, a),  de) uses all { CallI(); }
+gen         CALL(  ARG2(param, hl), de) uses all { CallI(); }
+gen a :=    CALLE1(     param,      de) uses all { CallI(); }
+gen a :=    CALLE1(ARG1(param, a),  de) uses all { CallI(); }
+gen a :=    CALLE1(ARG2(param, hl), de) uses all { CallI(); }
+gen hl :=   CALLE2(     param,      de) uses all { CallI(); }
+gen hl :=   CALLE2(ARG1(param, a),  de) uses all { CallI(); }
+gen hl :=   CALLE2(ARG2(param, hl), de) uses all { CallI(); }
+gen stk4 := CALLE4(     param,      de) uses all { CallI(); }
+gen stk4 := CALLE4(ARG1(param, a),  de) uses all { CallI(); }
+gen stk4 := CALLE4(ARG2(param, hl), de) uses all { CallI(); }
 
 gen param := END();
 

--- a/src/cowbe/arch8086.cow.ng
+++ b/src/cowbe/arch8086.cow.ng
@@ -571,39 +571,39 @@ gen mem4 := DEREF4(ADDRESS():a) cost 5 { $@$.operand.mem.sym := &$a.sym; $@$.ope
 	end sub;
 %}
 
-gen         CALL(       param,         SUBREF():a) uses ax|bx|cx|dx|si|di { Call(&$a); }
-gen         CALL(  ARG1(param, al),    SUBREF():a) uses    bx|cx|dx|si|di { Call(&$a); }
-gen         CALL(  ARG2(param, ax),    SUBREF():a) uses    bx|cx|dx|si|di { Call(&$a); }
-gen         CALL(  ARG4(param, dxax),  SUBREF():a) uses    bx|cx|dx|si|di { Call(&$a); }
-gen al   := CALLE1(     param,         SUBREF():a) uses    bx|cx|dx|si|di { Call(&$a); }
-gen al   := CALLE1(ARG1(param, al),    SUBREF():a) uses    bx|cx|dx|si|di { Call(&$a); }
-gen al   := CALLE1(ARG2(param, ax),    SUBREF():a) uses    bx|cx|dx|si|di { Call(&$a); }
-gen al   := CALLE1(ARG4(param, dxax),  SUBREF():a) uses    bx|cx|dx|si|di { Call(&$a); }
-gen ax   := CALLE2(     param,         SUBREF():a) uses    bx|cx|dx|si|di { Call(&$a); }
-gen ax   := CALLE2(ARG1(param, al),    SUBREF():a) uses    bx|cx|dx|si|di { Call(&$a); }
-gen ax   := CALLE2(ARG2(param, ax),    SUBREF():a) uses    bx|cx|dx|si|di { Call(&$a); }
-gen ax   := CALLE2(ARG4(param, dxax),  SUBREF():a) uses    bx|cx|dx|si|di { Call(&$a); }
-gen dxax := CALLE4(     param,         SUBREF():a) uses    bx|cx   |si|di { Call(&$a); }
-gen dxax := CALLE4(ARG1(param, al),    SUBREF():a) uses    bx|cx   |si|di { Call(&$a); }
-gen dxax := CALLE4(ARG2(param, ax),    SUBREF():a) uses    bx|cx   |si|di { Call(&$a); }
-gen dxax := CALLE4(ARG4(param, dxax),  SUBREF():a) uses    bx|cx   |si|di { Call(&$a); }
+gen         CALL(       param,         SUBREF():a) uses all { Call(&$a); }
+gen         CALL(  ARG1(param, al),    SUBREF():a) uses all { Call(&$a); }
+gen         CALL(  ARG2(param, ax),    SUBREF():a) uses all { Call(&$a); }
+gen         CALL(  ARG4(param, dxax),  SUBREF():a) uses all { Call(&$a); }
+gen al   := CALLE1(     param,         SUBREF():a) uses all { Call(&$a); }
+gen al   := CALLE1(ARG1(param, al),    SUBREF():a) uses all { Call(&$a); }
+gen al   := CALLE1(ARG2(param, ax),    SUBREF():a) uses all { Call(&$a); }
+gen al   := CALLE1(ARG4(param, dxax),  SUBREF():a) uses all { Call(&$a); }
+gen ax   := CALLE2(     param,         SUBREF():a) uses all { Call(&$a); }
+gen ax   := CALLE2(ARG1(param, al),    SUBREF():a) uses all { Call(&$a); }
+gen ax   := CALLE2(ARG2(param, ax),    SUBREF():a) uses all { Call(&$a); }
+gen ax   := CALLE2(ARG4(param, dxax),  SUBREF():a) uses all { Call(&$a); }
+gen dxax := CALLE4(     param,         SUBREF():a) uses all { Call(&$a); }
+gen dxax := CALLE4(ARG1(param, al),    SUBREF():a) uses all { Call(&$a); }
+gen dxax := CALLE4(ARG2(param, ax),    SUBREF():a) uses all { Call(&$a); }
+gen dxax := CALLE4(ARG4(param, dxax),  SUBREF():a) uses all { Call(&$a); }
 
-gen         CALL(       param,        bx) uses ax|cx|dx|si|di { CallBX(); }
-gen         CALL(  ARG1(param, al),   bx) uses    cx|dx|si|di { CallBX(); }
-gen         CALL(  ARG2(param, ax),   bx) uses    cx|dx|si|di { CallBX(); }
-gen         CALL(  ARG4(param, dxax), bx) uses    cx|dx|si|di { CallBX(); }
-gen al   := CALLE1(     param,        bx) uses    cx|dx|si|di { CallBX(); }
-gen al   := CALLE1(ARG1(param, al),   bx) uses    cx|dx|si|di { CallBX(); }
-gen al   := CALLE1(ARG2(param, ax),   bx) uses    cx|dx|si|di { CallBX(); }
-gen al   := CALLE1(ARG4(param, dxax), bx) uses    cx|dx|si|di { CallBX(); }
-gen ax   := CALLE2(     param,        bx) uses    cx|dx|si|di { CallBX(); }
-gen ax   := CALLE2(ARG1(param, al),   bx) uses    cx|dx|si|di { CallBX(); }
-gen ax   := CALLE2(ARG2(param, ax),   bx) uses    cx|dx|si|di { CallBX(); }
-gen ax   := CALLE2(ARG4(param, dxax), bx) uses    cx|dx|si|di { CallBX(); }
-gen dxax := CALLE4(     param,        bx) uses    cx|dx|si|di { CallBX(); }
-gen dxax := CALLE4(ARG1(param, al),   bx) uses    cx|dx|si|di { CallBX(); }
-gen dxax := CALLE4(ARG2(param, ax),   bx) uses    cx|dx|si|di { CallBX(); }
-gen dxax := CALLE4(ARG4(param, dxax), bx) uses    cx|dx|si|di { CallBX(); }
+gen         CALL(       param,        bx) uses all { CallBX(); }
+gen         CALL(  ARG1(param, al),   bx) uses all { CallBX(); }
+gen         CALL(  ARG2(param, ax),   bx) uses all { CallBX(); }
+gen         CALL(  ARG4(param, dxax), bx) uses all { CallBX(); }
+gen al   := CALLE1(     param,        bx) uses all { CallBX(); }
+gen al   := CALLE1(ARG1(param, al),   bx) uses all { CallBX(); }
+gen al   := CALLE1(ARG2(param, ax),   bx) uses all { CallBX(); }
+gen al   := CALLE1(ARG4(param, dxax), bx) uses all { CallBX(); }
+gen ax   := CALLE2(     param,        bx) uses all { CallBX(); }
+gen ax   := CALLE2(ARG1(param, al),   bx) uses all { CallBX(); }
+gen ax   := CALLE2(ARG2(param, ax),   bx) uses all { CallBX(); }
+gen ax   := CALLE2(ARG4(param, dxax), bx) uses all { CallBX(); }
+gen dxax := CALLE4(     param,        bx) uses all { CallBX(); }
+gen dxax := CALLE4(ARG1(param, al),   bx) uses all { CallBX(); }
+gen dxax := CALLE4(ARG2(param, ax),   bx) uses all { CallBX(); }
+gen dxax := CALLE4(ARG4(param, dxax), bx) uses all { CallBX(); }
 
 gen param := END();
 

--- a/src/cowbe/archpdp11.cow.ng
+++ b/src/cowbe/archpdp11.cow.ng
@@ -1149,39 +1149,39 @@ gen RETURN()
 	end sub;
 %}
 
-gen         CALL(       param,        SUBREF():a) uses r32          { Call(&$a); }
-gen         CALL(  ARG1(param, r0b),  SUBREF():a) uses r1|r2r3|r4r5 { Call(&$a); }
-gen         CALL(  ARG2(param, r0),   SUBREF():a) uses r1|r2r3|r4r5 { Call(&$a); }
-gen         CALL(  ARG4(param, r0r1), SUBREF():a) uses r2r3|r4r5    { Call(&$a); }
-gen r0b :=  CALLE1(     param,        SUBREF():a) uses r1|r2r3|r4r5 { Call(&$a); }
-gen r0b :=  CALLE1(ARG1(param, r0b),  SUBREF():a) uses r1|r2r3|r4r5 { Call(&$a); }
-gen r0b :=  CALLE1(ARG2(param, r0),   SUBREF():a) uses r1|r2r3|r4r5 { Call(&$a); }
-gen r0b :=  CALLE1(ARG4(param, r0r1), SUBREF():a) uses r2r3|r4r5    { Call(&$a); }
-gen r0  :=  CALLE2(     param,        SUBREF():a) uses r1|r2r3|r4r5 { Call(&$a); }
-gen r0  :=  CALLE2(ARG1(param, r0b),  SUBREF():a) uses r1|r2r3|r4r5 { Call(&$a); }
-gen r0  :=  CALLE2(ARG2(param, r0),   SUBREF():a) uses r1|r2r3|r4r5 { Call(&$a); }
-gen r0  :=  CALLE2(ARG4(param, r0r1), SUBREF():a) uses r2r3|r4r5    { Call(&$a); }
-gen r0r1 := CALLE4(     param,        SUBREF():a) uses r2r3|r4r5    { Call(&$a); }
-gen r0r1 := CALLE4(ARG1(param, r0b),  SUBREF():a) uses r2r3|r4r5    { Call(&$a); }
-gen r0r1 := CALLE4(ARG2(param, r0),   SUBREF():a) uses r2r3|r4r5    { Call(&$a); }
-gen r0r1 := CALLE4(ARG4(param, r0r1), SUBREF():a) uses r2r3|r4r5    { Call(&$a); }
+gen         CALL(       param,        SUBREF():a) uses all { Call(&$a); }
+gen         CALL(  ARG1(param, r0b),  SUBREF():a) uses all { Call(&$a); }
+gen         CALL(  ARG2(param, r0),   SUBREF():a) uses all { Call(&$a); }
+gen         CALL(  ARG4(param, r0r1), SUBREF():a) uses all { Call(&$a); }
+gen r0b :=  CALLE1(     param,        SUBREF():a) uses all { Call(&$a); }
+gen r0b :=  CALLE1(ARG1(param, r0b),  SUBREF():a) uses all { Call(&$a); }
+gen r0b :=  CALLE1(ARG2(param, r0),   SUBREF():a) uses all { Call(&$a); }
+gen r0b :=  CALLE1(ARG4(param, r0r1), SUBREF():a) uses all { Call(&$a); }
+gen r0  :=  CALLE2(     param,        SUBREF():a) uses all { Call(&$a); }
+gen r0  :=  CALLE2(ARG1(param, r0b),  SUBREF():a) uses all { Call(&$a); }
+gen r0  :=  CALLE2(ARG2(param, r0),   SUBREF():a) uses all { Call(&$a); }
+gen r0  :=  CALLE2(ARG4(param, r0r1), SUBREF():a) uses all { Call(&$a); }
+gen r0r1 := CALLE4(     param,        SUBREF():a) uses all { Call(&$a); }
+gen r0r1 := CALLE4(ARG1(param, r0b),  SUBREF():a) uses all { Call(&$a); }
+gen r0r1 := CALLE4(ARG2(param, r0),   SUBREF():a) uses all { Call(&$a); }
+gen r0r1 := CALLE4(ARG4(param, r0r1), SUBREF():a) uses all { Call(&$a); }
 
-gen         CALL(       param,        r2) uses r0|r1|r3|r4r5 { CallR2(); }
-gen         CALL(  ARG1(param, r0b),  r2) uses r1|r3|r4r5    { CallR2(); }
-gen         CALL(  ARG2(param, r0),   r2) uses r1|r3|r4r5    { CallR2(); }
-gen         CALL(  ARG4(param, r0r1), r2) uses r3|r4r5       { CallR2(); }
-gen r0b :=  CALLE1(     param,        r2) uses r1|r3|r4r5    { CallR2(); }
-gen r0b :=  CALLE1(ARG1(param, r0b),  r2) uses r1|r3|r4r5    { CallR2(); }
-gen r0b :=  CALLE1(ARG2(param, r0),   r2) uses r1|r3|r4r5    { CallR2(); }
-gen r0b :=  CALLE1(ARG4(param, r0r1), r2) uses r3|r4r5       { CallR2(); }
-gen r0  :=  CALLE2(     param,        r2) uses r1|r3|r4r5    { CallR2(); }
-gen r0  :=  CALLE2(ARG1(param, r0b),  r2) uses r1|r3|r4r5    { CallR2(); }
-gen r0  :=  CALLE2(ARG2(param, r0),   r2) uses r1|r3|r4r5    { CallR2(); }
-gen r0  :=  CALLE2(ARG4(param, r0r1), r2) uses r3|r4r5       { CallR2(); }
-gen r0r1 := CALLE4(     param,        r2) uses r3|r4r5       { CallR2(); }
-gen r0r1 := CALLE4(ARG1(param, r0b),  r2) uses r3|r4r5       { CallR2(); }
-gen r0r1 := CALLE4(ARG2(param, r0),   r2) uses r3|r4r5       { CallR2(); }
-gen r0r1 := CALLE4(ARG4(param, r0r1), r2) uses r3|r4r5       { CallR2(); }
+gen         CALL(       param,        r2) uses all { CallR2(); }
+gen         CALL(  ARG1(param, r0b),  r2) uses all { CallR2(); }
+gen         CALL(  ARG2(param, r0),   r2) uses all { CallR2(); }
+gen         CALL(  ARG4(param, r0r1), r2) uses all { CallR2(); }
+gen r0b :=  CALLE1(     param,        r2) uses all { CallR2(); }
+gen r0b :=  CALLE1(ARG1(param, r0b),  r2) uses all { CallR2(); }
+gen r0b :=  CALLE1(ARG2(param, r0),   r2) uses all { CallR2(); }
+gen r0b :=  CALLE1(ARG4(param, r0r1), r2) uses all { CallR2(); }
+gen r0  :=  CALLE2(     param,        r2) uses all { CallR2(); }
+gen r0  :=  CALLE2(ARG1(param, r0b),  r2) uses all { CallR2(); }
+gen r0  :=  CALLE2(ARG2(param, r0),   r2) uses all { CallR2(); }
+gen r0  :=  CALLE2(ARG4(param, r0r1), r2) uses all { CallR2(); }
+gen r0r1 := CALLE4(     param,        r2) uses all { CallR2(); }
+gen r0r1 := CALLE4(ARG1(param, r0b),  r2) uses all { CallR2(); }
+gen r0r1 := CALLE4(ARG2(param, r0),   r2) uses all { CallR2(); }
+gen r0r1 := CALLE4(ARG4(param, r0r1), r2) uses all { CallR2(); }
 
 gen param := END();
 

--- a/src/cowbe/archthumb2.cow.ng
+++ b/src/cowbe/archthumb2.cow.ng
@@ -385,39 +385,39 @@ gen r32 := ADDRESS():a
 	end sub;
 %}
 
-gen       CALL(       param,      SUBREF():a) uses r32     { Call(&$a); }
-gen       CALL(  ARG1(param, r0), SUBREF():a) uses r32|~r0 { Call(&$a); }
-gen       CALL(  ARG2(param, r0), SUBREF():a) uses r32|~r0 { Call(&$a); }
-gen       CALL(  ARG4(param, r0), SUBREF():a) uses r32|~r0 { Call(&$a); }
-gen r0 := CALLE1(     param,      SUBREF():a) uses r32|~r0 { Call(&$a); }
-gen r0 := CALLE1(ARG1(param, r0), SUBREF():a) uses r32|~r0 { Call(&$a); }
-gen r0 := CALLE1(ARG2(param, r0), SUBREF():a) uses r32|~r0 { Call(&$a); }
-gen r0 := CALLE1(ARG4(param, r0), SUBREF():a) uses r32|~r0 { Call(&$a); }
-gen r0 := CALLE2(     param,      SUBREF():a) uses r32|~r0 { Call(&$a); }
-gen r0 := CALLE2(ARG1(param, r0), SUBREF():a) uses r32|~r0 { Call(&$a); }
-gen r0 := CALLE2(ARG2(param, r0), SUBREF():a) uses r32|~r0 { Call(&$a); }
-gen r0 := CALLE2(ARG4(param, r0), SUBREF():a) uses r32|~r0 { Call(&$a); }
-gen r0 := CALLE4(     param,      SUBREF():a) uses r32|~r0 { Call(&$a); }
-gen r0 := CALLE4(ARG1(param, r0), SUBREF():a) uses r32|~r0 { Call(&$a); }
-gen r0 := CALLE4(ARG2(param, r0), SUBREF():a) uses r32|~r0 { Call(&$a); }
-gen r0 := CALLE4(ARG4(param, r0), SUBREF():a) uses r32|~r0 { Call(&$a); }
+gen       CALL(       param,      SUBREF():a) uses all { Call(&$a); }
+gen       CALL(  ARG1(param, r0), SUBREF():a) uses all { Call(&$a); }
+gen       CALL(  ARG2(param, r0), SUBREF():a) uses all { Call(&$a); }
+gen       CALL(  ARG4(param, r0), SUBREF():a) uses all { Call(&$a); }
+gen r0 := CALLE1(     param,      SUBREF():a) uses all { Call(&$a); }
+gen r0 := CALLE1(ARG1(param, r0), SUBREF():a) uses all { Call(&$a); }
+gen r0 := CALLE1(ARG2(param, r0), SUBREF():a) uses all { Call(&$a); }
+gen r0 := CALLE1(ARG4(param, r0), SUBREF():a) uses all { Call(&$a); }
+gen r0 := CALLE2(     param,      SUBREF():a) uses all { Call(&$a); }
+gen r0 := CALLE2(ARG1(param, r0), SUBREF():a) uses all { Call(&$a); }
+gen r0 := CALLE2(ARG2(param, r0), SUBREF():a) uses all { Call(&$a); }
+gen r0 := CALLE2(ARG4(param, r0), SUBREF():a) uses all { Call(&$a); }
+gen r0 := CALLE4(     param,      SUBREF():a) uses all { Call(&$a); }
+gen r0 := CALLE4(ARG1(param, r0), SUBREF():a) uses all { Call(&$a); }
+gen r0 := CALLE4(ARG2(param, r0), SUBREF():a) uses all { Call(&$a); }
+gen r0 := CALLE4(ARG4(param, r0), SUBREF():a) uses all { Call(&$a); }
 
-gen       CALL(       param,      r1) uses r32     { CallR1(); }
-gen       CALL(  ARG1(param, r0), r1) uses r32|~r0 { CallR1(); }
-gen       CALL(  ARG2(param, r0), r1) uses r32|~r0 { CallR1(); }
-gen       CALL(  ARG4(param, r0), r1) uses r32|~r0 { CallR1(); }
-gen r0 := CALLE1(     param,      r1) uses r32|~r0 { CallR1(); }
-gen r0 := CALLE1(ARG1(param, r0), r1) uses r32|~r0 { CallR1(); }
-gen r0 := CALLE1(ARG2(param, r0), r1) uses r32|~r0 { CallR1(); }
-gen r0 := CALLE1(ARG4(param, r0), r1) uses r32|~r0 { CallR1(); }
-gen r0 := CALLE2(     param,      r1) uses r32|~r0 { CallR1(); }
-gen r0 := CALLE2(ARG1(param, r0), r1) uses r32|~r0 { CallR1(); }
-gen r0 := CALLE2(ARG2(param, r0), r1) uses r32|~r0 { CallR1(); }
-gen r0 := CALLE2(ARG4(param, r0), r1) uses r32|~r0 { CallR1(); }
-gen r0 := CALLE4(     param,      r1) uses r32|~r0 { CallR1(); }
-gen r0 := CALLE4(ARG1(param, r0), r1) uses r32|~r0 { CallR1(); }
-gen r0 := CALLE4(ARG2(param, r0), r1) uses r32|~r0 { CallR1(); }
-gen r0 := CALLE4(ARG4(param, r0), r1) uses r32|~r0 { CallR1(); }
+gen       CALL(       param,      r1) uses all { CallR1(); }
+gen       CALL(  ARG1(param, r0), r1) uses all { CallR1(); }
+gen       CALL(  ARG2(param, r0), r1) uses all { CallR1(); }
+gen       CALL(  ARG4(param, r0), r1) uses all { CallR1(); }
+gen r0 := CALLE1(     param,      r1) uses all { CallR1(); }
+gen r0 := CALLE1(ARG1(param, r0), r1) uses all { CallR1(); }
+gen r0 := CALLE1(ARG2(param, r0), r1) uses all { CallR1(); }
+gen r0 := CALLE1(ARG4(param, r0), r1) uses all { CallR1(); }
+gen r0 := CALLE2(     param,      r1) uses all { CallR1(); }
+gen r0 := CALLE2(ARG1(param, r0), r1) uses all { CallR1(); }
+gen r0 := CALLE2(ARG2(param, r0), r1) uses all { CallR1(); }
+gen r0 := CALLE2(ARG4(param, r0), r1) uses all { CallR1(); }
+gen r0 := CALLE4(     param,      r1) uses all { CallR1(); }
+gen r0 := CALLE4(ARG1(param, r0), r1) uses all { CallR1(); }
+gen r0 := CALLE4(ARG2(param, r0), r1) uses all { CallR1(); }
+gen r0 := CALLE4(ARG4(param, r0), r1) uses all { CallR1(); }
 
 gen param := END();
 

--- a/src/cowbe/codegen.coh
+++ b/src/cowbe/codegen.coh
@@ -23,6 +23,7 @@ record Instruction is
 	producable_regs: RegId;
 	produced_reg: RegId;
 	input_regs: RegId;
+	used_regs: RegId;
 	output_regs: RegId;
 	spills: RegMove[MAX_MOVE_COUNT];
 	reloads: RegMove[MAX_MOVE_COUNT];
@@ -117,7 +118,7 @@ sub CalculateBlockedRegisters(insn: [Instruction], last: [Instruction]): (blocke
 	blocked := 0;
 	insn := insn.next;
 	while insn != last loop
-		blocked := blocked | insn.input_regs | insn.output_regs;
+		blocked := blocked | insn.input_regs | insn.output_regs | insn.used_regs;
 		if insn == last then
 			break;
 		end if;
@@ -130,6 +131,7 @@ sub BlockRegisters(insn: [Instruction], last: [Instruction], blocked: RegId) is
 	insn := insn.next;
 	while insn != last loop
 		insn.input_regs := insn.input_regs | blocked;
+		insn.used_regs := insn.used_regs | blocked;
 		insn.output_regs := insn.output_regs | blocked;
 		if insn == last then
 			break;
@@ -476,7 +478,7 @@ sub Generate(rootnode: [Node]) is
 
 			producer.ruleid := ruleid;
 			producer.producable_regs := rule.producable_regs;
-			producer.output_regs := rule.uses_regs;
+			producer.used_regs := rule.uses_regs;
 
 			# Copy child nodes into the current instruction and make sure they're
 			# pushed for later instruction allocation.

--- a/tools/newgen/main.c
+++ b/tools/newgen/main.c
@@ -708,6 +708,7 @@ int main(int argc, const char* argv[])
 		fatal("cannot open output H file '%s': %s", argv[3], strerror(errno));
 
 	include_file(open_file(infp));
+	define_regclass("all", -1);
 	parse();
 
 	sort_rules();


### PR DESCRIPTION
This makes dealing with them much easier. In the rule files, you can now say 'uses all' to corrupt all registers, and still have normal inputs and outputs.