### PR TITLE
Doc fix: no sub without () allowed

### DIFF
--- a/doc/language.md
+++ b/doc/language.md
@@ -35,7 +35,7 @@ end if
 # subroutine with one input parameter
 sub ThisIsASubroutine(i: uint8) is
   # subroutine with no input or output parameters
-  sub ThisIsANestedSubroutine is
+  sub ThisIsANestedSubroutine() is
     print("nested subroutines can access upvalues!");
     print_i8(i);
   end sub;


### PR DESCRIPTION
When I copy-pasted this piece of code for testing, it tripped on the missing braces. Uh, and on the missing import that I forgot to add in this PR.