### PR TITLE
partial register cache invalidation

### DIFF
--- a/src/cowbe/arch6303.cow.ng
+++ b/src/cowbe/arch6303.cow.ng
@@ -328,6 +328,7 @@
             when REG_IMM:
                 RegCacheLeavesConstant(srcreg, operand.imm.value as uint16);
             when REG_MEM:
+                RegCacheFlushValue(operand.mem.sym, operand.mem.off);
                 RegCacheLeavesValue(srcreg, operand.mem.sym, operand.mem.off);
         end case;
     end sub;

--- a/src/cowbe/arch6502.cow.ng
+++ b/src/cowbe/arch6502.cow.ng
@@ -1418,6 +1418,7 @@ gen STORE1(a:lhs, DEREF1(ptrs)) uses y
 
 gen STORE1(a|x|y:lhs, DEREF1(ADDRESS():a))
 {
+    RegCacheFlushValue(&$a.sym, $a.off);
     E_st($lhs);
     E_symref(&$a.sym, $a.off);
     E_nl();

--- a/src/cowbe/arch80386.cow.ng
+++ b/src/cowbe/arch80386.cow.ng
@@ -217,6 +217,7 @@
 	end sub;
 
 	sub E_store(reg: RegId, sym: [Symbol], off: Size, index: RegId) is
+		RegCacheFlushValue(sym, off);
 		E_mov(reg);
 		E_reg(reg);
 		E(", (");

--- a/src/cowbe/archpdp11.cow.ng
+++ b/src/cowbe/archpdp11.cow.ng
@@ -221,6 +221,7 @@
 	end sub;
 
 	sub E_store(reg: RegId, sym: [Symbol], off: Size, byte: uint8) is
+		RegCacheFlushValue(sym, off);
 		E_mov(reg);
 		E_reg(reg);
 		E(", ");

--- a/src/cowbe/archz80.cow.ng
+++ b/src/cowbe/archz80.cow.ng
@@ -341,6 +341,7 @@
 	end sub;
 
 	sub E_store16(src: RegId, sym: [Symbol], off: Size) is
+		RegCacheFlushValue(sym, off);
 		E("\tld (");
 		E_symref(sym, off);
 		E("), ");
@@ -1199,6 +1200,7 @@ gen STORE4(r32:val, DEREF4(ADD2(ix|iy:ptr, CONSTANT(value is indexable_32bit):c)
 
 gen STORE4(r32:val, DEREF4(ADDRESS():a))
 {
+	RegCacheFlushValue(&$a.sym, $a.off);
 	E_store16(wordreg($val), &$a.sym, $a.off);
 	E_exx();
 	E_store16(wordreg($val), &$a.sym, $a.off+2);

--- a/src/cowbe/codegen.coh
+++ b/src/cowbe/codegen.coh
@@ -129,6 +129,10 @@ sub FindLast(inreg: RegId): (outreg: RegId) is
 	end loop;
 end sub;
 
+sub RegCacheFlushValue(sym: [Symbol], off: Size) is
+    RegCacheFlush(FindConflictingRegisters(RegCacheFindValue(sym, off)));
+end sub;
+
 sub FindBitNumber(reg: RegId): (bit: uint8) is
 	bit := 0;
 	while reg != 0 loop


### PR DESCRIPTION
I was trying to make register allocator respect register cache; this didn't produce smaller code but exposed these missing cache invalidations.