### PR TITLE
pdp11 experiment: don't flush register cache before a forward jump

### DIFF
--- a/src/cowbe/archpdp11.cow.ng
+++ b/src/cowbe/archpdp11.cow.ng
@@ -35,7 +35,9 @@
 	end sub;
 
 	sub E_label(label: LabelRef) is
+		if (label & 1) != 0 then
 		R_flushall();
+		end if;
 		E_labelref(label);
 		E(":\n");
 	end sub;
@@ -1122,7 +1124,7 @@ gen STARTSUB() uses all
 
 gen ENDSUB() uses all
 {
-	R_flushall();
+#	R_flushall();
 
 	E("end_");
 	E_subref(current_subr);
@@ -1474,10 +1476,10 @@ gen r32   := RSHIFTS4($$:lhs, CONSTANT():c)      { E_sari4($c.value as uint8, $l
 %{
 	sub CmpJumps(trueinsn: string, falseinsn: string, node: [Node]) is
 		if node.beq.truelabel != node.beq.fallthrough then
-			E_jump(trueinsn, node.beq.truelabel);
+			E_jump_noflush(trueinsn, node.beq.truelabel);
 		end if;
 		if node.beq.falselabel != node.beq.fallthrough then
-			E_jump(falseinsn, node.beq.falselabel);
+			E_jump_noflush(falseinsn, node.beq.falselabel);
 		end if;
 	end sub;
 

--- a/src/cowbe/codegen.coh
+++ b/src/cowbe/codegen.coh
@@ -53,7 +53,7 @@ var emitting_asm: uint8 := 0;
 
 sub AllocLabel(): (label: LabelRef) is
 	label := next_label_id;
-	next_label_id := next_label_id + 1;
+	next_label_id := next_label_id + 2;
 end sub;
 
 sub AllocSubrId(): (id: uint16) is
@@ -1081,7 +1081,7 @@ sub GenerateConditional(rootnode: [Node]) is
 		var rr: LabelRef;
 		case op is
 			when MIDCODE_BOR:
-				rr := AllocLabel();
+				rr := AllocLabel() + 1;
 
 				lhs.beq.truelabel := t;
 				lhs.beq.falselabel := rr;
@@ -1090,7 +1090,7 @@ sub GenerateConditional(rootnode: [Node]) is
 				push_and_free();
 
 			when MIDCODE_BAND:
-				rr := AllocLabel();
+				rr := AllocLabel() + 1;
 
 				lhs.beq.truelabel := rr;
 				lhs.beq.falselabel := f;

--- a/src/cowfe/codegen.coh
+++ b/src/cowfe/codegen.coh
@@ -1,6 +1,6 @@
 sub AllocLabel(): (label: LabelRef) is
 	label := next_label_id;
-	next_label_id := next_label_id + 1;
+	next_label_id := next_label_id + 2;
 end sub;
 
 sub AllocSubrId(): (id: uint16) is
@@ -100,7 +100,7 @@ sub GenerateConditional(rootnode: [Node]) is
 		var rr: LabelRef;
 		case op is
 			when MIDCODE_BOR:
-				rr := AllocLabel();
+				rr := AllocLabel() + 1;
 
 				lhs.beq.truelabel := t;
 				lhs.beq.falselabel := rr;
@@ -109,7 +109,7 @@ sub GenerateConditional(rootnode: [Node]) is
 				push_and_free();
 
 			when MIDCODE_BAND:
-				rr := AllocLabel();
+				rr := AllocLabel() + 1;
 
 				lhs.beq.truelabel := rr;
 				lhs.beq.falselabel := f;

--- a/src/cowfe/parser.y
+++ b/src/cowfe/parser.y
@@ -212,8 +212,8 @@ if_begin ::= .
 
 if_conditional ::= conditional(C).
 {
-	var t := AllocLabel();
-	var f := AllocLabel();
+	var t := AllocLabel() + 1;
+	var f := AllocLabel() + 1;
 	current_if.true_label := t;
 	current_if.false_label := f;
 	C.beq.truelabel := t;


### PR DESCRIPTION
This is quite hacky and probably not fit for merge as is, but does save about 1% of binary size:
```
13900->13736 bin/cowasm-for-pdp11-with-unixv7
35606->35408 bin/cowbe-for-pdp11-with-unixv7
39640->39218 bin/cowfe-for-pdp11-with-unixv7
10128->10008 bin/cowlink-for-v7unix-with-unixv7
```

Thoughts?