### PR TITLE
Add experimental runtime for ANDOS on Electronika BK.

### DIFF
--- a/rt/bk10/build.py
+++ b/rt/bk10/build.py
@@ -1,0 +1,3 @@
+from src.build import cowwrap
+
+cowwrap(name="cowgolcoo", src="./cowgol.cos")

--- a/rt/bk10/cowgol.coh
+++ b/rt/bk10/cowgol.coh
@@ -1,0 +1,68 @@
+var LOMEM: [uint8];
+var HIMEM: [uint8];
+var HW: int16;
+var API: int16;
+
+@asm "mov himem, ", HIMEM;
+@asm "mov #bss_end+2, ", LOMEM;
+@asm "mov hw, ", HW;
+@asm "mov api, ", API;
+
+sub Exit() is
+	@asm "br exit";
+end sub;
+
+sub ExitWithError() is
+	@asm "br exit";
+end sub;
+
+sub AlignUp(in: intptr): (out: intptr) is
+	out := (in + 1) & ~1;
+end sub;
+
+# only bk10 does auto CR on LF
+sub print_char(c: uint8) is
+	if API > 0 and c == '\n' then
+		case API is
+			when 2:
+			@asm "mov #15o, r0";
+			@asm "emt 16o";
+			when 1:
+			@asm "mov #15o, r0";
+			@asm "call @140156o";
+		end case;
+	end if;
+	@asm "mov", c, ", r0";
+	@asm "cmp", API, ", #1";
+	@asm "bne pc2";
+	@asm "call @140156o";
+	@asm "ret";
+	@asm "pc2: emt 16o";
+end sub;
+
+sub MemSet(buf: [uint8], byte: uint8, len: uint16) is
+	var bufend := buf + len;
+	@asm "mov", buf, ", r0";
+	@asm "mov", len, ", r1";
+	@asm "movb", byte, ", r2";
+	@asm "movb r2, (r0)+";
+	@asm "sob r1, $-2";
+end sub;
+
+sub print_oct_i16(value: uint16) is
+	var i: uint8 := 5;
+	if (value & 0o100000) != 0 then print_char('1'); else print_char('0'); end if;
+	loop
+		var digit := (((value >> 12) & 7) + '0') as uint8;
+		print_char(digit);
+		value := value << 3;
+		i := i - 1;
+		if i == 0 then
+			break;
+		end if;
+	end loop;
+end sub;
+
+include "common.coh";
+
+# vim: ts=4 sw=4 noet

--- a/rt/bk10/cowgol.cos
+++ b/rt/bk10/cowgol.cos
@@ -1,0 +1,84 @@
+# Unsigned 32-bit division.
+# Computes r2r3/r0r1, putting the quotient in r2r3 and the remainder in r4r5.
+&X _divremu4
+	; _divremu4
+``:
+	; The PDP11 has a 32/16->16%16 signed division instruction. Synthesising
+	; 32/32->32%32 unsigned division from this is surprisingly hard, so for
+    ; now we don't bother and just use long division.
+
+    clr r4              ; reset remainder
+    clr r5
+    mov r0, -(sp)       ; move hi(RHS) onto the stack, as we need r0...
+    mov #32, r0         ; ...for the loop counter
+    br ``_entry
+
+``_loop:
+    dec r0
+    beq ``_exit
+``_entry:
+    ashc #1, r2         ; left shift LHS
+    rol r5              ; ...moving the shifted out top bit into the remainder
+    rol r4
+
+    cmp r4, 0(sp)       ; if remainder < RHS, loop without subtracting
+    bcs ``_loop
+    cmp r5, r1
+    bcs ``_loop
+
+    inc r3              ; set the bottom bit of the quotient (guaranteed to be 0)
+    sub 0(sp), r4       ; remainder = remainder - RHS
+    sbc r5
+    sub r1, r5
+    br ``_loop
+``_exit:
+    mov (sp)+, r0       ; retract stack
+    ret
+
+# Signed 32-bit division.
+# Computes r2r3/r0r1, putting the quotient in r2r3 and the remainder in r4r5.
+# This is a wrapper around _divremu4 above.
+&X _divrems4
+	; _divrems4
+``:
+    xor r2, r0          ; discover sign of result
+    mov r0, -(sp)       ; save for later
+    xor r2, r0          ; recover result
+    mov r2, -(sp)       ; save result for sign of remainder
+
+    tst r0              ; set flags from hi(rhs)
+    bpl ``_1
+    com r0              ; negate r0r1
+    com r1
+    add #1, r1          ; add (setting carry)
+    adc r0
+``_1:
+    tst r2              ; set flags from hi(lhs)
+    bpl ``_2
+    com r2              ; negate r2r3
+    com r3
+    add #1, r3
+    adc r2
+``_2:
+
+    call `_divremu4     ; perform unsigned division
+
+    tst 0(sp)           ; check sign of remainder
+    bpl ``_3
+    com r4
+    com r5
+    add #1, r5
+    adc r4
+``_3:
+    tst 2(sp)           ; check sign of quotient
+    bpl ``_4
+    com r2
+    com r3
+    add #1, r3
+    adc r2
+``_4:
+    add #4, sp          ; retract over stack
+    ret
+
+# vim: ts=4 sw=4 et
+

--- a/rt/bk10/crtany.coh
+++ b/rt/bk10/crtany.coh
@@ -1,0 +1,83 @@
+# API==0 only
+
+const T_3264  := 0o233;
+const T_DC    := 0o202;
+const T_GRAPH := 0o225;
+
+const T_RED   := 0o221;
+const T_GREEN := 0o222;
+const T_BLUE  := 0o223;
+const T_BLACK := 0o224;
+
+const T_LIGHT := 0o235;
+const T_CURSOR:= 0o232;
+const T_UL    := 0o237;
+const T_RV    := 0o234;
+
+#
+
+# write to system (status) line
+sub putsysc(c: uint8, x: uint8) is
+	if API == 0 then
+		@asm "movb", c, ", r0";
+		@asm "movb", x, ", r1";
+		@asm "emt 22o";
+	elseif API == 2 then
+		@asm "clr -(sp)";
+		@asm "bisb", c, ", (sp)";
+		@asm "clr -(sp)";
+		@asm "bisb", x, ", (sp)";
+		@asm "emt 22o";
+	end if;
+end sub;
+
+sub puts(s: [uint8]) is
+	if API != 0 then print(s); return; end if;
+	@asm "mov", s, ", r1";
+	@asm "clr r2";
+	@asm "emt 20o";
+end sub;
+
+sub crtstatus(): (ret: uint16) is
+	@asm "emt 34o";
+	@asm "mov r0,", ret;
+end sub;
+
+sub crtsane() is
+	case API is
+		when 0:
+			var crt := crtstatus();
+			if (crt & ((1 << 0) | (1 << 4) | (1 << 5) | (1 << 6) | (1 << 8) | (1 << 14))) == 0 then return; end if;
+			if (crt & (1 << 0)) != 0 then print_char(T_3264); end if;	# reset 32-char mode
+			if (crt & (1 << 4)) != 0 then print_char(T_UL); end if;	# reset underline attr
+			if (crt & (1 << 5)) != 0 then print_char(T_RV); end if;	# reset inverse attr
+			if (crt & (1 << 6)) != 0 then print_char(T_DC); end if;	# reset display controls mode
+			if (crt & (1 << 8)) != 0 then print_char(T_GRAPH); end if;	# reset graphics mode
+			if (crt & (1 << 14)) != 0 then print_char(T_CURSOR); end if;	# enable cursor
+		when 2:
+			var buf: uint16[] := { 2, 0, 0, 0, 0, 0o200 | (0o200 << 8) };
+			var pcrt: [uint16] := &buf[0];
+			@asm "mov", pcrt, ", r0";
+			@asm "emt 64o";
+		when 1:
+			puts("\e1\e4\e7\e8\eO\eU");
+		end case;
+end sub;
+
+# turn off cursor for faster text output
+sub crtcursor() is
+	case API is
+		when 0: print_char(T_CURSOR);
+		when 2:
+			var buf: uint16[6];
+			var pcrt: [uint16] := &buf[0];
+			@asm "mov", pcrt, ", r0";
+			@asm "emt 34o";
+			buf[0] := buf[0] | 0x2000;
+			@asm "mov", pcrt, ", r0";
+			@asm "emt 64o";
+		when 1: puts("\e9");
+	end case;
+end sub;
+
+# vim: ts=4 sw=4 noet

--- a/rt/bk10/file.coh
+++ b/rt/bk10/file.coh
@@ -1,0 +1,203 @@
+
+const FCB_BUFFER_SIZE := 512;
+typedef FCBIndexType is uint16;
+
+# cassette I/O CB (EMT 36 API)
+
+record IOCB is
+	req: uint8;			# 0
+	resp: uint8;		# 1
+	addr: uint16;		# 2
+	len: uint16;		# 4
+	name: uint8[16];	# 6
+	curaddr: uint16;	# 26
+	curlen: uint16;		# 30
+	curname: uint8[16];	# 32
+end record;
+
+const IO_REPACK	   := 0;
+const IO_MOTOR_OFF := 1;
+const IO_WRITE	   := 2;
+const IO_READ	   := 3;
+const IO_NOOP	   := 4;
+const IO_DELETE	   := 0o200;
+const IO_ALTWRITE  := 0o202;
+const IO_FASTREAD  := 0o203;
+const IO_PRINTDIR  := 0o204;
+
+# ANDOS FAT directory entry
+
+record DIRENT is
+	name: uint8[8];		# 0
+	ext: uint8[3];		# 10
+	attr: uint8;		# 13
+	res: uint8[8];		# 14
+	dir: uint8;			# 24
+	parent: uint8;		# 25
+	addr: uint16;		# 26
+	date: uint16;		# 30
+	cluster: uint16;	# 32
+	size: uint32;		# 34
+end record;
+
+#
+
+record RawFCB is
+	dirent: DIRENT;
+	iocb: IOCB;
+	blk: uint16;
+	rawblock: uint16;
+	clusters: uint16;
+	fat: [uint16];
+end record;
+
+# ANDOS -- documented offsets
+
+const ANDOS_NAMBUF := 0o120114;
+const ANDOS_USRERR := 0o120146;
+const ANDOS_SCREEN := 0o120150;
+const ANDOS_DEVICE := 0o120154;
+const ANDOS_DEVTEK := 0o120155;
+const ANDOS_DEVSYS := 0o120156;
+const ANDOS_SIZE   := 0o120162;
+const ANDOS_VERS   := 0o120170;
+const ANDOS_MDOSEM := 0o120176;
+
+include "fileio.coh";
+
+# FIXME handle out of bounds access
+sub fcb_i_mapblock(fcb: [FCB], pos: uint32): (rawblock: uint16) is
+	rawblock := [fcb.fat + ((pos as int32 >> 11) << 1) as uint16] + (((pos as int32 >> 9) as uint16) & 3);
+end sub;
+
+	# RWBLOK reads one disk block (amount <= 512) to user buffer; buffer and amount must be aligned to 2
+	# RDBLOK reads one disk block (amount == 512) to OS buffer with caching
+	# RWCLAS reads sequential clusters (amount <= N*2048) to user buffer
+
+@impl sub FCBRawRead is
+	var failed: int16 := 0;
+	var block: uint16;
+	var buf := &fcb.buffer[0];
+
+	amount := 0;
+	if len != FCB_BUFFER_SIZE or (pos % FCB_BUFFER_SIZE) != 0 or pos >= fcb.dirent.size then
+		fcb.flags := fcb.flags | FCB_FLAG_ERROR;
+		return;
+	end if;
+
+	block := fcb_i_mapblock(fcb, pos);
+	@asm "mov", block, ", r0";
+	@asm "mov #256, r1";
+	@asm "mov", buf, ", r2";
+	@asm "call @120226o"; # RWBLOK
+	@asm "adc", failed;
+	if failed != 0 then
+		fcb.flags := fcb.flags | FCB_FLAG_ERROR;
+	else
+		amount := len;
+	end if;
+end sub;
+
+# FIXME
+@impl sub FCBRawWrite is
+	fcb.flags := fcb.flags | FCB_FLAG_ERROR;
+end sub;
+
+@decl sub file_i_mapfat(fcb: [FCB]): (errno: uint8);
+
+sub file_i_init(fcb: [FCB], filename: [uint8]): (errno: uint8) is
+	var iocb := &fcb.iocb;
+	var diroff: [uint8];
+
+	errno := 0;
+	MemSet(&fcb.iocb.name as [uint8], 0x20, 16); # @bytesof crashes cowfe
+	CopyString(filename, &fcb.iocb.name as [uint8]);
+
+	@asm "mov", iocb, ", r1";
+	@asm "call @120272o"; # DONAME
+	@asm "adcb", errno;
+	if errno != 0 then return; end if;
+
+	@asm "call @120204o"; # INIDRV
+	@asm "adcb", errno;
+	if errno != 0 then errno := 2; return; end if;
+
+	@asm "call @120260o"; # DIRFI2; ignores directories
+	@asm "adcb", errno;
+	@asm "mov r2,", diroff;
+	if errno != 0 then errno := 3; return; end if;
+
+	MemCopy(diroff, @bytesof DIRENT, &fcb.dirent as [uint8]);
+
+	# map cluster chain starting from fcb.dirent.cluster
+	errno := file_i_mapfat(fcb);
+end sub;
+
+@impl sub file_i_mapfat is
+	var e: uint16 := fcb.dirent.cluster;
+	var max: uint16 := 0;
+
+	errno := 0;
+	@asm "call @120230o";	# RDFAT
+
+	# find length of cluster chain
+	loop
+		@asm "mov", e, ", r0";
+		@asm "call @120234o";	# GETFAT
+		@asm "mov r0,", e;
+		max := max + 1;
+		# end of cluster chain?
+		if (e == 0o7777 or e == 0) then
+			break;
+		end if;
+	end loop;
+
+	# fetch cluster chain and translate cluster numbers into raw block numbers
+	fcb.clusters := max;
+	fcb.fat := RawAlloc(max + max) as [uint16];
+	if fcb.fat == nil then
+		errno := 4; return;
+	end if;
+
+	e := fcb.dirent.cluster;
+	max := 0;
+	loop
+		# convert to disk sector number
+		[fcb.fat + max] := (e + 1) << 2;
+		@asm "mov", e, ", r0";
+		@asm "call @120234o";	# GETFAT
+		@asm "mov r0,", e;
+		if (e == 0o7777 or e == 0) then
+			break;
+		end if;
+		max := max + 2;
+	end loop;
+end sub;
+
+sub FCBOpenIn(fcb: [FCB], filename: [uint8]): (errno: uint8) is
+	errno := file_i_init(fcb, filename);
+end sub;
+
+# FIXME
+sub FCBOpenUp(fcb: [FCB], filename: [uint8]): (errno: uint8) is
+	errno := 1;
+end sub;
+
+sub FCBOpenOut(fcb: [FCB], filename: [uint8]): (errno: uint8) is
+	errno := FCBOpenUp(fcb, filename);
+end sub;
+
+sub FCBClose(fcb: [FCB]): (errno: uint8) is
+	FCBFlush(fcb);
+	Free(fcb.fat as [uint8]);
+	errno := 0;
+end sub;
+
+sub FCBExt(fcb: [FCB]): (len: uint32) is
+#	FCBFlush(fcb);
+	len := fcb.dirent.size;
+end sub;
+
+include "common-file.coh";
+
+# vim: ts=4 sw=4 noet

--- a/src/cowlink/archbk10.coh
+++ b/src/cowlink/archbk10.coh
@@ -1,0 +1,134 @@
+const STACK_SIZE := 128;
+
+var workspaceSize: Size[NUM_WORKSPACES];
+
+sub E_nl() is
+	E_b8('\n');
+end sub;
+
+sub ArchAlignUp(value: Size, alignment: uint8): (newvalue: Size) is
+	var a := (alignment-1) as Size;
+	newvalue := (value+a) & ~a;
+end sub;
+
+sub ArchEmitSubRef(subr: [Subroutine]) is
+	E_b8('f');
+	E_u16(subr.id);
+	E_b8('_');
+	E(subr.name);
+end sub;
+
+sub ArchEmitWSRef(wid: uint8, address: Size) is
+	E("ws+");
+	E_u16(address);
+end sub;
+
+#
+# This produces standalone binaries that can be loaded from (virtual) tape.
+#
+# Delete leading 4 bytes before saving them to ANDOS disk,
+# then set starting address manually from ANDOS file manager.
+#
+sub ArchEmitHeader(coo: [Coo]) is
+	E("\tcseg\n");
+	E("\torg 0\n");
+	E("\tdw 2000o\n"); # high start address to avoid stack corruption if loaded after bk11 BASIC (sets SP to 2000)
+	E("\tdw bss_end - start\n");
+
+	E("\torg 2000o\n");
+	E("start:\n");
+
+	#
+	# which hardware do we have?
+	#
+	# hw=0 -- bk10
+	# hw=1 -- bk11m
+	# hw=2 -- bk11
+	#
+	# which API do we use?
+	#
+	# api=0 -- bk10 EMT calls, may be available on bk11(m) with bk10 BIOS loaded by OS
+	# api=1 -- bk11m ROM calls
+	# api=2 -- bk11 EMT calls
+	#
+
+	# himem pointers, valid only on real bk10
+	E("\tmov @#202o, r0\n");
+	E("\tmov @#206o, r1\n");
+
+	# check CPU start address
+	E("\tmov @#177716o, r2\n");
+	E("\tbic #255, r2\n");
+	E("\tcmp r2, #100000o\n");
+	E("\tbeq bk10\n");
+
+	# check known value in ROM BIOS
+	E("\tcmp @#144444o, #177716o\n"); # bk11?
+	E("\tbne bk11hw\n");
+	E("\tmov #2, hw\n");
+	E("\tbr apitest\n");
+	E("bk11hw:\tmov #1, hw\n");
+
+	# test if bk10 BIOS is loaded on bk11(m)
+	E("apitest:\n");
+	E("\tcmp r0, #40000o\n");
+	E("\tbeq ap2\n");
+	E("\tcmp r0, #70000o\n");
+	E("\tbne bk11\n");
+	E("\tcmp r1, #10000o\n");
+	E("\tbeq bk10api\n");
+	E("\tbr bk11\n");
+	E("ap2:\tcmp r1, #40000o\n");
+	E("\tbeq bk10api\n");
+
+	E("bk11:\tmov hw, api\n");
+	E("\tmov #040000o, himem\n");
+	E("\tbr out\n");
+
+	E("bk10:\tclr hw\n");
+	E("bk10api:\tclr api\n");
+	E("\tmov @#202o, himem\n");
+
+	E("out:\n");
+	E("\tcmp @#160016o, #167o\n"); # enable EIS emulator if present
+	E("\tbne noeis\n");
+	E("\tmov #160016o, @#10o\n");
+	E("\tcmp @#167776o, #176000o\n"); # force EIS emulator in SMK ROM if on SMK00
+	E("\tbge noeis\n");
+	E("\tclr @#175774o\n");
+	E("noeis:\n");
+
+	while coo != nil loop
+		var main := coo.index.subroutines[0];
+		if main != nil then
+			E("\tcall ");
+			ArchEmitSubRef(main);
+			E_nl();
+		end if;
+		coo := coo.next;
+	end loop;
+
+	E("exit:\n");
+	E("\tcmp api, #1\n");
+	E("\tblt exit10\n");
+	E("\tbge exit11\n");
+	E("\tcall @140012o\n");
+	E("exit11:\tmov #1, r0\n");
+	E("\temt 0\n");
+	E("exit10\tjmp @#100442o\n");
+end sub;
+
+sub ArchEmitFooter(coo: [Coo]) is
+	E("\n\tdseg\n");
+	E("\talign 2\n");
+
+	E("himem: ds 2\n");
+	E("api: ds 2\n");
+	E("hw: ds 2\n");
+	E("ws: ds ");
+	E_u16(workspaceSize[0]);
+	E_nl();
+	E("\talign 2\n");
+	E("bss_end:\n");
+end sub;
+

--- a/src/cowlink/build.py
+++ b/src/cowlink/build.py
@@ -7,6 +7,7 @@ ARCHS = [
     "basic",
     "bbct",
     "bbctn",
+    "bk10",
     "bk10dx",
     "cgen",
     "fuzix6303",


### PR DESCRIPTION
ANDOS was sold commercially, last release was 3.30 in 1997. Uses (modified) FAT filesystem; has no CLI or streaming I/O API.

There were other operating systems (quote unquote), but none too interesting to write a runtime for -- https://pashigorov.pdp-11.ru/files/osreview.html