### PR TITLE
x86: Avoid using DX register as divisor

### DIFF
--- a/src/cowbe/arch8086.cow.ng
+++ b/src/cowbe/arch8086.cow.ng
@@ -748,10 +748,10 @@ gen al := REMU1(al, mem1|bl|cl|dl:rhs)         { E("\txor ah, ah\n"); E_insn("di
 gen al := DIVS1(al, mem1|bl|cl|dl:rhs)         { E("\tcbw\n"); E_insn("idiv"); E_op0($rhs, &$@rhs.operand); E_nl(); }
 gen al := REMS1(al, mem1|bl|cl|dl:rhs)         { E("\tcbw\n"); E_insn("idiv"); E_op0($rhs, &$@rhs.operand); E_nl(); E("\tmov al, ah\n"); }
 
-gen ax := DIVU2(ax, mem2|bx|cx|dx:rhs) uses dx { E("\txor dx, dx\n"); E_insn("div"); E_op0($rhs, &$@rhs.operand); E_nl(); }
-gen dx := REMU2(ax, mem2|bx|cx|dx:rhs)         { E("\txor dx, dx\n"); E_insn("div"); E_op0($rhs, &$@rhs.operand); E_nl(); }
-gen ax := DIVS2(ax, mem2|bx|cx|dx:rhs) uses dx { E("\tcwd\n"); E_insn("idiv"); E_op0($rhs, &$@rhs.operand); E_nl(); }
-gen dx := REMS2(ax, mem2|bx|cx|dx:rhs)         { E("\tcwd\n"); E_insn("idiv"); E_op0($rhs, &$@rhs.operand); E_nl(); }
+gen ax := DIVU2(ax, mem2|bx|cx|di|si:rhs) uses dx    { E("\txor dx,dx\n"); E_insn("div"); E_op0($rhs, &$@rhs.operand); E_nl(); }
+gen dx := REMU2(ax, mem2|bx|cx|di|si:rhs)            { E("\txor dx,dx\n"); E_insn("div"); E_op0($rhs, &$@rhs.operand); E_nl(); }
+gen ax := DIVS2(ax, mem2|bx|cx|di|si:rhs) uses dx    { E("\tcwd\n"); E_insn("idiv"); E_op0($rhs, &$@rhs.operand); E_nl(); }
+gen dx := REMS2(ax, mem2|bx|cx|di|si:rhs)            { E("\tcwd\n"); E_insn("idiv"); E_op0($rhs, &$@rhs.operand); E_nl(); }
 
 gen al|bl|dl       := LSHIFT1($$:lhs, cl:rhs)  { E_insn("shl"); E_reg($lhs); E(", cl\n"); }
 gen ax|bx|dx|si|di := LSHIFT2($$:lhs, cl:rhs)  { E_insn("shl"); E_reg($lhs); E(", cl\n"); }

--- a/src/cowbe/archcgen.cow.ng
+++ b/src/cowbe/archcgen.cow.ng
@@ -354,7 +354,9 @@ gen v8 := DEREF8(v8:addr) { LoadVV(8); }
 		E_u8(width);
 		E(" v");
 		E_u16(vid);
-		E(" = v");
+		E(" = (s");
+		E_u8(width);
+		E(")v");
 		E_u16(lhsid);
 		E(op);
 		E("(");

--- a/tests/divrem-16bit-s.good
+++ b/tests/divrem-16bit-s.good
@@ -2,6 +2,10 @@
 -7/3=-2: yes
 7/-3=-2: yes
 -7/-3=2: yes
+7/THREE=2: yes
+-7/THREE=-2: yes
+7/-THREE=-2: yes
+-7/-THREE=2: yes
 7%3=1: yes
 -7%3=-1: yes
 7%-3=1: yes

--- a/tests/divrem-16bit-s.test.cow
+++ b/tests/divrem-16bit-s.test.cow
@@ -11,6 +11,11 @@ print("-7/3=-2");  if mseven/three == -2  then yes(); else no(); end if;
 print("7/-3=-2");  if seven/mthree == -2  then yes(); else no(); end if;
 print("-7/-3=2");  if mseven/mthree == 2  then yes(); else no(); end if;
 
+print("7/THREE=2");if (seven/3) == 2        then yes(); else no(); end if;
+print("-7/THREE=-2");if (mseven/3) == -2    then yes(); else no(); end if;
+print("7/-THREE=-2");if (seven/-3) == -2    then yes(); else no(); end if;
+print("-7/-THREE=2");if (mseven/-3) == 2    then yes(); else no(); end if;
+
 print("7%3=1");    if seven%three == 1    then yes(); else no(); end if;
 print("-7%3=-1");  if mseven%three == -1  then yes(); else no(); end if;
 print("7%-3=1");   if seven%mthree == 1   then yes(); else no(); end if;


### PR DESCRIPTION
C backend doesn't seem to support signed integers and fails the new test -- no idea how to fix that