### PR TITLE
Support MACRO-11 in PDP-11 code generator and add RT-11 runtime.

### DIFF
--- a/rt/bk10dx/file.coh
+++ b/rt/bk10dx/file.coh
@@ -116,6 +116,7 @@ sub FCBOpenIn(fcb: [FCB], filename: [uint8]): (errno: uint8) is
 	var dxcb := &fcb.dxcb;
 	errno := 0;
 	_fcb_init(fcb);
+	fcb.readonly := FCB_FLAG_READONLY;
 
 	@asm "mov", filename, ", r1";
 	@asm "mov", dxcb, ", r4";
@@ -134,6 +135,7 @@ end sub;
 
 sub FCBOpenUp(fcb: [FCB], filename: [uint8]): (errno: uint8) is
 	errno := FCBOpenIn(fcb, filename);
+	fcb.readonly := 0;
 end sub;
 
 sub FCBOpenOut(fcb: [FCB], filename: [uint8]): (errno: uint8) is

--- a/rt/fileio.coh
+++ b/rt/fileio.coh
@@ -1,6 +1,7 @@
 const FCB_FLAG_ERROR := 1<<0;
 const FCB_FLAG_READ := 1<<1;
 const FCB_FLAG_WRITE := 1<<2;
+const FCB_FLAG_READONLY := 1<<3;
 
 record FCB: RawFCB is
 	pos: uint32;
@@ -8,6 +9,7 @@ record FCB: RawFCB is
 	index: FCBIndexType;
 	buffer: uint8[FCB_BUFFER_SIZE];
 	flags: uint8;
+	readonly: uint8;
 end record;
 
 @decl sub FCBRawRead(fcb: [FCB], pos: uint32, len: FCBIndexType): (amount: FCBIndexType);
@@ -18,6 +20,7 @@ sub _fcb_init(fcb: [FCB]) is
 	fcb.buflen := 0;
 	fcb.index := 0;
 	fcb.flags := 0;
+	fcb.readonly := 0;
 end sub;
 
 sub _fcb_advance(fcb: [FCB]) is
@@ -28,7 +31,7 @@ sub _fcb_fillbuffer(fcb: [FCB]): (b: uint8) is
 	var bufpos := fcb.pos + (fcb.index as uint32);
 	fcb.buflen := FCBRawRead(fcb, bufpos, FCB_BUFFER_SIZE);
 	b := 0;
-	if (fcb.flags  & FCB_FLAG_ERROR) != 0 then
+	if (fcb.flags & FCB_FLAG_ERROR) != 0 then
 		return;
 	end if;
 	fcb.flags := FCB_FLAG_READ;
@@ -42,7 +45,11 @@ end sub;
 
 sub FCBFlush(fcb: [FCB]) is
 	if (fcb.flags & FCB_FLAG_WRITE) != 0 then
-		FCBRawWrite(fcb, fcb.pos, fcb.index);
+		if (fcb.readonly != 0) then
+			fcb.flags := fcb.flags | FCB_FLAG_ERROR;
+		else
+			FCBRawWrite(fcb, fcb.pos, fcb.index);
+		end if;
 		if (fcb.flags & FCB_FLAG_ERROR) != 0 then
 			return;
 		end if;
@@ -55,7 +62,7 @@ end sub;
 
 sub _fcb_flushbuffer(fcb: [FCB], b: uint8) is
 	FCBFlush(fcb);
-	if (fcb.flags  & FCB_FLAG_ERROR) != 0 then
+	if (fcb.flags & FCB_FLAG_ERROR) != 0 then
 		return;
 	end if;
 	fcb.flags := FCB_FLAG_WRITE;

--- a/rt/rt11/argv.coh
+++ b/rt/rt11/argv.coh
@@ -1,0 +1,44 @@
+# XXX not ported yet
+
+var argv: uint8[81];
+var argv_pointer: [uint8] := &argv[0];
+
+sub ArgvInit() is
+    var carry: uint8 := 0;
+    var prompt: [uint8] := "DCL>";
+    var tmp: uint8[81];
+    var ptr: [uint8];
+
+    @asm ".gtlin", argv_pointer, ",", prompt;
+    @asm "adcb", carry;
+
+    print("error: "); print_i32(carry as uint32); print_nl();
+    print("csi args: "); print(argv_pointer); print_nl();
+    ptr := argv_pointer + StrLen(argv_pointer);
+
+    # undo CSI conversion: "a b c" -> "b c=a"
+    loop
+        ptr := @prev ptr;
+        var c := [ptr];
+        if (c == '=') then break; end if;
+        if ptr == argv_pointer then return; end if;
+    end loop;
+
+    print("tmp: "); print(ptr); print_nl();
+    print("tmp: "); print_char([ptr + 1]); print_nl();
+
+    # found '=' char
+    [ptr] := 0;
+    CopyString(ptr + 1, &tmp[0]);
+    tmp[StrLen(ptr + 1) as uint8] := ' ';
+    CopyString(argv_pointer, &tmp[StrLen(ptr + 1) as uint8 + 1]);
+    CopyString(&tmp[0], argv_pointer);
+    print("unix args: "); print(argv_pointer); print_nl();
+end sub;
+
+# Returns null is there's no next argument.
+sub ArgvNext(): (arg: [uint8]) is
+    arg := argv_pointer;
+end sub;
+
+# vim: ts=4 sw=4 et

--- a/rt/rt11/build.lua
+++ b/rt/rt11/build.lua
@@ -1,0 +1,5 @@
+cowwrap {
+	ins = { "rt/rt11/cowgol.cos" },
+	outs = { "$OBJ/rt/rt11/cowgol.coo" }
+}
+

--- a/rt/rt11/build.py
+++ b/rt/rt11/build.py
@@ -1,0 +1,3 @@
+from src.build import cowwrap
+
+cowwrap(name="cowgolcoo", src="./cowgol.cos")

--- a/rt/rt11/cowgol.coh
+++ b/rt/rt11/cowgol.coh
@@ -1,0 +1,63 @@
+var LOMEM: [uint8];
+var HIMEM: [uint8];
+var HW: int16;
+var API: int16;
+
+@asm "; set LOMEM and HIMEM";
+@asm "mov limit+2,", LOMEM;
+@asm ".gval #limit, #^O266"; # $USRLC
+@asm ".setto r0";
+@asm "mov r0,", HIMEM;
+@asm "clr", HW;
+@asm "clr", API;
+@asm ";";
+
+sub Exit() is
+	@asm "bisb\t#1, @#^O53";
+	@asm "br\texit";
+end sub;
+
+sub ExitWithError() is
+	@asm "bisb\t#4, @#^O53";
+	@asm "br\texit";
+end sub;
+
+sub AlignUp(in: intptr): (out: intptr) is
+	out := (in + 1) & ~1;
+end sub;
+
+sub print_char(c: uint8) is
+	if c == '\n' then
+		@asm ".ttyou #^O15";
+	end if;
+	@asm ".ttyou", c;
+end sub;
+
+sub MemSet(buf: [uint8], byte: uint8, len: uint16) is
+	var bufend := buf + len;
+	loop
+		if buf == bufend then
+			return;
+		end if;
+		[buf] := byte;
+		buf := buf + 1;
+	end loop;
+end sub;
+
+sub print_oct_i16(value: uint16) is
+	var i: uint8 := 5;
+	print_char(((value >> 15) + '0') as uint8);
+	loop
+		var digit := (((value >> 12) & 7) + '0') as uint8;
+		print_char(digit);
+		value := value << 3;
+		i := i - 1;
+		if i == 0 then
+			break;
+		end if;
+	end loop;
+end sub;
+
+include "common.coh";
+
+# vim: ts=4 sw=4 et

--- a/rt/rt11/cowgol.cos
+++ b/rt/rt11/cowgol.cos
@@ -1,0 +1,86 @@
+# Unsigned 32-bit division.
+# Computes r2r3/r0r1, putting the quotient in r2r3 and the remainder in r4r5.
+&X _divremu4
+	; _divremu4
+``:
+	; The PDP11 has a 32/16->16%16 signed division instruction. Synthesising
+	; 32/32->32%32 unsigned division from this is surprisingly hard, so for
+    ; now we don't bother and just use long division.
+
+    clr r4              ; reset remainder
+    clr r5
+    mov r0, -(sp)       ; move hi(RHS) onto the stack, as we need r0...
+    mov #32, r0         ; ...for the loop counter
+    br ``_entry
+
+``_loop:
+    dec r0
+    beq ``_exit
+``_entry:
+    ashc #1, r2         ; left shift LHS
+    rol r5              ; ...moving the shifted out top bit into the remainder
+    rol r4
+
+    cmp r4, (sp)        ; if remainder < RHS, loop without subtracting
+    bcs ``_loop
+    bne ``_skip
+    cmp r5, r1
+    bcs ``_loop
+
+``_skip:
+    inc r3              ; set the bottom bit of the quotient (guaranteed to be 0)
+    sub r1, r5
+    sbc r4              ; remainder = remainder - RHS
+    sub (sp), r4
+    br ``_loop
+``_exit:
+    mov (sp)+, r0       ; retract stack
+    rts pc
+
+# Signed 32-bit division.
+# Computes r2r3/r0r1, putting the quotient in r2r3 and the remainder in r4r5.
+# This is a wrapper around _divremu4 above.
+&X _divrems4
+	; _divrems4
+``:
+    xor r2, r0          ; discover sign of result
+    mov r0, -(sp)       ; save for later
+    xor r2, r0          ; recover result
+    mov r2, -(sp)       ; save result for sign of remainder
+
+    tst r0              ; set flags from hi(rhs)
+    bpl ``_1
+    com r0              ; negate r0r1
+    com r1
+    add #1, r1          ; add (setting carry)
+    adc r0
+``_1:
+    tst r2              ; set flags from hi(lhs)
+    bpl ``_2
+    com r2              ; negate r2r3
+    com r3
+    add #1, r3
+    adc r2
+``_2:
+
+    call `_divremu4     ; perform unsigned division
+
+    tst (sp)            ; check sign of remainder
+    bpl ``_3
+    com r4
+    com r5
+    add #1, r5
+    adc r4
+``_3:
+    tst 2(sp)           ; check sign of quotient
+    bpl ``_4
+    com r2
+    com r3
+    add #1, r3
+    adc r2
+``_4:
+    add #4, sp          ; retract over stack
+    rts pc
+
+# vim: ts=4 sw=4 et
+

--- a/rt/rt11/file.coh
+++ b/rt/rt11/file.coh
@@ -1,0 +1,221 @@
+const FCB_BUFFER_SIZE := 512;
+typedef FCBIndexType is uint16;
+
+var usrerr: [uint8] := 0o52;
+var channels: [FCB][4];
+
+channels[0] := nil;
+channels[1] := nil;
+channels[2] := nil;
+channels[3] := nil;
+
+record RawFCB is
+    # RT-11 area
+    chan: uint8;
+    code: uint8; # filled by macro
+    blk: uint16;
+    buf: uint16;
+    wcnt: uint16;
+    last: uint16; # crtn in .readc/writc
+end record;
+
+include "fileio.coh";
+
+@impl sub FCBRawRead is
+    var carry: uint8 := 0;
+    var rtbuf := &fcb.buffer;
+    var chan := fcb.chan;
+
+    amount := 0;
+    if len == 0 then
+        return;
+    elseif len != FCB_BUFFER_SIZE or (pos % FCB_BUFFER_SIZE) != 0 then # FIXME
+        fcb.flags := fcb.flags | FCB_FLAG_ERROR;
+        return;
+    end if;
+
+    fcb.blk := (pos >> 9) as uint16;
+
+    @asm ".readw", fcb, ",", chan, ",", rtbuf, ", #256";
+    @asm "adcb", carry;
+
+    if carry != 0 then
+        if [usrerr] == 0 then return; end if; # ignore reads past EOF
+        fcb.flags := fcb.flags | FCB_FLAG_ERROR;
+    else
+        amount := len;
+    end if;
+end sub;
+
+@impl sub FCBRawWrite is
+    var carry: uint8 := 0;
+    var rtbuf := &fcb.buffer;
+    var chan := fcb.chan;
+
+    if len == 0 then
+        return;
+    elseif len > FCB_BUFFER_SIZE or (pos % FCB_BUFFER_SIZE) != 0 then # FIXME
+        fcb.flags := fcb.flags | FCB_FLAG_ERROR;
+        return;
+    end if;
+
+    fcb.blk := (pos >> 9) as uint16;
+    len := (len + 1) >> 1;
+    @asm ".writw", fcb, ",", chan, ",", rtbuf, ",", len;
+    @asm "adcb", carry;
+
+    if carry == 0 then
+        fcb.flags := fcb.flags | FCB_FLAG_ERROR;
+    end if;
+end sub;
+
+sub file_i_channel_find(fcb: [FCB]): (ret: uint8) is
+    var i: uint8 := 0;
+    while i < @sizeof channels loop
+#       if channels[i] == fcb then
+#           ret := i;
+#           return;
+        if channels[i] == nil then
+            channels[i] := fcb;
+            ret := i;
+            return;
+        end if;
+        i := i + 1;
+    end loop;
+    ret := i;
+end sub;
+
+sub file_i_channel_free(chan: uint8) is
+    var i: uint8 := 0;
+    while i < @sizeof channels loop
+        if i == chan then
+            channels[i] := nil;
+            return;
+        end if;
+        i := i + 1;
+    end loop;
+end sub;
+
+# ok
+sub FCBOpenIn(fcb: [FCB], filename: [uint8]): (errno: uint8) is
+    _fcb_init(fcb);
+    fcb.readonly := FCB_FLAG_READONLY;
+
+    var carry: uint8 := 0;
+    var rtbuf := &fcb.buffer;
+    var rad50 := rtbuf + 30;
+    var defext: uint16[] := {0, 0, 0, 0};
+    var chan := file_i_channel_find(fcb);
+
+    if chan == @sizeof channels then
+        errno := 100;
+        return;
+    end if;
+    fcb.chan := chan;
+
+    # parse ASCII filename into RAD50 rtbuf
+
+    errno := 0;
+    @asm "mov sp, r5";
+    @asm ".csisp", rtbuf, ",", defext, ",", filename;
+    @asm "adcb", carry;
+    @asm "mov r5, sp";
+
+    if carry != 0 then
+        errno := [usrerr] + 1;
+        return;
+    end if;
+
+    @asm ".looku", fcb, ",", chan, ",", rad50;
+    @asm "adcb", carry;
+
+    if carry != 0 then
+        errno := [usrerr] + 1;
+        return;
+    end if;
+end sub;
+
+sub FCBOpenUp(fcb: [FCB], filename: [uint8]): (errno: uint8) is
+    (errno) := FCBOpenIn(fcb, filename);
+    fcb.readonly := 0;
+end sub;
+
+# ok?
+sub FCBOpenOut(fcb: [FCB], filename: [uint8]): (errno: uint8) is
+    _fcb_init(fcb);
+
+    var carry: uint8 := 0;
+    var rtbuf := &fcb.buffer;
+    var rad50 := rtbuf + 30;
+    var defext: uint16[] := {0, 0, 0, 0};
+    var chan := file_i_channel_find(fcb);
+
+    if chan == @sizeof channels then
+        errno := 100;
+        return;
+    end if;
+    fcb.chan := chan;
+
+    # parse ASCII filename into RAD50 rtbuf
+
+    errno := 0;
+    @asm "mov sp, r5";
+    @asm ".csisp", rtbuf, ",", defext, ",", filename;
+    @asm "adcb", carry;
+    @asm "mov r5, sp";
+
+    if carry != 0 then
+        errno := [usrerr] + 1;
+        return;
+    end if
+
+    @asm ".enter", fcb, ",", chan, ",", rad50, ", #0";
+    @asm "adcb", carry;
+
+    if carry != 0 then
+        errno := [usrerr] + 1;
+        return;
+    end if
+end sub;
+
+# ok?
+sub FCBClose(fcb: [FCB]): (errno: uint8) is
+    FCBFlush(fcb);
+
+    var chan := fcb.chan;
+    var carry: uint8 := 0;
+    errno := 0;
+    @asm ".close", chan;
+    @asm "adcb", carry;
+
+    if carry != 0 then
+        errno := [usrerr] + 1;
+        return;
+    else
+        file_i_channel_free(fcb.chan);
+    end if
+end sub;
+
+# ok
+sub FCBExt(fcb: [FCB]): (len: uint32) is
+    var carry: uint8 := 0;
+    var rtbuf := &fcb.buffer;
+    var chan := fcb.chan;
+
+    FCBFlush(fcb);
+
+    @asm ".cstat", fcb, ",", chan, ",", rtbuf;
+    @asm "adcb", carry;
+
+    if carry == 0 then
+        # 4 = length of file
+        # 6 = highest relative block written
+        len := [&fcb.buffer[4] as [uint16]] as uint32 << 9;
+    else
+        len := ~0;
+    end if;
+end sub;
+
+include "common-file.coh";
+
+# vim: ts=4 sw=4 et

--- a/rt/rt11/longjmp.mac
+++ b/rt/rt11/longjmp.mac
@@ -1,0 +1,271 @@
+	.nlist
+
+	.macro	ret
+	return
+	.endm
+
+	.macro	jbr, label
+	; forward jump?
+	.if gt label-.
+		.if gt label-.-254
+			jmp	label
+		.iff
+			br	label
+			nop
+		.endc
+	.iff
+	; backward jump?
+		.if gt .-label-256
+			jmp	label
+		.iff
+			br	label
+			nop
+		.endc
+	.endc
+	.endm
+
+	.macro	jbeq, label
+	; forward jump?
+	.if gt label-.
+		.if gt label-.-254
+			bne	.+6
+			jmp	label
+		.iff
+			beq	label
+			nop
+			nop
+		.endc
+	.iff
+	; backward jump?
+		.if gt .-label-256
+			bne	.+6
+			jmp	label
+		.iff
+			beq	label
+			nop
+			nop
+		.endc
+	.endc
+	.endm
+
+	.macro	jbne, label
+	; forward jump?
+	.if gt label-.
+		.if gt label-.-254
+			beq	.+6
+			jmp	label
+		.iff
+			bne	label
+			nop
+			nop
+		.endc
+	.iff
+	; backward jump?
+		.if gt .-label-256
+			beq	.+6
+			jmp	label
+		.iff
+			bne	label
+			nop
+			nop
+		.endc
+	.endc
+	.endm
+
+
+	.macro	jbge, label
+	; forward jump?
+	.if gt label-.
+		.if gt label-.-254
+			blt	.+6
+			jmp	label
+		.iff
+			bge	label
+			nop
+			nop
+		.endc
+	.iff
+	; backward jump?
+		.if gt .-label-256
+			blt	.+6
+			jmp	label
+		.iff
+			bge	label
+			nop
+			nop
+		.endc
+	.endc
+	.endm
+
+	.macro	jblt, label
+	; forward jump?
+	.if gt label-.
+		.if gt label-.-254
+			bge	.+6
+			jmp	label
+		.iff
+			blt	label
+			nop
+			nop
+		.endc
+	.iff
+	; backward jump?
+		.if gt .-label-256
+			bge	.+6
+			jmp	label
+		.iff
+			blt	label
+			nop
+			nop
+		.endc
+	.endc
+	.endm
+
+
+	.macro	jblo, label
+	; forward jump?
+	.if gt label-.
+		.if gt label-.-254
+			bhis	.+6
+			jmp	label
+		.iff
+			blo	label
+			nop
+			nop
+		.endc
+	.iff
+	; backward jump?
+		.if gt .-label-256
+			bhis	.+6
+			jmp	label
+		.iff
+			blo	label
+			nop
+			nop
+		.endc
+	.endc
+	.endm
+
+	.macro	jbhis, label
+	; forward jump?
+	.if gt label-.
+		.if gt label-.-254
+			blo	.+6
+			jmp	label
+		.iff
+			bhis	label
+			nop
+			nop
+		.endc
+	.iff
+	; backward jump?
+		.if gt .-label-256
+			blo	.+6
+			jmp	label
+		.iff
+			bhis	label
+			nop
+			nop
+		.endc
+	.endc
+	.endm
+
+
+	.macro	jbgt, label
+	; forward jump?
+	.if gt label-.
+		.if gt label-.-254
+			ble	.+6
+			jmp	label
+		.iff
+			bgt	label
+			nop
+			nop
+		.endc
+	.iff
+	; backward jump?
+		.if gt .-label-256
+			ble	.+6
+			jmp	label
+		.iff
+			bgt	label
+			nop
+			nop
+		.endc
+	.endc
+	.endm
+
+	.macro	jble, label
+	; forward jump?
+	.if gt label-.
+		.if gt label-.-254
+			bgt	.+6
+			jmp	label
+		.iff
+			ble	label
+			nop
+			nop
+		.endc
+	.iff
+	; backward jump?
+		.if gt .-label-256
+			bgt	.+6
+			jmp	label
+		.iff
+			ble	label
+			nop
+			nop
+		.endc
+	.endc
+	.endm
+
+
+	.macro	jblos, label
+	; forward jump?
+	.if gt label-.
+		.if gt label-.-254
+			bhi	.+6
+			jmp	label
+		.iff
+			blos	label
+			nop
+			nop
+		.endc
+	.iff
+	; backward jump?
+		.if gt .-label-256
+			bhi	.+6
+			jmp	label
+		.iff
+			blos	label
+			nop
+			nop
+		.endc
+	.endc
+	.endm
+
+	.macro	jbhi, label
+	; forward jump?
+	.if gt label-.
+		.if gt label-.-254
+			blos	.+6
+			jmp	label
+		.iff
+			bhi	label
+			nop
+			nop
+		.endc
+	.iff
+	; backward jump?
+		.if gt .-label-256
+			blos	.+6
+			jmp	label
+		.iff
+			bhi	label
+			nop
+			nop
+		.endc
+	.endc
+	.endm
+
+	.list

--- a/src/cowbe/archpdp11-rt11.cow.ng
+++ b/src/cowbe/archpdp11-rt11.cow.ng
@@ -1,0 +1,3 @@
+$define ARCH_RT11
+$include "archpdp11.cow.ng"
+

--- a/src/cowbe/archpdp11.cow.ng
+++ b/src/cowbe/archpdp11.cow.ng
@@ -320,6 +320,9 @@
 
 	sub E_jump_noflush(insn: string, label: LabelRef) is
 		E_tab();
+		$ifdef ARCH_RT11
+		E_b8('J');
+		$endif
 		E(insn);
 		E_tab();
 		E_labelref(label);
@@ -524,7 +527,11 @@
 
 	sub E_cmpeq4(src: RegId, dest: RegId) is
 		E_alu2_noflush("CMP", hireg(src), hireg(dest));
+		$ifdef ARCH_RT11
+		E("\tbne\t.+4\n");
+		$else
 		E("\tbne\t$+4\n");
+		$endif
 		E_alu2_noflush("CMP", loreg(src), loreg(dest));
 	end sub;
 
@@ -908,12 +915,20 @@
 		var i: uint16 := 0;
 
 		EmitterOpenStream(current_subr);
+		$ifdef ARCH_RT11
+		E("\t.even\n");
+		$else
 		E("\tdseg\n");
+		$endif
 
 		E_b8(COO_ESCAPE_THISCOO);
 		E_b8('z');
 		E_u16(sid);
+		$ifdef ARCH_RT11
+		E(":\n\t.byte\t");
+		$else
 		E(":\n\tdb\t");
+		$endif
 
 		loop
 			var c := [data];
@@ -925,13 +940,19 @@
 
 			E_u8(c);
 			if (i % 16) == 0 then
+				$ifdef ARCH_RT11
+				E("\n\t.byte\t");
+				$else
 				E("\n\tdb\t");
+				$endif
 			else
 				E_comma();
 			end if;
 		end loop;
 		E("0\n");
+		$ifndef ARCH_RT11
 		E("\tcseg\n");
+		$endif
 		EmitterCloseStream();
 
 		E_b8(COO_ESCAPE_THISCOO);
@@ -1049,7 +1070,12 @@ gen STARTSUB() uses all
 	E_b8(0);
 	E_nl();
 
+	$ifdef ARCH_RT11
+	E("\t.enabl\tlsb\n");
+	E("\t.even\n");
+	$else
 	E("\talign 2\n");
+	$endif
 	E_b8(COO_ESCAPE_THISSUB);
 	E(":\n");
 
@@ -1163,7 +1189,11 @@ gen RETURN() uses all
 	if current_subr.num_output_parameters == 0 then
 		E_ret();
 	else
+		$ifdef ARCH_RT11
+		E("\tJBR\tend_");
+		$else
 		E("\tBR\tend_");
+		$endif
 		E_subref(current_subr);
 		E_nl();
 	end if;
@@ -1568,35 +1598,53 @@ gen r16 := STRING():s
 gen STARTINIT():s
 {
 	EmitterOpenStream(current_subr);
+	$ifdef ARCH_RT11
+	E("\t.even\n");
+	$else
 	E("\tdseg\n");
 	E("\talign 2\n");
+	$endif
 	E_symref(&$s.sym, 0);
 	E(":\n");
 }
 
 gen ENDINIT()
 {
+	$ifndef ARCH_RT11
 	E("\tcseg\n");
+	$endif
 	EmitterCloseStream();
 }
 
 gen INIT1():c
 {
+	$ifdef ARCH_RT11
+	E("\t.byte\t");
+	$else
 	E("\tdb\t");
+	$endif
 	E_u8($c.value as uint8);
 	E_nl();
 }
 
 gen INIT2():c
 {
+	$ifdef ARCH_RT11
+	E("\t.word\t");
+	$else
 	E("\tdw\t");
+	$endif
 	E_u16($c.value as uint16);
 	E_nl();
 }
 
 gen INIT4():c
 {
+	$ifdef ARCH_RT11
+	E("\t.word\t");
+	$else
 	E("\tdw\t");
+	$endif
 	E_u16($c.value as uint16);
 	E_comma();
 	E_u16((($c.value as uint32) >> 16) as uint16);
@@ -1605,21 +1653,33 @@ gen INIT4():c
 
 gen INITADDRESS():a
 {
+	$ifdef ARCH_RT11
+	E("\t.word\t");
+	$else
 	E("\tdw\t");
+	$endif
 	E_symref(&$a.sym, $a.off);
 	E_nl();
 }
 
 gen INITSUBREF():a
 {
+	$ifdef ARCH_RT11
+	E("\t.word\t");
+	$else
 	E("\tdw\t");
+	$endif
 	E_subref($a.subr);
 	E_nl();
 }
 
 gen INITSTRING():s
 {
+	$ifdef ARCH_RT11
+	E("\t.word\t");
+	$else
 	E("\tdw\t");
+	$endif
 	E_string($s.text);
 	E_nl();
 }

--- a/src/cowbe/build.py
+++ b/src/cowbe/build.py
@@ -15,6 +15,7 @@ ARCHS = [
     "basic",
     "cgen",
     "pdp11",
+    "pdp11-rt11",
     "powerpc",
     "thumb2",
     "z80",
@@ -23,6 +24,7 @@ ARCHS = [
 extras = {
     "65c02": ["src/cowbe/arch6502.cow.ng"],
     "65c02-tiny": ["src/cowbe/arch6502.cow.ng"],
+    "pdp11-rt11": ["src/cowbe/archpdp11.cow.ng"],
 }
 
 for arch in ARCHS:

--- a/src/cowlink/archrt11.coh
+++ b/src/cowlink/archrt11.coh
@@ -24,9 +24,10 @@ sub ArchEmitWSRef(wid: uint8, address: Size) is
 end sub;
 
 sub ArchEmitHeader(coo: [Coo]) is
+	E("; Assemble with macro11 -yus -ysl 16 -rt11 -m .../SYSMAC.SML\n\n");
 	E("\t.mcall\t.serr, .herr, .exit, .qset, .mrkt, .cmkt, .print, .ttyou\n");
 	E("\t.mcall\t.csisp, .looku, .cstat, .enter, .close, .readw, .writw\n");
-	E("\t.mcall\t.setto, .gval, .mfps, .mtps, .readc\n");
+	E("\t.mcall\t.setto, .gval, .mfps, .mtps, .readc, .ttyin, .gtlin\n");
 	E("\t.radix\t10\n\n");
 	E("start:\n");
 	E("\t.serr\n");


### PR DESCRIPTION
MACRO-11 (and macro11) do not support jump expansion, longjmp.mac is a workaround for that.
Add 'read-only' flag to fileio.